### PR TITLE
fix: flaky `ownershipTransfer` e2e test

### DIFF
--- a/packages/delegator-e2e/test/caveats/ownershipTransfer.test.ts
+++ b/packages/delegator-e2e/test/caveats/ownershipTransfer.test.ts
@@ -148,7 +148,11 @@ describe('Ownership Transfer Caveat', () => {
       ...gasPrice,
     });
 
-    await expectUserOperationToSucceed(userOpHash);
+    const receipt = await sponsoredBundlerClient.waitForUserOperationReceipt({
+      hash: userOpHash,
+    });
+
+    await expectUserOperationToSucceed(receipt);
 
     // Verify ownership was transferred successfully
     const finalOwner = await getContractOwner(contractAddress);
@@ -304,7 +308,11 @@ describe('Ownership Transfer Caveat', () => {
       ...gasPrice,
     });
 
-    await expectUserOperationToSucceed(userOpHash);
+    const receipt = await sponsoredBundlerClient.waitForUserOperationReceipt({
+      hash: userOpHash,
+    });
+
+    await expectUserOperationToSucceed(receipt);
 
     // Verify ownership was transferred successfully
     const finalOwner = await getContractOwner(contractAddress);

--- a/packages/delegator-e2e/test/utils/assertions.ts
+++ b/packages/delegator-e2e/test/utils/assertions.ts
@@ -1,8 +1,7 @@
 import { Address } from 'viem';
 import { expect } from 'vitest';
 import { publicClient } from './helpers';
-import { UserOperationReceiptResponse } from '@metamask/delegation-toolkit';
-
+import type { UserOperationReceipt } from 'viem/account-abstraction';
 // common assertions to be shared across tests
 
 export const expectCodeAt = async (address: Address, message?: string) => {
@@ -21,11 +20,11 @@ export const expectNoCodeAt = async (address: Address, message?: string) => {
 // todo: make this attempt to decode the failure logs
 // that is why I've made this asyncronous
 export const expectUserOperationToSucceed = async (
-  receipt: UserOperationReceiptResponse,
+  receipt: UserOperationReceipt,
   message?: string,
 ) => {
   expect(
     receipt.success,
     message || `Expected user operation ${receipt.userOpHash} to succeed`,
-  ).toBeTruthy;
+  ).toBeTruthy();
 };


### PR DESCRIPTION
## 📝 Description

The `ownershipTransfer` e2e tests were incorrectly passing the useroperation hash to the `expectUserOperationToSucceed` function, that actually expects a parameter of type `UserOperationReceipt`. 

This assertion function was then ensuring that the `receipt.success` is true - but the assertion was not being executed.

This resulted in two problems:

- the tests in `ownershipTransfer` e2e tests never awaited the receipt
- the assertion was never checking that the user operation succeeds - in any test

## 🔄 What Changed?

- Fixes `expectUserOperationToSucceed` parameter type
- Fixes `expectUserOperationToSucceed` to actually execute `toBeTruthy` assertion
- Fixes call to `expectUserOperationToSucceed` in flaky test to pass `UserOperationReceipt` rather than `UserOperationHash`

## 🧪 How to Test?

E2E tests should pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ownership transfer e2e tests now wait for the user operation receipt and pass it to the assertion, which is updated to use viem’s UserOperationReceipt and correctly invoke toBeTruthy().
> 
> - **E2E Tests (`packages/delegator-e2e/test/caveats/ownershipTransfer.test.ts`)**:
>   - Wait for `UserOperationReceipt` via `waitForUserOperationReceipt({ hash })` and pass the receipt to `expectUserOperationToSucceed` (replacing direct `userOpHash`).
> - **Test Utils (`packages/delegator-e2e/test/utils/assertions.ts`)**:
>   - Change `expectUserOperationToSucceed` param type to `viem/account-abstraction` `UserOperationReceipt`.
>   - Fix assertion to call `toBeTruthy()`.
>   - Remove `UserOperationReceiptResponse` import from `@metamask/delegation-toolkit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c83f223babe9491a0050e1d3e0afff3660171988. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->