### PR TITLE
Revert smart-accounts-kit version to 0.1.0 and make private

### DIFF
--- a/packages/smart-accounts-kit/package.json
+++ b/packages/smart-accounts-kit/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@metamask/smart-accounts-kit",
-  "version": "0.13.0",
+  "version": "0.1.0",
   "type": "module",
   "description": "Toolkit for managing and interacting with MetaMask Smart Accounts, built on Viem",
   "license": "(MIT-0 OR Apache-2.0)",
+  "private": true,
   "keywords": [
     "MetaMask",
     "Ethereum"


### PR DESCRIPTION
## 📝 Description

When attempting to publish @metamask/delegation-deployments the publish step fails with:

> RELEASE_PACKAGES='{"packages":{"@metamask/delegation-deployments":{"name":"@metamask/delegation-deployments","path":"packages/delegation-deployments","version":"0.13.0"},"@metamask/smart-accounts-kit":{"name":"@metamask/smart-accounts-kit","path":"packages/smart-accounts-kit","version":"0.13.0"}}}'
>
>Error: Error: Specified release version does not exist: '0.13.0'
    at Changelog.getStringifiedRelease (/home/runner/work/_actions/MetaMask/action-publish-release/v3/dist/index.js:1181:19)
    at getPackageReleaseNotes (/home/runner/work/_actions/MetaMask/action-publish-release/v3/dist/index.js:11156:10)
    at async getReleaseNotesForMonorepoWithIndependentVersions (/home/runner/work/_actions/MetaMask/action-publish-release/v3/dist/index.js:11101:64)
    at async getMonorepoReleaseNotes (/home/runner/work/_actions/MetaMask/action-publish-release/v3/dist/index.js:11133:11)
    at async getReleaseNotes (/home/runner/work/_actions/MetaMask/action-publish-release/v3/dist/index.js:11086:24)

Which I'm interpreting as the build script attempting to publish the newly renamed @metamask/smart-accounts-kit package, even though it's not intentionally included in the release.

As a workaround, I have marked the package as private, meaning that it should not be included in the release.

Once this release is complete, we will remove this attribution, so that a subsequent release can include the new package.

This PR also reverts the version back to 0.1.0 as this would be the first release of this new package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts @metamask/smart-accounts-kit to version 0.1.0 and marks it private to exclude it from release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b5156b44e034e8fdcc2e4e539b3ebfba905876f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->