### PR TITLE
Revert "Release/13.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.0.0]
-
 ## [12.0.0]
 
 ## [11.0.0]
@@ -21,8 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0]
 
-[Unreleased]: https://github.com/MetaMask/smart-accounts-kit/compare/delegator-sdk-monorepo@13.0.0...HEAD
-[13.0.0]: https://github.com/MetaMask/smart-accounts-kit/compare/delegator-sdk-monorepo@12.0.0...delegator-sdk-monorepo@13.0.0
+[Unreleased]: https://github.com/MetaMask/smart-accounts-kit/compare/delegator-sdk-monorepo@12.0.0...HEAD
 [12.0.0]: https://github.com/MetaMask/smart-accounts-kit/compare/delegator-sdk-monorepo@11.0.0...delegator-sdk-monorepo@12.0.0
 [11.0.0]: https://github.com/MetaMask/smart-accounts-kit/compare/delegator-sdk-monorepo@10.0.0...delegator-sdk-monorepo@11.0.0
 [10.0.0]: https://github.com/MetaMask/smart-accounts-kit/compare/delegator-sdk-monorepo@9.0.0...delegator-sdk-monorepo@10.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delegator-sdk-monorepo",
-  "version": "13.0.0",
+  "version": "12.0.0",
   "license": "(MIT-0 OR Apache-2.0)",
   "private": true,
   "repository": {

--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -7,11 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.13.0]
-
-### Added
-
-- Add deployments for Sei mainnet ([#84](https://github.com/metamask/smart-accounts-kit/pull/84))
-
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@0.13.0...HEAD
-[0.13.0]: https://github.com/metamask/smart-accounts-kit/releases/tag/@metamask/delegation-deployments@0.13.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/

--- a/packages/delegation-deployments/package.json
+++ b/packages/delegation-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-deployments",
-  "version": "0.13.0",
+  "version": "0.12.0",
   "description": "A history of deployments of the Delegation Framework",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -628,14 +628,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/delegation-deployments@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "@metamask/delegation-deployments@npm:0.12.0"
-  checksum: 10/fd3b373efc1857cc867b44b4ca33db0cf8487c1109d6f2ed7e3ce10e6a65d4165b7fcc034cab92d919d6f0833e3749a055ff862adc8d7a348cdd3a0f593f6aa6
-  languageName: node
-  linkType: hard
-
-"@metamask/delegation-deployments@workspace:packages/delegation-deployments":
+"@metamask/delegation-deployments@npm:^0.12.0, @metamask/delegation-deployments@workspace:packages/delegation-deployments":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-deployments@workspace:packages/delegation-deployments"
   dependencies:


### PR DESCRIPTION
Reverts MetaMask/smart-accounts-kit#94

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the 13.0.0 release by restoring package versions and pruning related changelog entries/links.
> 
> - **Versions**:
>   - Downgrade root `package.json` from `13.0.0` to `12.0.0`.
>   - Downgrade `packages/delegation-deployments/package.json` from `0.13.0` to `0.12.0`.
> - **Changelogs**:
>   - Remove `13.0.0` and `0.13.0` sections.
>   - Update `[Unreleased]` links to compare from `12.0.0` and simplify deployments package link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e17914aa4691a3a9dd7d993da8cb2dcc177747f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->