### PR TITLE
Upgrade yarn to 4.10.1 to resolve failing release

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "viem": "2.31.4",
     "webauthn-p256": "^0.0.10"
   },
-  "packageManager": "yarn@4.10.0",
+  "packageManager": "yarn@4.10.1",
   "engines": {
     "node": "^18.18 || >=20"
   },


### PR DESCRIPTION
https://github.com/yarnpkg/berry/issues/6903 broke the publish step, with `ERROR: Yarn is terminating due to an unexpected empty event loop.` which is fixed in yarn@4.10.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `packageManager` in `package.json` from `yarn@4.10.0` to `yarn@4.10.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d90968f1df7d21bf893fcd3828832bdba7403cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->