### PR TITLE
Replace absolute imports with relative

### DIFF
--- a/packages/smart-accounts-kit/src/actions/erc7710RedeemDelegationAction.ts
+++ b/packages/smart-accounts-kit/src/actions/erc7710RedeemDelegationAction.ts
@@ -23,7 +23,7 @@ import {
   ExecutionMode,
 } from '../executions';
 import { getSmartAccountsEnvironment } from '../smartAccountsEnvironment';
-import type { Call } from 'src/types';
+import type { Call } from '../types';
 
 export type DelegatedCall = Call &
   OneOf<{ permissionsContext: Hex; delegationManager: Hex } | object>;

--- a/packages/smart-accounts-kit/src/caveatBuilder/types.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/types.ts
@@ -1,4 +1,4 @@
-import type { SmartAccountsEnvironment } from 'src/types';
+import type { SmartAccountsEnvironment } from '../types';
 
 export enum BalanceChangeType {
   Increase = 0x0,


### PR DESCRIPTION
## 📝 Description

When promoting experimental actions, some imports were erroneously replaced with absolute imports. 

This PR replaces them with relative imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace absolute imports with relative paths to `../types` in smart-accounts-kit.
> 
> - **Smart Accounts Kit**:
>   - Update imports to use relative paths to `../types`.
>     - `packages/smart-accounts-kit/src/actions/erc7710RedeemDelegationAction.ts`: `Call` import.
>     - `packages/smart-accounts-kit/src/caveatBuilder/types.ts`: `SmartAccountsEnvironment` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 058e024a58cba1d8402338ae96966b3b634bd185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->