### PR TITLE
fix: throw custom message on hex validation

### DIFF
--- a/packages/smart-accounts-kit/src/actions/erc7715RequestExecutionPermissionsAction.ts
+++ b/packages/smart-accounts-kit/src/actions/erc7715RequestExecutionPermissionsAction.ts
@@ -265,9 +265,7 @@ function assertIsDefined<TValue>(
 ): asserts value is TValue {
   if (!isDefined(value)) {
     throw new Error(
-      parameterName
-        ? `Invalid parameters: ${parameterName} is required`
-        : 'Invalid parameters: value is required',
+      `Invalid parameters: ${parameterName ?? 'value'} is required`,
     );
   }
 }
@@ -288,9 +286,7 @@ function toHexOrThrow(
   if (typeof value === 'string') {
     if (!isHex(value)) {
       throw new Error(
-        parameterName
-          ? `Invalid parameters: ${parameterName} is not a valid hex value`
-          : 'Invalid parameters: invalid hex value',
+        `Invalid parameters: ${parameterName ?? 'value'} is not a valid hex value`,
       );
     }
     return value;


### PR DESCRIPTION
## 📝 Description

Currently if validation fails in `toHexOrThrow` custom message is thrown in some cases (not in isHex check). And custom message needs to be defined. Which results in not exact error messages and that in some cases we don't tell the user for which field the validation failed.

With this update we have standardized error messages and made sure the field name is in every error message which makes it much more helpful for users. 

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Tests added/updated
- [x] Changelog updated (if needed)
- [x] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes validation by adding parameter-aware error messages and updating permission formatters to pass field names to hex/required checks.
> 
> - **Validation helpers**:
>   - Update `assertIsDefined` to accept `parameterName` and throw `Invalid parameters: <name> is required`.
>   - Update `toHexOrThrow` to accept `parameterName` and throw `... is not a valid hex value` for invalid hex.
> - **Permission formatters**:
>   - Pass explicit field names to `toHexOrThrow` for `amountPerSecond`, `initialAmount`, `maxAmount`, `tokenAddress`, and `periodAmount` across:
>     - `native-token-stream`
>     - `erc20-token-stream`
>     - `native-token-periodic`
>     - `erc20-token-periodic`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 591eb94d221abe674afbc62c957714bbdf3501f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->