### PR TITLE
Add `allowedCalldata` terms builder in `@metamask/delegation-core`

### DIFF
--- a/packages/delegation-core/src/caveats/allowedCalldata.ts
+++ b/packages/delegation-core/src/caveats/allowedCalldata.ts
@@ -1,0 +1,74 @@
+import { bytesToHex, remove0x, type BytesLike } from '@metamask/utils';
+
+import {
+  defaultOptions,
+  prepareResult,
+  type EncodingOptions,
+  type ResultValue,
+} from '../returns';
+import type { Hex } from '../types';
+import { toHexString } from '../utils';
+
+/**
+ * Terms for configuring an AllowedCalldata caveat.
+ */
+export type AllowedCalldataTerms = {
+  startIndex: number;
+  value: BytesLike;
+};
+
+/**
+ * Creates terms for an AllowedCalldata caveat that ensures the provided execution calldata
+ * matches the expected calldata at the specified index.
+ *
+ * @param terms - The terms for the AllowedCalldata caveat.
+ * @param encodingOptions - The encoding options for the result.
+ * @returns The terms as the calldata itself.
+ * @throws Error if the `calldata` is invalid.
+ */
+export function createAllowedCalldataTerms(
+  terms: AllowedCalldataTerms,
+  encodingOptions?: EncodingOptions<'hex'>,
+): Hex;
+export function createAllowedCalldataTerms(
+  terms: AllowedCalldataTerms,
+  encodingOptions: EncodingOptions<'bytes'>,
+): Uint8Array;
+/**
+ * Creates terms for an AllowedCalldata caveat that ensures the provided execution calldata
+ * matches the expected calldata at the specified index.
+ * @param terms - The terms for the AllowedCalldata caveat.
+ * @param encodingOptions - The encoding options for the result.
+ * @returns The terms as the calldata itself.
+ * @throws Error if the `calldata` is invalid.
+ */
+export function createAllowedCalldataTerms(
+  terms: AllowedCalldataTerms,
+  encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
+): Hex | Uint8Array {
+  const { startIndex, value } = terms;
+
+  if (startIndex < 0) {
+    throw new Error('Invalid startIndex: must be zero or positive');
+  }
+
+  if (!Number.isInteger(startIndex)) {
+    throw new Error('Invalid startIndex: must be a whole number');
+  }
+
+  let unprefixedValue: string;
+
+  if (typeof value === 'string') {
+    if (!value.startsWith('0x')) {
+      throw new Error('Invalid value: must be a hex string starting with 0x');
+    }
+    unprefixedValue = remove0x(value);
+  } else {
+    unprefixedValue = remove0x(bytesToHex(value));
+  }
+
+  const indexHex = toHexString({ value: startIndex, size: 32 });
+
+  // The terms are the index encoded as 32 bytes followed by the expected value.
+  return prepareResult(`0x${indexHex}${unprefixedValue}`, encodingOptions);
+}

--- a/packages/delegation-core/src/caveats/index.ts
+++ b/packages/delegation-core/src/caveats/index.ts
@@ -6,3 +6,4 @@ export { createNativeTokenStreamingTerms } from './nativeTokenStreaming';
 export { createERC20StreamingTerms } from './erc20Streaming';
 export { createERC20TokenPeriodTransferTerms } from './erc20TokenPeriodTransfer';
 export { createNonceTerms } from './nonce';
+export { createAllowedCalldataTerms } from './allowedCalldata';

--- a/packages/delegation-core/src/index.ts
+++ b/packages/delegation-core/src/index.ts
@@ -13,6 +13,7 @@ export {
   createERC20StreamingTerms,
   createERC20TokenPeriodTransferTerms,
   createNonceTerms,
+  createAllowedCalldataTerms,
 } from './caveats';
 
 export {

--- a/packages/delegation-core/test/caveats/allowedCalldata.test.ts
+++ b/packages/delegation-core/test/caveats/allowedCalldata.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect } from 'vitest';
+
+import { createAllowedCalldataTerms } from '../../src/caveats/allowedCalldata';
+import type { Hex } from '../../src/types';
+import { toHexString } from '../../src/utils';
+
+describe('createAllowedCalldataTerms', function () {
+  const prefixWithIndex = (startIndex: number, value: Hex) => {
+    const indexHex = toHexString({ value: startIndex, size: 32 });
+    return `0x${indexHex}${value.slice(2)}` as Hex;
+  };
+
+  // Note: AllowedCalldata terms length varies based on input calldata length + 32-byte index prefix
+  it('creates valid terms for simple value', () => {
+    const value = '0x1234567890abcdef';
+    const startIndex = 0;
+    const result = createAllowedCalldataTerms({ startIndex, value });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, value));
+  });
+
+  it('creates valid terms for empty value', () => {
+    const value = '0x';
+    const startIndex = 5;
+    const result = createAllowedCalldataTerms({ startIndex, value });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, value));
+  });
+
+  it('creates valid terms for function call with parameters', () => {
+    // Example: transfer(address,uint256) function call
+    const value =
+      '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+    const startIndex = 12;
+    const result = createAllowedCalldataTerms({ startIndex, value });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, value));
+  });
+
+  it('creates valid terms for complex value', () => {
+    const value =
+      '0x23b872dd000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5f0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+    const startIndex = 4;
+    const result = createAllowedCalldataTerms({ startIndex, value });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, value));
+  });
+
+  it('creates valid terms for uppercase hex value', () => {
+    const value = '0x1234567890ABCDEF';
+    const startIndex = 0;
+    const result = createAllowedCalldataTerms({ startIndex, value });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, value));
+  });
+
+  it('creates valid terms for mixed case hex value', () => {
+    const value = '0x1234567890AbCdEf';
+    const startIndex = 1;
+    const result = createAllowedCalldataTerms({ startIndex, value });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, value));
+  });
+
+  it('creates valid terms for very long value', () => {
+    const longValue: Hex = `0x${'a'.repeat(1000)}`;
+    const startIndex = 31;
+    const result = createAllowedCalldataTerms({
+      startIndex,
+      value: longValue,
+    });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, longValue));
+  });
+
+  it('throws an error for value without 0x prefix', () => {
+    const invalidValue = '1234567890abcdef' as Hex;
+    expect(() =>
+      createAllowedCalldataTerms({
+        startIndex: 0,
+        value: invalidValue,
+      }),
+    ).toThrow('Invalid value: must be a hex string starting with 0x');
+  });
+
+  it('throws an error for empty string', () => {
+    const invalidValue = '' as Hex;
+    expect(() =>
+      createAllowedCalldataTerms({
+        startIndex: 0,
+        value: invalidValue,
+      }),
+    ).toThrow('Invalid value: must be a hex string starting with 0x');
+  });
+
+  it('throws an error for malformed hex prefix', () => {
+    const invalidValue = '0X1234' as Hex; // uppercase X
+    expect(() =>
+      createAllowedCalldataTerms({
+        startIndex: 0,
+        value: invalidValue,
+      }),
+    ).toThrow('Invalid value: must be a hex string starting with 0x');
+  });
+
+  it('throws an error for undefined value', () => {
+    expect(() =>
+      createAllowedCalldataTerms({
+        startIndex: 0,
+        value: undefined as unknown as Hex,
+      }),
+    ).toThrow();
+  });
+
+  it('throws an error for null value', () => {
+    expect(() =>
+      createAllowedCalldataTerms({
+        startIndex: 0,
+        value: null as unknown as Hex,
+      }),
+    ).toThrow();
+  });
+
+  it('throws an error for non-string non-Uint8Array value', () => {
+    expect(() =>
+      createAllowedCalldataTerms({
+        startIndex: 0,
+        value: 1234 as unknown as Hex,
+      }),
+    ).toThrow();
+  });
+
+  it('handles single function selector', () => {
+    const functionSelector = '0xa9059cbb'; // transfer(address,uint256) selector
+    const startIndex = 7;
+    const result = createAllowedCalldataTerms({
+      startIndex,
+      value: functionSelector,
+    });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, functionSelector));
+  });
+
+  it('handles calldata with odd length', () => {
+    const oddLengthValue = '0x123';
+    const startIndex = 0;
+    const result = createAllowedCalldataTerms({
+      startIndex,
+      value: oddLengthValue,
+    });
+    expect(result).toStrictEqual(prefixWithIndex(startIndex, oddLengthValue));
+  });
+
+  // Tests for bytes return type
+  describe('bytes return type', () => {
+    it('returns Uint8Array when bytes encoding is specified', () => {
+      const value = '0x1234567890abcdef';
+      const startIndex = 2;
+      const result = createAllowedCalldataTerms(
+        { startIndex, value },
+        { out: 'bytes' },
+      );
+      // Expect: 32 bytes index + 8 bytes value = 40 bytes
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result).toHaveLength(32 + 8);
+      // Verify prefix bytes equal encoded index
+      const expectedPrefixHex = toHexString({ value: startIndex, size: 32 });
+      const expectedPrefix = Array.from(Buffer.from(expectedPrefixHex, 'hex'));
+      expect(Array.from(result.slice(0, 32))).toEqual(expectedPrefix);
+      // Verify value bytes at the end
+      expect(Array.from(result.slice(32))).toEqual([
+        0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+      ]);
+    });
+
+    it('returns Uint8Array for empty value with bytes encoding', () => {
+      const value = '0x';
+      const startIndex = 0;
+      const result = createAllowedCalldataTerms(
+        { startIndex, value },
+        { out: 'bytes' },
+      );
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result).toHaveLength(32); // just the index prefix
+    });
+
+    it('returns Uint8Array for complex value with bytes encoding', () => {
+      const value =
+        '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+      const startIndex = 15;
+      const result = createAllowedCalldataTerms(
+        { startIndex, value },
+        { out: 'bytes' },
+      );
+      expect(result).toBeInstanceOf(Uint8Array);
+      // 32 prefix + 68 bytes calldata
+      expect(result).toHaveLength(32 + 68);
+    });
+  });
+
+  describe('startIndex validation', () => {
+    it('throws for negative integer startIndex', () => {
+      const value = '0x1234';
+      expect(() =>
+        createAllowedCalldataTerms({ startIndex: -1, value }),
+      ).toThrow('Invalid startIndex: must be zero or positive');
+    });
+
+    it('throws for negative fractional startIndex', () => {
+      const value = '0x1234';
+      expect(() =>
+        createAllowedCalldataTerms({ startIndex: -0.1, value }),
+      ).toThrow('Invalid startIndex: must be zero or positive');
+    });
+
+    it('throws for non-integer positive startIndex', () => {
+      const value = '0x1234';
+      expect(() =>
+        createAllowedCalldataTerms({ startIndex: 1.5, value }),
+      ).toThrow('Invalid startIndex: must be a whole number');
+    });
+
+    it('throws for NaN startIndex', () => {
+      const value = '0x1234';
+      expect(() =>
+        createAllowedCalldataTerms({ startIndex: Number.NaN, value }),
+      ).toThrow('Invalid startIndex: must be a whole number');
+    });
+
+    it('throws for Infinity startIndex', () => {
+      const value = '0x1234';
+      expect(() =>
+        createAllowedCalldataTerms({ startIndex: Infinity, value }),
+      ).toThrow('Invalid startIndex: must be a whole number');
+    });
+
+    it('accepts zero startIndex', () => {
+      const value = '0xdeadbeef';
+      const result = createAllowedCalldataTerms({ startIndex: 0, value });
+      expect(result).toStrictEqual(prefixWithIndex(0, value));
+    });
+
+    it('accepts large integer startIndex and encodes correctly', () => {
+      const value = '0x00';
+      const large = Number.MAX_SAFE_INTEGER; // 2^53 - 1
+      const result = createAllowedCalldataTerms({
+        startIndex: large,
+        value,
+      });
+      const expected = prefixWithIndex(large, value);
+      expect(result).toStrictEqual(expected);
+      // Check length: 32-byte prefix + 1-byte calldata = 33 bytes hex (66 chars) + '0x'
+      expect(result.length).toBe(2 + 64 + 2);
+    });
+  });
+
+  // Tests for Uint8Array input parameter
+  describe('Uint8Array input parameter', () => {
+    it('accepts Uint8Array as value parameter', () => {
+      const valueBytes = new Uint8Array([
+        0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+      ]);
+      const startIndex = 3;
+      const result = createAllowedCalldataTerms({
+        startIndex,
+        value: valueBytes,
+      });
+      expect(result).toStrictEqual(
+        prefixWithIndex(startIndex, '0x1234567890abcdef'),
+      );
+    });
+
+    it('accepts empty Uint8Array as value parameter', () => {
+      const callDataBytes = new Uint8Array([]);
+      const startIndex = 0;
+      const result = createAllowedCalldataTerms({
+        startIndex,
+        value: callDataBytes,
+      });
+      expect(result).toStrictEqual(prefixWithIndex(startIndex, '0x'));
+    });
+
+    it('accepts Uint8Array for function call with parameters', () => {
+      // transfer(address,uint256) function call as bytes
+      const valueBytes = new Uint8Array([
+        0xa9,
+        0x05,
+        0x9c,
+        0xbb, // transfer selector
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00, // padding
+        0x74,
+        0x2d,
+        0x35,
+        0xcc,
+        0x66,
+        0x34,
+        0xc0,
+        0x53,
+        0x29,
+        0x25,
+        0xa3,
+        0xb8,
+        0xd4,
+        0x0e,
+        0xc4,
+        0x9b,
+        0x0e,
+        0x8b,
+        0xaa,
+        0x5e, // address
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x0d,
+        0xe0,
+        0xb6,
+        0xb3,
+        0xa7,
+        0x64,
+        0x00,
+        0x00, // amount
+      ]);
+      const startIndex = 8;
+      const result = createAllowedCalldataTerms({
+        startIndex,
+        value: valueBytes,
+      });
+      expect(result).toStrictEqual(
+        prefixWithIndex(
+          startIndex,
+          '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+        ),
+      );
+    });
+
+    it('returns Uint8Array when input is Uint8Array and bytes encoding is specified', () => {
+      const valueBytes = new Uint8Array([0x12, 0x34, 0x56, 0x78]);
+      const startIndex = 0;
+      const result = createAllowedCalldataTerms(
+        { startIndex, value: valueBytes },
+        { out: 'bytes' },
+      );
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(Array.from(result)).toEqual([
+        // 32-byte index (all zeros)
+        ...new Array(32).fill(0x00),
+        // calldata
+        0x12,
+        0x34,
+        0x56,
+        0x78,
+      ]);
+    });
+  });
+});

--- a/packages/smart-accounts-kit/src/caveatBuilder/allowedCalldataBuilder.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/allowedCalldataBuilder.ts
@@ -1,4 +1,5 @@
-import { type Hex, concat, isHex, toHex } from 'viem';
+import { createAllowedCalldataTerms } from '@metamask/delegation-core';
+import { type Hex } from 'viem';
 
 import type { SmartAccountsEnvironment, Caveat } from '../types';
 
@@ -30,21 +31,7 @@ export const allowedCalldataBuilder = (
 ): Caveat => {
   const { startIndex, value } = config;
 
-  if (!isHex(value)) {
-    throw new Error('Invalid value: must be a valid hex string');
-  }
-
-  if (startIndex < 0) {
-    throw new Error('Invalid startIndex: must be zero or positive');
-  }
-
-  if (!Number.isInteger(startIndex)) {
-    throw new Error('Invalid startIndex: must be a whole number');
-  }
-
-  const startIndexHex = toHex(startIndex, { size: 32 });
-
-  const terms = concat([startIndexHex, value]);
+  const terms = createAllowedCalldataTerms({ startIndex, value });
 
   const {
     caveatEnforcers: { AllowedCalldataEnforcer },

--- a/packages/smart-accounts-kit/test/caveatBuilder/allowedCalldataBuilder.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/allowedCalldataBuilder.test.ts
@@ -20,7 +20,7 @@ describe('allowedCalldataBuilder()', () => {
   describe('validation', () => {
     it('should fail with empty value', () => {
       expect(() => buildWithParams(0, '' as Hex)).to.throw(
-        'Invalid value: must be a valid hex string',
+        'Invalid value: must be a hex string starting with 0x',
       );
     });
 


### PR DESCRIPTION
## 📝 Description

Adds a new terms builder for `allowedCalldata` caveat to @metamask/delegation-core, decomposing the logic from @metamask/smart-accounts-kit

## 🔄 What Changed?

Logic for encoding terms for the `allowedCalldata` is moved into @metamask/delegation-core allowing applications that interact with this package directly to use this caveat.
## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Tests added/updated
- [x] Changelog updated (if needed)
- [x] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce shared `createAllowedCalldataTerms` in delegation-core and refactor smart-accounts-kit `allowedCalldataBuilder` to use it, updating exports and tests.
> 
> - **delegation-core**
>   - **New API**: `createAllowedCalldataTerms` in `src/caveats/allowedCalldata.ts` encodes terms as 32-byte `startIndex` + calldata; validates inputs; supports hex or bytes output.
>   - **Exports**: Re-export from `src/caveats/index.ts` and package `src/index.ts`.
>   - **Tests**: Add comprehensive unit tests for hex/bytes outputs, input validation, and `Uint8Array` handling.
> - **smart-accounts-kit**
>   - **Refactor**: `allowedCalldataBuilder` now uses `@metamask/delegation-core` `createAllowedCalldataTerms`; removes inline encoding/validation.
>   - **Tests**: Update error messages and keep term length/structure assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f52dc1a826cd7d1c693aa53b91c974923d4f1b67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->