### PR TITLE
Function call scope no longer accepts native token value

### DIFF
--- a/packages/smart-accounts-kit/src/caveatBuilder/scope/functionCallScope.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/scope/functionCallScope.ts
@@ -6,17 +6,18 @@ import type { AllowedTargetsBuilderConfig } from '../allowedTargetsBuilder';
 import { createCaveatBuilder } from '../coreCaveatBuilder';
 import type { CoreCaveatBuilder } from '../coreCaveatBuilder';
 import type { ExactCalldataBuilderConfig } from '../exactCalldataBuilder';
+import type { ValueLteBuilderConfig } from '../valueLteBuilder';
 
 type FunctionCallScopeBaseConfig = {
   type: 'functionCall';
+  allowedCalldata?: AllowedCalldataBuilderConfig[];
+  exactCalldata?: ExactCalldataBuilderConfig;
+  valueLte?: ValueLteBuilderConfig;
 };
 
 export type FunctionCallScopeConfig = FunctionCallScopeBaseConfig &
   AllowedTargetsBuilderConfig &
-  AllowedMethodsBuilderConfig & {
-    allowedCalldata?: AllowedCalldataBuilderConfig[];
-    exactCalldata?: ExactCalldataBuilderConfig;
-  };
+  AllowedMethodsBuilderConfig;
 
 const isFunctionCallConfig = (
   config: FunctionCallScopeConfig,
@@ -49,9 +50,12 @@ export function createFunctionCallCaveatBuilder(
     );
   }
 
+  const valueLteConfig = config.valueLte ?? { maxValue: 0n };
+
   const caveatBuilder = createCaveatBuilder(environment)
     .addCaveat('allowedTargets', { targets })
-    .addCaveat('allowedMethods', { selectors });
+    .addCaveat('allowedMethods', { selectors })
+    .addCaveat('valueLte', valueLteConfig);
 
   if (allowedCalldata && allowedCalldata.length > 0) {
     allowedCalldata.forEach((calldataConfig) => {

--- a/packages/smart-accounts-kit/test/DelegationFramework/DelegationManager/delegationManagement.test.ts
+++ b/packages/smart-accounts-kit/test/DelegationFramework/DelegationManager/delegationManagement.test.ts
@@ -98,7 +98,7 @@ describe('DelegationManager - Delegation Management', () => {
       });
 
       expect(isHex(encodedData, { strict: true })).toBe(true);
-      expect(encodedData.length).toBe(1482);
+      expect(encodedData.length).toBe(1930);
     });
   });
 
@@ -123,7 +123,7 @@ describe('DelegationManager - Delegation Management', () => {
       });
 
       expect(isHex(encodedData, { strict: true })).toBe(true);
-      expect(encodedData.length).toBe(1482);
+      expect(encodedData.length).toBe(1930);
     });
   });
 
@@ -154,7 +154,7 @@ describe('DelegationManager - Delegation Management', () => {
       });
 
       expect(isHex(encodedData, { strict: true })).toBe(true);
-      expect(encodedData.length).toBe(2442);
+      expect(encodedData.length).toBe(2890);
     });
   });
 });

--- a/packages/smart-accounts-kit/test/caveatBuilder/scope/functionCallScope.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/scope/functionCallScope.test.ts
@@ -14,6 +14,7 @@ describe('createFunctionCallCaveatBuilder', () => {
       AllowedMethodsEnforcer: randomAddress(),
       AllowedCalldataEnforcer: randomAddress(),
       ExactCalldataEnforcer: randomAddress(),
+      ValueLteEnforcer: randomAddress(),
     },
   } as unknown as SmartAccountsEnvironment;
 
@@ -38,6 +39,11 @@ describe('createFunctionCallCaveatBuilder', () => {
         enforcer: environment.caveatEnforcers.AllowedMethodsEnforcer,
         args: '0x',
         terms: concat(config.selectors as Hex[]),
+      },
+      {
+        enforcer: environment.caveatEnforcers.ValueLteEnforcer,
+        args: '0x',
+        terms: toHex(0n, { size: 32 }),
       },
     ]);
   });
@@ -65,6 +71,11 @@ describe('createFunctionCallCaveatBuilder', () => {
         enforcer: environment.caveatEnforcers.AllowedMethodsEnforcer,
         args: '0x',
         terms: concat(config.selectors as Hex[]),
+      },
+      {
+        enforcer: environment.caveatEnforcers.ValueLteEnforcer,
+        args: '0x',
+        terms: toHex(0n, { size: 32 }),
       },
       {
         enforcer: environment.caveatEnforcers.AllowedCalldataEnforcer,
@@ -102,9 +113,45 @@ describe('createFunctionCallCaveatBuilder', () => {
         terms: concat(config.selectors as Hex[]),
       },
       {
+        enforcer: environment.caveatEnforcers.ValueLteEnforcer,
+        args: '0x',
+        terms: toHex(0n, { size: 32 }),
+      },
+      {
         enforcer: environment.caveatEnforcers.ExactCalldataEnforcer,
         args: '0x',
         terms: exactCalldata.calldata,
+      },
+    ]);
+  });
+
+  it('creates a Function Call CaveatBuilder with configured valueLte', () => {
+    const config: FunctionCallScopeConfig = {
+      type: 'functionCall',
+      targets: [randomAddress()],
+      selectors: ['0x12345678'],
+      valueLte: { maxValue: 123n },
+    };
+
+    const caveatBuilder = createFunctionCallCaveatBuilder(environment, config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.AllowedTargetsEnforcer,
+        args: '0x',
+        terms: concat(config.targets),
+      },
+      {
+        enforcer: environment.caveatEnforcers.AllowedMethodsEnforcer,
+        args: '0x',
+        terms: concat(config.selectors as Hex[]),
+      },
+      {
+        enforcer: environment.caveatEnforcers.ValueLteEnforcer,
+        args: '0x',
+        terms: toHex(123n, { size: 32 }),
       },
     ]);
   });


### PR DESCRIPTION
## 📝 Description

When configuring a function call scope, native token value is not restricted. This is ok, so long as the targeted function is not  payable.

This change adds a `valueLte` caveat with maximum value of `0`, ensuring that no native token value is allowed.

A delegator may specify a `maxValue` for the caveat, allowing up to a specified amount of native value, for cases where a payable method is being called.

```
createDelegation({
  scope: {
    type: "functionCall",
    targets: ["0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"], // USDC address on Sepolia.
    selectors: ["approve(address, uint256)"],
    valueLte: { maxValue: 10000n }
  },
  ...
});
```

## 🧪 How to Test?

Describe how to test these changes:

Create a delegation using the `functionCall` scope without specifying a `valueLte`, such as https://docs.metamask.io/smart-accounts-kit/reference/delegation/delegation-scopes/#example-7

Attempt to redeem the delegation with `value` greater than 0 specified in the transaction. Expect the delegation to fail with an error related to `maxValue`.

Create a delegation with `valueLte: { maxValue: 10000n }` and redeem in the same way above. Expect the delegation to succeed, with native `value` up to 10000n.

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [x] Breaking changes (describe below):

Unless specified in its config, a delegation created with the function call scope will no longer allow native value greater than 0.

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces a `valueLte` caveat (default 0) in functionCall scope and updates types and tests, including new encoding lengths.
> 
> - **Scope/Caveats**:
>   - `createFunctionCallCaveatBuilder` now always adds `valueLte` (default `{ maxValue: 0n }`), with optional override via `config.valueLte`.
>   - `FunctionCallScopeConfig` updated to include optional `allowedCalldata`, `exactCalldata`, and `valueLte` in base config; types/imports adjusted.
> - **Tests**:
>   - `functionCallScope.test.ts`: expect `ValueLteEnforcer` caveat (default 0 or configured), add test for custom `valueLte`.
>   - `DelegationManager` encoding tests: update expected encoded lengths (`disableDelegation`/`enableDelegation`: 1930; `redeemDelegations`: 2890).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0346c84fa7b2b971d8519443922bdb583304691a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->