### PR TITLE
Allow expiry to be omitted when requesting 7715 permissions

### DIFF
--- a/packages/smart-accounts-kit/src/actions/erc7715RequestExecutionPermissionsAction.ts
+++ b/packages/smart-accounts-kit/src/actions/erc7715RequestExecutionPermissionsAction.ts
@@ -149,9 +149,9 @@ export type PermissionRequestParameter = {
   // Account to assign the permission to.
   signer: SignerParam;
   // address from which the permission should be granted.
-  address?: Address;
+  address?: Address | undefined | null;
   // Timestamp (in seconds) that specifies the time by which this permission MUST expire.
-  expiry: number;
+  expiry?: number | undefined | null;
 };
 
 /**
@@ -223,15 +223,17 @@ function formatPermissionsRequest(
       ? parameters.signer
       : parameters.signer.data.address;
 
-  const rules: Rule[] = [
-    {
-      type: 'expiry',
-      isAdjustmentAllowed,
-      data: {
-        timestamp: expiry,
-      },
-    },
-  ];
+  const rules: Rule[] = isDefined(expiry)
+    ? [
+        {
+          type: 'expiry',
+          isAdjustmentAllowed,
+          data: {
+            timestamp: expiry,
+          },
+        },
+      ]
+    : [];
 
   const optionalFields = {
     ...(address ? { address } : {}),

--- a/packages/smart-accounts-kit/test/actions/erc7715RequestExecutionPermissionsAction.test.ts
+++ b/packages/smart-accounts-kit/test/actions/erc7715RequestExecutionPermissionsAction.test.ts
@@ -921,6 +921,59 @@ describe('erc7715RequestExecutionPermissionsAction', () => {
     });
   });
 
+  it('omits expiry rule when expiry is not provided', async () => {
+    const permissionRequest = {
+      chainId: 31337,
+      address: bob.address,
+      // expiry is intentionally omitted
+      permission: {
+        type: 'native-token-stream' as const,
+        data: {
+          amountPerSecond: 0x1n,
+          maxAmount: 2n,
+          startTime: 2,
+          justification: 'Test justification',
+        },
+      },
+      isAdjustmentAllowed: false,
+      signer: alice.address,
+    };
+    const parameters: RequestExecutionPermissionsParameters = [
+      permissionRequest,
+    ];
+
+    stubRequest.resolves(mockResponse);
+
+    await erc7715RequestExecutionPermissionsAction(mockClient, parameters);
+
+    expect(stubRequest.callCount).to.equal(1);
+    expect(stubRequest.firstCall.args[0]).to.deep.equal({
+      method: 'wallet_requestExecutionPermissions',
+      params: [
+        {
+          chainId: '0x7a69',
+          address: bob.address,
+          permission: {
+            type: 'native-token-stream',
+            data: {
+              amountPerSecond: '0x1',
+              maxAmount: '0x2',
+              startTime: 2,
+              justification: 'Test justification',
+            },
+            isAdjustmentAllowed: false,
+          },
+          signer: {
+            type: 'account',
+            data: {
+              address: alice.address,
+            },
+          },
+          rules: [],
+        },
+      ],
+    });
+  });
   describe('erc7715ProviderActions integration', () => {
     it('should extend the client with erc7715 actions', async () => {
       const client = createClient({


### PR DESCRIPTION
## 📝 Description

With this change, expiry is now optional on all 7715 advanced permissions requests.

## 🔄 What Changed?

Expiry is no longer a required rule type. The caller may omit this in the request object.

## 🧪 How to Test?

Must be tested in conjunction with https://github.com/MetaMask/snap-7715-permissions/pull/240

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Tests added/updated
- [x] Changelog updated (if needed)
- [x] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables requests without an expiry by making `expiry` optional and updating rule construction accordingly.
> 
> - Update `PermissionRequestParameter` to allow `address` and `expiry` to be `undefined | null`; `expiry` now optional
> - Build `rules` array conditionally so the `expiry` rule is only included when `expiry` is defined
> - Add test to assert requests omit the `expiry` rule when `expiry` is not provided
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 362e48011ff9c745aa69c13fa7ee3014f38d2e83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->