### PR TITLE
chore: add mega eth to deployments

### DIFF
--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add chain deployment for MegaETH mainnet ([#124](https://github.com/MetaMask/smart-accounts-kit/pull/124))
+
 ## [0.15.0]
 
 ### Added

--- a/packages/delegation-deployments/script/validate-contract-deployments.ts
+++ b/packages/delegation-deployments/script/validate-contract-deployments.ts
@@ -12,6 +12,22 @@ import { compareVersions } from 'compare-versions';
   code is found at the expected address for each contract.
 */
 
+const megaEthMainnetChain: Chain = {
+  id: 4326,
+  name: 'MegaEth Mainnet',
+  rpcUrls: {
+    default: {
+      // tbd: megaeth is not yet live
+      http: ['https://mainnet.megaeth.com/rpc'],
+    },
+  },
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+};
+
 const megaEthTestNetChain: Chain = {
   id: 6342,
   name: 'MegaEth Testnet',
@@ -176,6 +192,7 @@ export const chains = {
   inkSepolia: inkSepoliaChain,
   sonicTestnet: sonicTestnetChain,
   monad: monadMainnetChain,
+  megaEthMainnet: megaEthMainnetChain,
 } as any as { [key: string]: Chain };
 
 // The default rpc urls for these chains are not reliable, so we override them

--- a/packages/delegation-deployments/src/index.ts
+++ b/packages/delegation-deployments/src/index.ts
@@ -22,6 +22,7 @@ export const CHAIN_ID = {
   sei: 0x531,
   sonic: 0x92,
   unichain: 0x82,
+  megaEthMainnet: 0x10e6,
   // Testnets
   bscTestnet: 0x61,
   arbitrumSepolia: 0x66eee,
@@ -99,6 +100,7 @@ export const DELEGATOR_CONTRACTS: DeployedContracts = {
     [CHAIN_ID.sei]: deployments_1_3_0,
     [CHAIN_ID.sonic]: deployments_1_3_0,
     [CHAIN_ID.monad]: deployments_1_3_0,
+    [CHAIN_ID.megaEthMainnet]: deployments_1_3_0,
     // Testnets
     [CHAIN_ID.bscTestnet]: deployments_1_3_0,
     [CHAIN_ID.citreaTestnet]: deployments_1_3_0,


### PR DESCRIPTION
## 📝 Description

Adds MegaETH mainnet to deployments. 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds MegaETH mainnet to supported chains and deployment validation.
> 
> - Add `CHAIN_ID.megaEthMainnet (0x10e6)` and include it in `DELEGATOR_CONTRACTS['1.3.0']`
> - Extend `validate-contract-deployments.ts` with `megaEthMainnet` chain config and export in `chains`
> - Update `CHANGELOG.md` under Unreleased to note MegaETH mainnet deployment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a7c636928dfdfcc8d120f1a152ca1b86f0396ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->