### PR TITLE
Allow scope `type` parameter to be passed as a string as well as enum reference

### DIFF
--- a/packages/smart-accounts-kit/test/delegation.test.ts
+++ b/packages/smart-accounts-kit/test/delegation.test.ts
@@ -166,6 +166,24 @@ describe('resolveAuthority', () => {
 });
 
 describe('createDelegation', () => {
+  it('creates a delegation with a scope type as a string', () => {
+    const result = createDelegation({
+      environment: smartAccountEnvironment,
+      scope: { ...erc20Scope, type: 'erc20TransferAmount' },
+      to: mockDelegate,
+      from: mockDelegator,
+    });
+
+    expect(result).to.deep.equal({
+      delegate: mockDelegate,
+      delegator: mockDelegator,
+      authority: ROOT_AUTHORITY,
+      caveats: [...erc20ScopeCaveats],
+      salt: '0x',
+      signature: '0x',
+    });
+  });
+
   it('should create a basic delegation with root authority', () => {
     const result = createDelegation({
       environment: smartAccountEnvironment,
@@ -178,9 +196,9 @@ describe('createDelegation', () => {
     expect(result).to.deep.equal({
       delegate: mockDelegate,
       delegator: mockDelegator,
-      authority: ROOT_AUTHORITY as Hex,
+      authority: ROOT_AUTHORITY,
       caveats: [...erc20ScopeCaveats, mockCaveat],
-      salt: '0x' as Hex,
+      salt: '0x',
       signature: '0x',
     });
   });


### PR DESCRIPTION
## 📝 Description

#133 updates the `ScopeConfig` type to require the `type` parameter be passed as an enum reference. This PR updates this configuration type to also allow the enum _value_ to be passed.

This allows developers to pass either:

```
const scopeConfig = {
  type: ScopeType.Erc20TransferAmount,
  tokenAddress: '0x1234567890123456789012345678901234567890',
  maxAmount: 100n
};

const scopeConfig2 = {
  type: 'erc20TransferAmount',
  tokenAddress: '0x1234567890123456789012345678901234567890',
  maxAmount: 100n
};
```

## 🔄 What Changed?

Left the scope configurations and functions as is for simplicity, and just updated the `ScopeConfig` type (which is an argument on `createDelegation()` function) to accept both the enum reference and the enum _value_.

## 🚀 Why?

This change keeps the devex improvements from the original PR while aligning with established viem conventions. viem commonly uses string literal unions for parameters, and developers in that ecosystem generally expect to pass string values directly. Supporting both the enum reference and its string value preserves backwards compatibility, reduces friction for existing users, and adds flexibility without detracting from the value of the enum-based API.

## 🧪 How to Test?

Describe how to test these changes:

The `createDelegation` function should operate as documented, but optionally accept the enum `ScopeType` as the `type` parameter.

## ⚠️ Breaking Changes

This should no longer be breaking. If accepted, the parent PR may be marked as _non_-breaking.

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily a TypeScript typing/normalization change that widens accepted inputs for scope configs; runtime behavior is unchanged aside from accepting enum-equivalent strings.
> 
> **Overview**
> **Expands `ScopeConfig` inputs to accept either `ScopeType` enum members or their string values** (e.g. `'erc20TransferAmount'`).
> 
> Adds a small normalization step in `createCaveatBuilderFromScope` to coerce the input `type` back to `ScopeType` before switching/dispatching to the specific caveat builder.
> 
> Updates tests to cover creating delegations with string scope types and removes a few unnecessary `as Hex` assertions in expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f3203722cdac5f59c2052e3c002bdbce782aed6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->