### PR TITLE
chore: Add `lint:fix` task to all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "generate:abi": "cd ./shared/abi/scripts && ./generate-abi.sh",
     "lint": "turbo lint",
+    "lint:fix": "turbo lint:fix",
     "test": "turbo run test --filter='!./packages/delegator-e2e'",
     "test:e2e": "turbo run test:e2e --filter='./packages/delegator-e2e'",
     "test:external": "cd packages/delegator-e2e && yarn test:external",

--- a/packages/7715-permission-types/package.json
+++ b/packages/7715-permission-types/package.json
@@ -43,7 +43,9 @@
   "scripts": {
     "build": "yarn typecheck && tsup",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --cache --ext js,ts",
+    "lint": "yarn lint:eslint",
+    "lint:eslint": "eslint . --cache --ext js,ts",
+    "lint:fix": "yarn lint:eslint --fix",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/7715-permission-types",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/7715-permission-types"
   },

--- a/packages/delegation-abis/package.json
+++ b/packages/delegation-abis/package.json
@@ -57,7 +57,8 @@
     "typecheck": "tsc --noEmit",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/delegation-abis",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/delegation-abis",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "lint": ""
   },
   "publishConfig": {
     "access": "public",

--- a/packages/delegation-core/package.json
+++ b/packages/delegation-core/package.json
@@ -51,13 +51,8 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/delegation-core",
     "clean": "rm -rf dist",
     "lint": "yarn lint:eslint",
-    "lint:complete": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelog",
-    "lint:changelog": "auto-changelog validate --prettier",
-    "lint:constraints": "yarn constraints",
-    "lint:dependencies": "depcheck && yarn dedupe",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:constraints --fix && yarn lint:misc --write && yarn lint:dependencies && yarn lint:changelog",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern"
+    "lint:fix": "yarn lint:eslint --fix"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/delegation-deployments/package.json
+++ b/packages/delegation-deployments/package.json
@@ -43,7 +43,9 @@
   "scripts": {
     "build": "yarn typecheck && tsup",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --cache --ext js,ts",
+    "lint": "yarn lint:eslint",
+    "lint:eslint": "eslint . --cache --ext js,ts",
+    "lint:fix": "yarn lint:eslint --fix",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/delegation-deployments",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/delegation-deployments",
     "validate-latest-contracts": "yarn tsx script/validate-contract-deployments.ts"

--- a/packages/smart-accounts-kit/package.json
+++ b/packages/smart-accounts-kit/package.json
@@ -106,13 +106,8 @@
     "test:watch": "vitest watch",
     "format": "prettier --write \"src/**/*.{ts,tsx}\" --ignore-path .prettierignore",
     "lint": "yarn lint:eslint",
-    "lint:complete": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelog",
-    "lint:changelog": "auto-changelog validate --prettier",
-    "lint:constraints": "yarn constraints",
-    "lint:dependencies": "depcheck && yarn dedupe",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:constraints --fix && yarn lint:misc --write && yarn lint:dependencies && yarn lint:changelog",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern"
+    "lint:fix": "yarn lint:eslint --fix"
   },
   "publishConfig": {
     "access": "public",

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,9 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
+    "lint:fix": {
+      "dependsOn": ["^lint:fix"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## 📝 Description

This PR adds a `lint:fix` turbo task and yarn script, so that `yarn lint:fix` can be run from the root or any of the packages to resolve linting issues.

## 🔄 What Changed?

- Turbo "task" added
- Each package.json now defines a `lint:fix` script
- Removes legacy linting scripts that aren't used

## 🚀 Why?

This makes it easier to resolve linting issues.

## 🧪 How to Test?

Describe how to test these changes:

Run `yarn lint:fix` from the root and each package. Ensure that it performs the linting check, and passes.

## ⚠️ Breaking Changes

No breaking changes

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build tooling/script-only changes; low risk aside from potentially different lint execution behavior in CI or local workflows.
> 
> **Overview**
> Adds a new `lint:fix` workflow across the monorepo: root `package.json` now exposes `yarn lint:fix` which runs a new Turbo `lint:fix` task.
> 
> Updates package `package.json` scripts (e.g., `7715-permission-types`, `delegation-deployments`) to include `lint:fix` running ESLint with `--fix`, and adjusts `turbo.json` to register `lint:fix` (and simplifies `lint` task config).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 217e4ce4c8bc39472fd453cdf63706bf5daaca87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->