### PR TITLE
Remove unused utilities

### DIFF
--- a/packages/smart-accounts-kit/src/utils.ts
+++ b/packages/smart-accounts-kit/src/utils.ts
@@ -1,60 +1,6 @@
 import { type Hex, isHex, toHex } from 'viem';
 
 /**
- * Checks if two hexadecimal strings are equal, ignoring case sensitivity.
- *
- * @param a - The first hexadecimal string.
- * @param b - The second hexadecimal string.
- * @returns True if the hexadecimal strings are equal, false otherwise.
- */
-export function isEqualHex(a: Hex, b: Hex): boolean {
-  return isHex(a) && a.toLowerCase() === b.toLowerCase();
-}
-
-/**
- * Recursively converts all members of an object to hexadecimal format.
- * Handles various data types including functions, null, strings, booleans,
- * bigints, arrays, and objects.
- *
- * @param obj - The object to convert to hexadecimal format.
- * @returns The object with all values converted to hexadecimal format.
- */
-export function deepHexlify(obj: any): any {
-  if (typeof obj === 'function') {
-    return undefined;
-  }
-
-  if (
-    obj === null ||
-    obj === undefined ||
-    typeof obj === 'string' ||
-    typeof obj === 'boolean'
-  ) {
-    return obj;
-  }
-
-  if (typeof obj === 'bigint') {
-    return toHex(obj);
-  }
-
-  if (obj._isBigNumber !== null || typeof obj !== 'object') {
-    return toHex(obj).replace(/^0x0/u, '0x');
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.map((member) => deepHexlify(member));
-  }
-
-  return Object.keys(obj).reduce(
-    (set, key) =>
-      Object.assign(Object.assign({}, set), {
-        [key]: deepHexlify(obj[key]),
-      }),
-    {},
-  );
-}
-
-/**
  * Utility function to check if an object has all specified properties defined and not undefined.
  *
  * @template TObject - The type of the object to check.


### PR DESCRIPTION
## 📝 Description

The following utilities are not used anywhere in code, and can safely be removed:

- deepHexlify
- isEqualHex

## 🔄 What Changed?

Remove the unused utilities. No tests for, or references to these functions exist in the code.

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely deletes unused code with no call sites found; risk is limited to any external consumers importing these exports.
> 
> **Overview**
> Removes the unused `isEqualHex` and `deepHexlify` helpers from `packages/smart-accounts-kit/src/utils.ts`, leaving only the property/validation utilities (`hasProperties`, `isDefined`, `assertIsDefined`, `toHexOrThrow`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 464faea37d46398e6ea223e17f8d0391551e8cdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->