### PR TITLE
feat: add Tempo Mainnet and Tempo Moderato Testnet

### DIFF
--- a/packages/delegation-deployments/script/validate-contract-deployments.ts
+++ b/packages/delegation-deployments/script/validate-contract-deployments.ts
@@ -121,6 +121,49 @@ const monadMainnetChain: Chain = {
   },
 };
 
+const tempoModeratoTestnetChain: Chain = {
+  id: 42431,
+  name: 'Tempo Testnet Moderato',
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.moderato.tempo.xyz'],
+    },
+  },
+  // There is no concept of native currency on Tempo,
+  // which is one of the challenges of this implementation.
+  // Gas can be paid using pathUSD (TIP20/ERC20)
+  // from Tempo's faucet: https://docs.tempo.xyz/quickstart/faucet
+  // pathUSD gets selected automatically when it is in the account.
+  // Information as dispensed by chainlist:
+  nativeCurrency: {
+    name: 'USD',
+    symbol: 'USD',
+    decimals: 18,
+  },
+};
+
+const tempoMainnetChain: Chain = {
+  id: 4217,
+  name: 'Tempo Mainnet',
+  rpcUrls: {
+    default: {
+      // Currently behind authwall (contract deployment tested with QuickNode endpoint)
+      http: ['https://rpc.tempo.xyz'],
+    },
+  },
+  // There is no concept of native currency on Tempo,
+  // which is one of the challenges of this implementation.
+  // Gas can be paid using pathUSD (TIP20/ERC20)
+  // from Tempo's faucet: https://docs.tempo.xyz/quickstart/faucet
+  // pathUSD gets selected automatically when it is in the account.
+  // Information as dispensed by chainlist:
+  nativeCurrency: {
+    name: 'USD',
+    symbol: 'USD',
+    decimals: 18,
+  },
+};
+
 const citreaTestnetChain: Chain = {
   id: 5115,
   name: 'Citrea Testnet',
@@ -210,6 +253,8 @@ export const chains = {
   monad: monadMainnetChain,
   megaEthMainnet: megaEthMainnetChain,
   roninSaigon: roninSaigonChain,
+  tempoModeratoTestnet: tempoModeratoTestnetChain,
+  tempoMainnet: tempoMainnetChain,
 } as any as { [key: string]: Chain };
 
 // The default rpc urls for these chains are not reliable, so we override them

--- a/packages/delegation-deployments/src/index.ts
+++ b/packages/delegation-deployments/src/index.ts
@@ -26,6 +26,7 @@ export const CHAIN_ID = {
   megaEthMainnet: 0x10e6,
   celo: 0xa4ec,
   ronin: 0x7e4,
+  tempoMainnet: 0x1079,
   // Testnets
   bscTestnet: 0x61,
   arbitrumSepolia: 0x66eee,
@@ -46,6 +47,7 @@ export const CHAIN_ID = {
   unichainSepolia: 0x515,
   celoSepolia: 0xaa044c,
   roninSaigon: 0x31769,
+  tempoModeratoTestnet: 0xa5bf,
   // decommissioned
   lineaGoerli: 0xe704,
 };
@@ -108,6 +110,7 @@ export const DELEGATOR_CONTRACTS: DeployedContracts = {
     [CHAIN_ID.megaEthMainnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.celo]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.ronin]: DEPLOYMENTS_1_3_0,
+    [CHAIN_ID.tempoMainnet]: DEPLOYMENTS_1_3_0,
     // Testnets
     [CHAIN_ID.bscTestnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.citreaTestnet]: DEPLOYMENTS_1_3_0,
@@ -128,5 +131,6 @@ export const DELEGATOR_CONTRACTS: DeployedContracts = {
     [CHAIN_ID.hoodiTestnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.celoSepolia]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.roninSaigon]: DEPLOYMENTS_1_3_0,
+    [CHAIN_ID.tempoModeratoTestnet]: DEPLOYMENTS_1_3_0,
   },
 };


### PR DESCRIPTION
## 📝 Description

Add Tempo Mainnet and Tempo Testnet Moderato with list of deployed smart contracts (1_3_0).

## 🔄 What Changed?

List the specific changes made:
- Add Tempo Mainnet and Tempo Testnet Moderato to `DEPLOYMENTS_1_3_0`.
- Add Tempo Mainnet and Tempo Testnet Moderato info in `packages/delegation-deployments/script/validate-contract-deployments.ts`.

## 🚀 Why?

Explain the motivation behind these changes:
- As a PoC / phase 1, we implement Tempo (EVM-ish network) as EIP-7702 powered network with gasless transactions.
- Find context: https://www.notion.so/consensys/Tempo-Integration-314fc61a326e80689fffc50d88e5445d

## 🧪 How to Test?

Deployments manually tested:

Testnet:
```
Checking 37 contracts on https://rpc.moderato.tempo.xyz
==================================================
✅ OK    ExactExecutionEnforcer (0x146713078D39eCC1F5338309c28405ccf85Abfbb) — 1583 bytes
✅ OK    MultiSigDeleGatorImpl (0x56a9EdB16a0105eb5a4C54f4C062e2868844f3A7) — 16949 bytes
✅ OK    DeployedEnforcer (0x24ff2AA430D53a8CD6788018E902E098083dcCd2) — 1864 bytes
✅ OK    OwnershipTransferEnforcer (0x7EEf9734E7092032B5C56310Eb9BbD1f4A524681) — 1711 bytes
✅ OK    ERC721BalanceChangeEnforcer (0x8aFdf96eDBbe7e1eD3f5Cd89C7E084841e12A09e) — 2428 bytes
✅ OK    AllowedCalldataEnforcer (0xc2b0d624c1c4319760C96503BA27C347F3260f55) — 1756 bytes
✅ OK    RedeemerEnforcer (0xE144b0b2618071B4E56f746313528a669c7E65c5) — 1611 bytes
✅ OK    MultiTokenPeriodEnforcer (0xFB2f1a9BD76d3701B730E5d69C3219D42D80eBb7) — 5259 bytes
✅ OK    NativeTokenPaymentEnforcer (0x4803a326ddED6dDBc60e659e5ed12d85c7582811) — 4326 bytes
✅ OK    ExactExecutionBatchEnforcer (0x1e141e455d08721Dd5BCDA1BaA6Ea5633Afd5017) — 2160 bytes
✅ OK    AllowedTargetsEnforcer (0x7F20f61b1f09b08D970938F6fa563634d65c4EeB) — 1846 bytes
✅ OK    HybridDeleGatorImpl (0x48dBe696A4D990079e039489bA2053B36E8FFEC4) — 20203 bytes
✅ OK    BlockNumberEnforcer (0x5d9818dF0AE3f66e9c3D0c5029DAF99d1823ca6c) — 1261 bytes
✅ OK    EntryPoint (0x0000000071727De22E5E9d8BAf0edAc6f37da032) — 16035 bytes
✅ OK    ArgsEqualityCheckEnforcer (0x44B8C6ae3C304213c3e298495e12497Ed3E56E41) — 951 bytes
✅ OK    ERC20BalanceChangeEnforcer (0xcdF6aB796408598Cea671d79506d7D48E97a5437) — 2398 bytes
✅ OK    DelegationManager (0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3) — 11503 bytes
✅ OK    NativeTokenTransferAmountEnforcer (0xF71af580b9c3078fbc2BBF16FbB8EEd82b330320) — 1485 bytes
✅ OK    NonceEnforcer (0xDE4f2FAC4B3D87A1d9953Ca5FC09FCa7F366254f) — 1294 bytes
✅ OK    SpecificActionERC20TransferBatchEnforcer (0x6649b61c873F6F9686A1E1ae9ee98aC380c7bA13) — 3333 bytes
✅ OK    IdEnforcer (0xC8B5D93463c893401094cc70e66A206fb5987997) — 1304 bytes
✅ OK    ExactCalldataBatchEnforcer (0x982FD5C86BBF425d7d1451f974192d4525113DfD) — 2106 bytes
✅ OK    AllowedMethodsEnforcer (0x2c21fD0Cb9DC8445CB3fb0DC5E7Bb0Aca01842B5) — 2044 bytes
✅ OK    NativeTokenStreamingEnforcer (0xD10b97905a320b13a0608f7E9cC506b56747df19) — 2468 bytes
✅ OK    TimestampEnforcer (0x1046bb45C8d673d4ea75321280DB34899413c069) — 1255 bytes
✅ OK    EIP7702StatelessDeleGatorImpl (0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B) — 11185 bytes
✅ OK    ERC1155BalanceChangeEnforcer (0x63c322732695cAFbbD488Fc6937A0A7B66fC001A) — 2507 bytes
✅ OK    ValueLteEnforcer (0x92Bf12322527cAA612fd31a0e810472BBB106A8F) — 1272 bytes
✅ OK    ERC20TransferAmountEnforcer (0xf100b0819427117EcF76Ed94B358B1A5b5C6D2Fc) — 2078 bytes
✅ OK    ERC20PeriodTransferEnforcer (0x474e3Ae7E169e940607cC624Da8A15Eb120139aB) — 3346 bytes
✅ OK    ERC721TransferEnforcer (0x3790e6B7233f779b09DA74C72b6e94813925b9aF) — 2081 bytes
✅ OK    NativeTokenPeriodTransferEnforcer (0x9BC0FAf4Aca5AE429F4c06aEEaC517520CB16BD9) — 2903 bytes
✅ OK    ExactCalldataEnforcer (0x99F2e9bF15ce5eC84685604836F71aB835DBBdED) — 1369 bytes
✅ OK    ERC20StreamingEnforcer (0x56c97aE02f233B29fa03502Ecc0457266d9be00e) — 2941 bytes
✅ OK    LimitedCallsEnforcer (0x04658B29F6b82ed55274221a06Fc97D318E25416) — 1257 bytes
✅ OK    SimpleFactory (0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c) — 751 bytes
✅ OK    NativeBalanceChangeEnforcer (0xbD7B277507723490Cd50b12EaaFe87C616be6880) — 2084 bytes
==================================================
Results: ✅ 37 deployed  ⚠️  0 empty  ❌ 0 error
```
Mainnet:
```
Checking 37 contracts on https://[redacted].tempo-mainnet.quiknode.pro/[redacted]/
==================================================
✅ OK    ExactExecutionEnforcer (0x146713078D39eCC1F5338309c28405ccf85Abfbb) — 1583 bytes
✅ OK    MultiSigDeleGatorImpl (0x56a9EdB16a0105eb5a4C54f4C062e2868844f3A7) — 16949 bytes
✅ OK    DeployedEnforcer (0x24ff2AA430D53a8CD6788018E902E098083dcCd2) — 1864 bytes
✅ OK    OwnershipTransferEnforcer (0x7EEf9734E7092032B5C56310Eb9BbD1f4A524681) — 1711 bytes
✅ OK    ERC721BalanceChangeEnforcer (0x8aFdf96eDBbe7e1eD3f5Cd89C7E084841e12A09e) — 2428 bytes
✅ OK    AllowedCalldataEnforcer (0xc2b0d624c1c4319760C96503BA27C347F3260f55) — 1756 bytes
✅ OK    RedeemerEnforcer (0xE144b0b2618071B4E56f746313528a669c7E65c5) — 1611 bytes
✅ OK    MultiTokenPeriodEnforcer (0xFB2f1a9BD76d3701B730E5d69C3219D42D80eBb7) — 5259 bytes
✅ OK    NativeTokenPaymentEnforcer (0x4803a326ddED6dDBc60e659e5ed12d85c7582811) — 4326 bytes
✅ OK    ExactExecutionBatchEnforcer (0x1e141e455d08721Dd5BCDA1BaA6Ea5633Afd5017) — 2160 bytes
✅ OK    AllowedTargetsEnforcer (0x7F20f61b1f09b08D970938F6fa563634d65c4EeB) — 1846 bytes
✅ OK    HybridDeleGatorImpl (0x48dBe696A4D990079e039489bA2053B36E8FFEC4) — 20203 bytes
✅ OK    BlockNumberEnforcer (0x5d9818dF0AE3f66e9c3D0c5029DAF99d1823ca6c) — 1261 bytes
✅ OK    EntryPoint (0x0000000071727De22E5E9d8BAf0edAc6f37da032) — 16035 bytes
✅ OK    ArgsEqualityCheckEnforcer (0x44B8C6ae3C304213c3e298495e12497Ed3E56E41) — 951 bytes
✅ OK    ERC20BalanceChangeEnforcer (0xcdF6aB796408598Cea671d79506d7D48E97a5437) — 2398 bytes
✅ OK    DelegationManager (0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3) — 11503 bytes
✅ OK    NativeTokenTransferAmountEnforcer (0xF71af580b9c3078fbc2BBF16FbB8EEd82b330320) — 1485 bytes
✅ OK    NonceEnforcer (0xDE4f2FAC4B3D87A1d9953Ca5FC09FCa7F366254f) — 1294 bytes
✅ OK    SpecificActionERC20TransferBatchEnforcer (0x6649b61c873F6F9686A1E1ae9ee98aC380c7bA13) — 3333 bytes
✅ OK    IdEnforcer (0xC8B5D93463c893401094cc70e66A206fb5987997) — 1304 bytes
✅ OK    ExactCalldataBatchEnforcer (0x982FD5C86BBF425d7d1451f974192d4525113DfD) — 2106 bytes
✅ OK    AllowedMethodsEnforcer (0x2c21fD0Cb9DC8445CB3fb0DC5E7Bb0Aca01842B5) — 2044 bytes
✅ OK    NativeTokenStreamingEnforcer (0xD10b97905a320b13a0608f7E9cC506b56747df19) — 2468 bytes
✅ OK    TimestampEnforcer (0x1046bb45C8d673d4ea75321280DB34899413c069) — 1255 bytes
✅ OK    EIP7702StatelessDeleGatorImpl (0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B) — 11185 bytes
✅ OK    ERC1155BalanceChangeEnforcer (0x63c322732695cAFbbD488Fc6937A0A7B66fC001A) — 2507 bytes
✅ OK    ValueLteEnforcer (0x92Bf12322527cAA612fd31a0e810472BBB106A8F) — 1272 bytes
✅ OK    ERC20TransferAmountEnforcer (0xf100b0819427117EcF76Ed94B358B1A5b5C6D2Fc) — 2078 bytes
✅ OK    ERC20PeriodTransferEnforcer (0x474e3Ae7E169e940607cC624Da8A15Eb120139aB) — 3346 bytes
✅ OK    ERC721TransferEnforcer (0x3790e6B7233f779b09DA74C72b6e94813925b9aF) — 2081 bytes
✅ OK    NativeTokenPeriodTransferEnforcer (0x9BC0FAf4Aca5AE429F4c06aEEaC517520CB16BD9) — 2903 bytes
✅ OK    ExactCalldataEnforcer (0x99F2e9bF15ce5eC84685604836F71aB835DBBdED) — 1369 bytes
✅ OK    ERC20StreamingEnforcer (0x56c97aE02f233B29fa03502Ecc0457266d9be00e) — 2941 bytes
✅ OK    LimitedCallsEnforcer (0x04658B29F6b82ed55274221a06Fc97D318E25416) — 1257 bytes
✅ OK    SimpleFactory (0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c) — 751 bytes
✅ OK    NativeBalanceChangeEnforcer (0xbD7B277507723490Cd50b12EaaFe87C616be6880) — 2084 bytes
==================================================
Results: ✅ 37 deployed  ⚠️  0 empty  ❌ 0 error
```

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new chain IDs/config entries and includes them in the existing `1.3.0` deployment mapping, without changing contract logic or validation behavior. Main risk is misconfigured chain IDs/RPC URLs causing deployment validation or downstream chain selection to fail.
> 
> **Overview**
> Adds **Tempo Mainnet** and **Tempo Moderato Testnet** to the `delegation-deployments` package by introducing new `CHAIN_ID` entries and including both chains in the `DELEGATOR_CONTRACTS['1.3.0']` mapping (using `DEPLOYMENTS_1_3_0`).
> 
> Extends `validate-contract-deployments.ts` with Tempo `Chain` configurations (RPC URLs and a placeholder `nativeCurrency`) and registers them in the exported `chains` list so the existing deployment validation script can target Tempo networks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d40e4afb674b6c2f3b4af190a893af4689affdba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->