### PR TITLE
feat: respect nonce keys, and accept `NonceKeyManager`

### DIFF
--- a/packages/smart-accounts-kit/src/toMetaMaskSmartAccount.ts
+++ b/packages/smart-accounts-kit/src/toMetaMaskSmartAccount.ts
@@ -8,6 +8,7 @@ import {
   entryPoint07Abi,
   toPackedUserOperation,
   toSmartAccount,
+  type ToSmartAccountParameters,
 } from 'viem/account-abstraction';
 
 import { isValid7702Implementation } from './actions/isValid7702Implementation';
@@ -32,6 +33,8 @@ import type {
 import { SIGNABLE_USER_OP_TYPED_DATA } from './userOp';
 
 const ENTRYPOINT_VERSION = '0.7' as const;
+
+type GetNonce = NonNullable<ToSmartAccountParameters['getNonce']>;
 
 /**
  * Creates a MetaMask DeleGator smart account instance.
@@ -186,12 +189,12 @@ export async function toMetaMaskSmartAccount<
 
   const getAddress = async () => address;
 
-  const getNonce = async () =>
+  const getNonce: GetNonce = async (parameters) =>
     _getNonce({
       client,
       entryPoint: environment.EntryPoint,
       contractAddress: address,
-      key: 0n,
+      key: parameters?.key ?? 0n,
     });
 
   const encodeCalls = async (calls: readonly Call[]) =>

--- a/packages/smart-accounts-kit/src/toMetaMaskSmartAccount.ts
+++ b/packages/smart-accounts-kit/src/toMetaMaskSmartAccount.ts
@@ -8,7 +8,6 @@ import {
   entryPoint07Abi,
   toPackedUserOperation,
   toSmartAccount,
-  type ToSmartAccountParameters,
 } from 'viem/account-abstraction';
 
 import { isValid7702Implementation } from './actions/isValid7702Implementation';
@@ -18,7 +17,6 @@ import {
   SIGNABLE_DELEGATION_TYPED_DATA,
   toDelegationStruct,
 } from './delegation';
-import { entryPointGetNonce as _getNonce } from './DelegationFramework/EntryPoint/read';
 import { encodeCallsForCaller } from './encodeCalls';
 import { resolveSigner } from './signer';
 import { getSmartAccountsEnvironment } from './smartAccountsEnvironment';
@@ -33,8 +31,6 @@ import type {
 import { SIGNABLE_USER_OP_TYPED_DATA } from './userOp';
 
 const ENTRYPOINT_VERSION = '0.7' as const;
-
-type GetNonce = NonNullable<ToSmartAccountParameters['getNonce']>;
 
 /**
  * Creates a MetaMask DeleGator smart account instance.
@@ -190,14 +186,6 @@ export async function toMetaMaskSmartAccount<
 
   const getAddress = async () => address;
 
-  const getNonce: GetNonce = async (parameters) =>
-    _getNonce({
-      client,
-      entryPoint: environment.EntryPoint,
-      contractAddress: address,
-      key: parameters?.key ?? 0n,
-    });
-
   const encodeCalls = async (calls: readonly Call[]) =>
     encodeCallsForCaller(address, calls);
 
@@ -227,7 +215,6 @@ export async function toMetaMaskSmartAccount<
     getAddress,
     getFactoryArgs,
     encodeCalls,
-    getNonce,
     signUserOperation,
     signDelegation,
     nonceKeyManager,

--- a/packages/smart-accounts-kit/src/toMetaMaskSmartAccount.ts
+++ b/packages/smart-accounts-kit/src/toMetaMaskSmartAccount.ts
@@ -56,6 +56,7 @@ export async function toMetaMaskSmartAccount<
     client,
     client: { chain },
     implementation,
+    nonceKeyManager,
   } = params;
 
   if (!chain) {
@@ -229,6 +230,7 @@ export async function toMetaMaskSmartAccount<
     getNonce,
     signUserOperation,
     signDelegation,
+    nonceKeyManager,
     ...signerMethods,
   });
 

--- a/packages/smart-accounts-kit/src/types.ts
+++ b/packages/smart-accounts-kit/src/types.ts
@@ -9,6 +9,7 @@ import type {
   Address,
   Chain,
   Hex,
+  NonceManager,
   OneOf,
   PublicClient,
   Transport,
@@ -154,6 +155,7 @@ export type ToMetaMaskSmartAccountParameters<
   implementation: TImplementation;
   signer?: SignerConfigByImplementation<TImplementation>;
   environment?: SmartAccountsEnvironment;
+  nonceKeyManager?: NonceManager;
 } & OneOf<
   | {
       deployParams: DeployParams<TImplementation>;

--- a/packages/smart-accounts-kit/test/toMetaMaskSmartAccount.test.ts
+++ b/packages/smart-accounts-kit/test/toMetaMaskSmartAccount.test.ts
@@ -1,5 +1,6 @@
 import type { Account, PublicClient } from 'viem';
 import {
+  createNonceManager,
   createPublicClient,
   custom,
   hashTypedData,
@@ -7,10 +8,14 @@ import {
   isHex,
   recoverAddress,
 } from 'viem';
-import { toPackedUserOperation } from 'viem/account-abstraction';
+import {
+  toPackedUserOperation,
+  toSmartAccount,
+} from 'viem/account-abstraction';
+import type * as viemAccountAbstraction from 'viem/account-abstraction';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { hardhat as chain } from 'viem/chains';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { randomAddress } from './utils';
 import { Implementation } from '../src/constants';
@@ -21,6 +26,16 @@ import type {
 } from '../src/types';
 import { SIGNABLE_USER_OP_TYPED_DATA } from '../src/userOp';
 
+vi.mock('viem/account-abstraction', async (importOriginal) => {
+  const actual = await importOriginal<typeof viemAccountAbstraction>();
+  return {
+    ...actual,
+    toSmartAccount: vi.fn(async (implementation) =>
+      actual.toSmartAccount(implementation),
+    ),
+  };
+});
+
 describe('MetaMaskSmartAccount', () => {
   let publicClient: PublicClient;
   let alice: Account;
@@ -28,6 +43,8 @@ describe('MetaMaskSmartAccount', () => {
   let environment: SmartAccountsEnvironment;
 
   beforeEach(async () => {
+    vi.mocked(toSmartAccount).mockClear();
+
     const transport = custom({
       request: async () => '0x',
     });
@@ -140,6 +157,41 @@ describe('MetaMaskSmartAccount', () => {
       });
 
       expect(smartAccount).toBeInstanceOf(Object);
+    });
+
+    it('passes nonceKeyManager as undefined when not specified', async () => {
+      await toMetaMaskSmartAccount({
+        client: publicClient,
+        implementation: Implementation.Hybrid,
+        deployParams: [alice.address, [], [], []],
+        deploySalt: '0x0',
+        signer: { account: alice },
+        environment,
+      });
+
+      expect(vi.mocked(toSmartAccount)).toHaveBeenCalledWith(
+        expect.objectContaining({ nonceKeyManager: undefined }),
+      );
+    });
+
+    it('passes nonceKeyManager into toSmartAccount when specified', async () => {
+      const nonceKeyManager = createNonceManager({
+        source: { get: () => 0, set: () => undefined },
+      });
+
+      await toMetaMaskSmartAccount({
+        client: publicClient,
+        implementation: Implementation.Hybrid,
+        deployParams: [alice.address, [], [], []],
+        deploySalt: '0x0',
+        signer: { account: alice },
+        environment,
+        nonceKeyManager,
+      });
+
+      expect(vi.mocked(toSmartAccount)).toHaveBeenCalledWith(
+        expect.objectContaining({ nonceKeyManager }),
+      );
     });
   });
   describe('optional signer', () => {


### PR DESCRIPTION
## 📝 Description

The `getNonce` function passed into `toSmartAccount` hardcodes nonce `key` as `0n`.

This PR improves nonce management by falling back to the default `getNonce` implementation (which respects the supplied `key` parameter), and allows a custom `nonceKeyManager` to be specified when calling `toMetaMaskSmartAccount`.

## 🔄 What Changed?

- Remove `getNonce` function defined in `toMetaMaskSmartAccount`.
- Accept custom `nonceKeyManager` when calling `toMetaMaskSmartAccount`

## 🚀 Why?

When the smart account only supports a single nonce key, parallel executors will suffer nonce collisions. By supporting multiple nonce keys, the executors are isolated from each other.

## 🧪 How to Test?

Describe how to test these changes:

1. Create an instance of `MetaMaskSmartAccount`
2. Call `getNonce({ key: 0n })` and `getNonce({ key: 1n })` on the `MetaMaskSmartAccount`

**Before:**

Both calls would return the same value.

**After:** 

Calls should return different values.

1. Create an instance of `MetaMaskSmartAccount` and specify a `nonceKeyManager`
2. Call `prepareUserOperation` multiple times
3. Expect the `get` function specified in `createNonceManager` to be called each time `prepareUserOperation` is called

## ⚠️ Breaking Changes

List any breaking changes:

- [X] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

A caller may now pass `nonceKeyManager: NonceManager` to `toMetaMaskSmartAccountsKit` function:

```
const nonceKeyManager = createNonceManager({
  source: { get: () => Date.now(), set: () => undefined },
});

await toMetaMaskSmartAccount({
  ...
  nonceKeyManager,
});
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes nonce retrieval behavior for smart accounts by removing a hardcoded nonce key and delegating nonce selection to viem/`NonceManager`, which can affect user operation ordering and parallel execution.
> 
> **Overview**
> `toMetaMaskSmartAccount` no longer overrides `getNonce` with a hardcoded `key: 0n`, letting the underlying `toSmartAccount` implementation handle nonce keys correctly.
> 
> It adds an optional `nonceKeyManager?: NonceManager` parameter (plumbed through to `toSmartAccount`) and updates tests to assert the parameter is forwarded when provided (and `undefined` otherwise).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f977d8635bd2d98992e39fa53cbee726157e7bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->