### PR TITLE
Remove unused dependency on buffer polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/keccak": "^3.0.4",
     "@yarnpkg/types": "^4.0.1",
     "abitype": "^1.0.2",
-    "buffer": "^6.0.3",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-turbo": "^1.11.3",

--- a/packages/smart-accounts-kit/package.json
+++ b/packages/smart-accounts-kit/package.json
@@ -133,7 +133,6 @@
     "@metamask/delegation-abis": "^1.0.0",
     "@metamask/delegation-core": "^1.0.0",
     "@metamask/delegation-deployments": "^1.1.0",
-    "buffer": "^6.0.3",
     "openapi-fetch": "^0.13.5",
     "ox": "0.8.1"
   },

--- a/packages/smart-accounts-kit/test/webAuthn.test.ts
+++ b/packages/smart-accounts-kit/test/webAuthn.test.ts
@@ -1,10 +1,10 @@
-import { Buffer as BufferPolyfill } from 'buffer/';
 import { Signature } from 'ox';
 import {
   decodeAbiParameters,
   isHex,
   keccak256,
   encodePacked,
+  hexToBytes,
   toHex,
   serializeSignature,
 } from 'viem';
@@ -65,9 +65,8 @@ const validWebAuthnData = {
 describe('webAuthn', () => {
   const overwriteAuthenticatorDataFlags = (flags: number) => {
     // we just take the known authenticator data and overwrite the flags
-    const authenticatorDataBuffer = BufferPolyfill.from(
-      validWebAuthnData.authenticatorData.slice(2),
-      'Hex',
+    const authenticatorDataBuffer = hexToBytes(
+      validWebAuthnData.authenticatorData,
     );
 
     // the 33rd byte (index 32) is the flags byte

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,7 +806,6 @@ __metadata:
     "@types/node": "npm:^20.19.0"
     "@types/sinon": "npm:^17.0.3"
     "@vitest/coverage-v8": "npm:3.2.4"
-    buffer: "npm:^6.0.3"
     dotenv: "npm:^16.3.1"
     eslint: "npm:^9.39.2"
     eslint-config-prettier: "npm:^9.1.0"
@@ -2240,13 +2239,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
-  version: 1.5.1
-  resolution: "base64-js@npm:1.5.1"
-  checksum: 10/669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
-  languageName: node
-  linkType: hard
-
 "before-after-hook@npm:^2.2.0":
   version: 2.2.3
   resolution: "before-after-hook@npm:2.2.3"
@@ -2318,16 +2310,6 @@ __metadata:
   dependencies:
     fill-range: "npm:^7.1.1"
   checksum: 10/fad11a0d4697a27162840b02b1fad249c1683cbc510cd5bf1a471f2f8085c046d41094308c577a50a03a579dd99d5a6b3724c4b5e8b14df2c4443844cfcda2c6
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: "npm:^1.3.1"
-    ieee754: "npm:^1.2.1"
-  checksum: 10/b6bc68237ebf29bdacae48ce60e5e28fc53ae886301f2ad9496618efac49427ed79096750033e7eab1897a4f26ae374ace49106a5758f38fb70c78c9fda2c3b1
   languageName: node
   linkType: hard
 
@@ -2702,7 +2684,6 @@ __metadata:
     "@types/keccak": "npm:^3.0.4"
     "@yarnpkg/types": "npm:^4.0.1"
     abitype: "npm:^1.0.2"
-    buffer: "npm:^6.0.3"
     eslint: "npm:^9.39.2"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-config-turbo: "npm:^1.11.3"
@@ -3890,13 +3871,6 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10/24e3292dd3dadaa81d065c6f8c41b274a47098150d444b96e5f53b4638a9a71482921ea6a91a1f59bb71d9796de25e04afd05919fa64c360347ba65d3766f10f
-  languageName: node
-  linkType: hard
-
-"ieee754@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "ieee754@npm:1.2.1"
-  checksum: 10/d9f2557a59036f16c282aaeb107832dc957a93d73397d89bbad4eb1130560560eb695060145e8e6b3b498b15ab95510226649a0b8f52ae06583575419fe10fc4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📝 Description

@metamask/smart-accounts-kit declares a dependency on `buffer` that is used only in tests.

## 🔄 What Changed?

The buffer polyfill was used for converting hex to bytes in `webauth.tests.ts` - now we use the `hexToBytes` util from `viem` instead.

## 🧪 How to Test?

Ensure all unit tests and end-to-end tests run successfully (this is removing a dist dependency, but not one that is used anywhere outside of tests).

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes an unused runtime dependency and updates a single test helper to use `viem` utilities; functional impact should be limited to test execution.
> 
> **Overview**
> Removes the `buffer` polyfill dependency from the root and `@metamask/smart-accounts-kit`, updating `yarn.lock` accordingly.
> 
> Updates `webAuthn.test.ts` to replace `Buffer`-based hex-to-bytes conversion with `viem`’s `hexToBytes`, keeping the same test behavior while avoiding a dist dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f1f8496b088a07f6388fa3f07ecdcdb070c9905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->