### PR TITLE
chore: add katana network

### DIFF
--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add chain deployment for Katana mainnet and Katana Bokuto ([#203](https://github.com/MetaMask/smart-accounts-kit/pull/203))
+
 ## [1.1.0]
 
 ### Added

--- a/packages/delegation-deployments/script/validate-contract-deployments.ts
+++ b/packages/delegation-deployments/script/validate-contract-deployments.ts
@@ -289,7 +289,7 @@ const katanaMainnet: Chain = {
   name: 'Katana Mainnet',
   rpcUrls: {
     default: {
-      http: ['	https://rpc.katana.network'],
+      http: ['https://rpc.katana.network'],
     },
   },
   nativeCurrency: {

--- a/packages/delegation-deployments/script/validate-contract-deployments.ts
+++ b/packages/delegation-deployments/script/validate-contract-deployments.ts
@@ -284,8 +284,8 @@ const mantleSepoliaChain: Chain = {
   },
 };
 
-const katanaMainnet: Chain = {
-  id: 	747474,
+const katanaMainnetChain: Chain = {
+  id: 747474,
   name: 'Katana Mainnet',
   rpcUrls: {
     default: {
@@ -299,7 +299,7 @@ const katanaMainnet: Chain = {
   },
 };
 
-const katanaBokuto: Chain = {
+const katanaBokutoChain: Chain = {
   id: 737373,
   name: 'Katana Bokuto',
   rpcUrls: {
@@ -333,8 +333,8 @@ export const chains = {
   citreaMainnet: citreaMainnetChain,
   mantleMainnet: mantleMainnetChain,
   mantleSepolia: mantleSepoliaChain,
-  katanaMainnet: katanaMainnet,
-  katanaBokuto: katanaBokuto,
+  katanaMainnet: katanaMainnetChain,
+  katanaBokuto: katanaBokutoChain,
 } as any as { [key: string]: Chain };
 
 // The default rpc urls for these chains are not reliable, so we override them

--- a/packages/delegation-deployments/script/validate-contract-deployments.ts
+++ b/packages/delegation-deployments/script/validate-contract-deployments.ts
@@ -284,6 +284,36 @@ const mantleSepoliaChain: Chain = {
   },
 };
 
+const katanaMainnet: Chain = {
+  id: 	747474,
+  name: 'Katana Mainnet',
+  rpcUrls: {
+    default: {
+      http: ['	https://rpc.katana.network'],
+    },
+  },
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+};
+
+const katanaBokuto: Chain = {
+  id: 737373,
+  name: 'Katana Bokuto',
+  rpcUrls: {
+    default: {
+      http: ['https://rpc-bokuto.katanarpc.com'],
+    },
+  },
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+};
+
 export const chains = {
   ...allChains,
   megaEthTestNet: megaEthTestNetChain,
@@ -303,6 +333,8 @@ export const chains = {
   citreaMainnet: citreaMainnetChain,
   mantleMainnet: mantleMainnetChain,
   mantleSepolia: mantleSepoliaChain,
+  katanaMainnet: katanaMainnet,
+  katanaBokuto: katanaBokuto,
 } as any as { [key: string]: Chain };
 
 // The default rpc urls for these chains are not reliable, so we override them

--- a/packages/delegation-deployments/src/index.ts
+++ b/packages/delegation-deployments/src/index.ts
@@ -29,6 +29,7 @@ export const CHAIN_ID = {
   tempoMainnet: 0x1079,
   citreaMainnet: 0x1012,
   mantleMainnet: 0x1388,
+  katanaMainnet: 0xb67d2,
   // Testnets
   bscTestnet: 0x61,
   arbitrumSepolia: 0x66eee,
@@ -51,6 +52,7 @@ export const CHAIN_ID = {
   roninSaigon: 0x31769,
   tempoModeratoTestnet: 0xa5bf,
   mantleSepolia: 0x138b,
+  katanaBokuto: 0xb405d,
   // decommissioned
   lineaGoerli: 0xe704,
 };
@@ -116,6 +118,7 @@ export const DELEGATOR_CONTRACTS: DeployedContracts = {
     [CHAIN_ID.tempoMainnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.citreaMainnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.mantleMainnet]: DEPLOYMENTS_1_3_0,
+    [CHAIN_ID.katanaMainnet]: DEPLOYMENTS_1_3_0,
     // Testnets
     [CHAIN_ID.bscTestnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.citreaTestnet]: DEPLOYMENTS_1_3_0,
@@ -138,5 +141,6 @@ export const DELEGATOR_CONTRACTS: DeployedContracts = {
     [CHAIN_ID.roninSaigon]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.tempoModeratoTestnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.mantleSepolia]: DEPLOYMENTS_1_3_0,
+    [CHAIN_ID.katanaBokuto]: DEPLOYMENTS_1_3_0,
   },
 };


### PR DESCRIPTION
## 📝 Description

Add deployments for katana mainnet and katana bokuto testnet.

## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only registers new chain IDs/RPC endpoints and includes them in the deployment-validation and `DELEGATOR_CONTRACTS` mappings. Main risk is misconfigured chain IDs/RPC URLs causing validation/runtime lookups to fail for the new networks.
> 
> **Overview**
> Adds **Katana Mainnet** and **Katana Bokuto (testnet)** support to `@metamask/delegation-deployments` by registering their chain IDs and wiring them into the `DELEGATOR_CONTRACTS` map for version `1.3.0`.
> 
> Updates the deployment validation script (`validate-contract-deployments.ts`) with Katana chain definitions (IDs and RPC URLs), and updates the changelog to note the new chain deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8f1a6803a0f2384ee22fb5c70f491e6813eaf75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->