### PR TITLE
fix: Balance change type enforcers now use `BalanceChangeType` enum instead of number type

### DIFF
--- a/packages/delegation-core/src/caveats/erc1155BalanceChange.ts
+++ b/packages/delegation-core/src/caveats/erc1155BalanceChange.ts
@@ -43,7 +43,7 @@ export type ERC1155BalanceChangeTerms<
   /** The balance change amount. */
   balance: bigint;
   /** The balance change type. */
-  changeType: number;
+  changeType: BalanceChangeType;
 };
 
 /**
@@ -74,13 +74,7 @@ export function createERC1155BalanceChangeTerms(
   terms: ERC1155BalanceChangeTerms,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
-  const {
-    tokenAddress,
-    recipient,
-    tokenId,
-    balance,
-    changeType: changeTypeNumber,
-  } = terms;
+  const { tokenAddress, recipient, tokenId, balance, changeType } = terms;
 
   const tokenAddressHex = normalizeAddressLowercase(
     tokenAddress,
@@ -98,8 +92,6 @@ export function createERC1155BalanceChangeTerms(
   if (tokenId < 0n) {
     throw new Error('Invalid tokenId: must be a non-negative number');
   }
-
-  const changeType = changeTypeNumber as BalanceChangeType;
 
   if (
     changeType !== BalanceChangeType.Increase &&

--- a/packages/delegation-core/src/caveats/erc20BalanceChange.ts
+++ b/packages/delegation-core/src/caveats/erc20BalanceChange.ts
@@ -40,7 +40,7 @@ export type ERC20BalanceChangeTerms<TBytesLike extends BytesLike = BytesLike> =
     /** The balance change amount. */
     balance: bigint;
     /** The balance change type. */
-    changeType: number;
+    changeType: BalanceChangeType;
   };
 
 /**
@@ -71,12 +71,7 @@ export function createERC20BalanceChangeTerms(
   terms: ERC20BalanceChangeTerms,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
-  const {
-    tokenAddress,
-    recipient,
-    balance,
-    changeType: changeTypeNumber,
-  } = terms;
+  const { tokenAddress, recipient, balance, changeType } = terms;
 
   const tokenAddressHex = normalizeAddressLowercase(
     tokenAddress,
@@ -90,8 +85,6 @@ export function createERC20BalanceChangeTerms(
   if (balance <= 0n) {
     throw new Error('Invalid balance: must be a positive number');
   }
-
-  const changeType = changeTypeNumber as BalanceChangeType;
 
   if (
     changeType !== BalanceChangeType.Increase &&

--- a/packages/delegation-core/src/caveats/erc721BalanceChange.ts
+++ b/packages/delegation-core/src/caveats/erc721BalanceChange.ts
@@ -40,7 +40,7 @@ export type ERC721BalanceChangeTerms<TBytesLike extends BytesLike = BytesLike> =
     /** The balance change amount. */
     amount: bigint;
     /** The balance change type. */
-    changeType: number;
+    changeType: BalanceChangeType;
   };
 
 /**
@@ -71,12 +71,7 @@ export function createERC721BalanceChangeTerms(
   terms: ERC721BalanceChangeTerms,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
-  const {
-    tokenAddress,
-    recipient,
-    amount,
-    changeType: changeTypeNumber,
-  } = terms;
+  const { tokenAddress, recipient, amount, changeType } = terms;
 
   const tokenAddressHex = normalizeAddressLowercase(
     tokenAddress,
@@ -90,8 +85,6 @@ export function createERC721BalanceChangeTerms(
   if (amount <= 0n) {
     throw new Error('Invalid balance: must be a positive number');
   }
-
-  const changeType = changeTypeNumber as BalanceChangeType;
 
   if (
     changeType !== BalanceChangeType.Increase &&

--- a/packages/delegation-core/src/caveats/nativeBalanceChange.ts
+++ b/packages/delegation-core/src/caveats/nativeBalanceChange.ts
@@ -38,7 +38,7 @@ export type NativeBalanceChangeTerms<TBytesLike extends BytesLike = BytesLike> =
     /** The balance change amount. */
     balance: bigint;
     /** The balance change type. */
-    changeType: number;
+    changeType: BalanceChangeType;
   };
 
 /**
@@ -69,7 +69,7 @@ export function createNativeBalanceChangeTerms(
   terms: NativeBalanceChangeTerms,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
-  const { recipient, balance, changeType: changeTypeNumber } = terms;
+  const { recipient, balance, changeType } = terms;
 
   const recipientHex = normalizeAddressLowercase(
     recipient,
@@ -79,8 +79,6 @@ export function createNativeBalanceChangeTerms(
   if (balance <= 0n) {
     throw new Error('Invalid balance: must be a positive number');
   }
-
-  const changeType = changeTypeNumber as BalanceChangeType;
 
   if (
     changeType !== BalanceChangeType.Increase &&

--- a/packages/delegation-core/src/index.ts
+++ b/packages/delegation-core/src/index.ts
@@ -4,6 +4,8 @@ export type {
   CaveatStruct as Caveat,
 } from './types';
 
+export { BalanceChangeType } from './caveats/types';
+
 export {
   createValueLteTerms,
   decodeValueLteTerms,

--- a/packages/delegation-core/test/caveats/decoders.test.ts
+++ b/packages/delegation-core/test/caveats/decoders.test.ts
@@ -64,6 +64,7 @@ import {
   createSpecificActionERC20TransferBatchTerms,
   decodeSpecificActionERC20TransferBatchTerms,
 } from '../../src/caveats';
+import { BalanceChangeType } from '../../src/caveats/types';
 
 describe('Terms Decoders', () => {
   describe('decodeValueLteTerms', () => {
@@ -295,7 +296,7 @@ describe('Terms Decoders', () => {
         recipient:
           '0x1234567890123456789012345678901234567890' as `0x${string}`,
         balance: 1000000000000000000n,
-        changeType: 0,
+        changeType: BalanceChangeType.Increase,
       };
       const encoded = createNativeBalanceChangeTerms(original);
       const decoded = decodeNativeBalanceChangeTerms(encoded);
@@ -355,7 +356,7 @@ describe('Terms Decoders', () => {
         recipient:
           '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
         balance: 1000000000000000000n,
-        changeType: 0,
+        changeType: BalanceChangeType.Increase,
       };
       const encoded = createERC20BalanceChangeTerms(original);
       const decoded = decodeERC20BalanceChangeTerms(encoded);
@@ -430,7 +431,7 @@ describe('Terms Decoders', () => {
         recipient:
           '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
         amount: 5n,
-        changeType: 0,
+        changeType: BalanceChangeType.Increase,
       };
       const encoded = createERC721BalanceChangeTerms(original);
       const decoded = decodeERC721BalanceChangeTerms(encoded);
@@ -454,7 +455,7 @@ describe('Terms Decoders', () => {
           '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
         tokenId: 123n,
         balance: 1000n,
-        changeType: 0,
+        changeType: BalanceChangeType.Increase,
       };
       const encoded = createERC1155BalanceChangeTerms(original);
       const decoded = decodeERC1155BalanceChangeTerms(encoded);

--- a/packages/delegation-core/test/caveats/erc1155BalanceChange.test.ts
+++ b/packages/delegation-core/test/caveats/erc1155BalanceChange.test.ts
@@ -53,6 +53,18 @@ describe('ERC1155BalanceChange', () => {
       ).toThrow('Invalid balance: must be a positive number');
     });
 
+    it('throws for invalid changeType', () => {
+      expect(() =>
+        createERC1155BalanceChangeTerms({
+          tokenAddress,
+          recipient,
+          tokenId: 1n,
+          balance: 1n,
+          changeType: 2 as any,
+        }),
+      ).toThrow('Invalid changeType: must be either Increase or Decrease');
+    });
+
     it('returns Uint8Array when bytes encoding is specified', () => {
       const result = createERC1155BalanceChangeTerms(
         {

--- a/packages/delegation-core/test/caveats/erc1155BalanceChange.test.ts
+++ b/packages/delegation-core/test/caveats/erc1155BalanceChange.test.ts
@@ -60,7 +60,7 @@ describe('ERC1155BalanceChange', () => {
           recipient,
           tokenId: 1n,
           balance: 1n,
-          changeType: 2 as any,
+          changeType: 2 as BalanceChangeType,
         }),
       ).toThrow('Invalid changeType: must be either Increase or Decrease');
     });

--- a/packages/delegation-core/test/caveats/erc20BalanceChange.test.ts
+++ b/packages/delegation-core/test/caveats/erc20BalanceChange.test.ts
@@ -27,6 +27,22 @@ describe('ERC20BalanceChange', () => {
       );
     });
 
+    it('creates valid terms for balance increase', () => {
+      const result = createERC20BalanceChangeTerms({
+        tokenAddress,
+        recipient,
+        balance: 1n,
+        changeType: BalanceChangeType.Increase,
+      });
+
+      expect(result).toStrictEqual(
+        '0x00' +
+          '00000000000000000000000000000000000000dd' +
+          '00000000000000000000000000000000000000ee' +
+          '0000000000000000000000000000000000000000000000000000000000000001',
+      );
+    });
+
     it('throws for invalid token address', () => {
       expect(() =>
         createERC20BalanceChangeTerms({
@@ -47,6 +63,17 @@ describe('ERC20BalanceChange', () => {
           changeType: BalanceChangeType.Increase,
         }),
       ).toThrow('Invalid balance: must be a positive number');
+    });
+
+    it('throws for invalid changeType', () => {
+      expect(() =>
+        createERC20BalanceChangeTerms({
+          tokenAddress,
+          recipient,
+          balance: 1n,
+          changeType: 2 as any,
+        }),
+      ).toThrow('Invalid changeType: must be either Increase or Decrease');
     });
 
     it('returns Uint8Array when bytes encoding is specified', () => {

--- a/packages/delegation-core/test/caveats/erc721BalanceChange.test.ts
+++ b/packages/delegation-core/test/caveats/erc721BalanceChange.test.ts
@@ -49,6 +49,17 @@ describe('ERC721BalanceChange', () => {
       ).toThrow('Invalid balance: must be a positive number');
     });
 
+    it('throws for invalid changeType', () => {
+      expect(() =>
+        createERC721BalanceChangeTerms({
+          tokenAddress,
+          recipient,
+          amount: 1n,
+          changeType: 2 as any,
+        }),
+      ).toThrow('Invalid changeType: must be either Increase or Decrease');
+    });
+
     it('returns Uint8Array when bytes encoding is specified', () => {
       const result = createERC721BalanceChangeTerms(
         {

--- a/packages/delegation-core/test/caveats/erc721BalanceChange.test.ts
+++ b/packages/delegation-core/test/caveats/erc721BalanceChange.test.ts
@@ -55,7 +55,7 @@ describe('ERC721BalanceChange', () => {
           tokenAddress,
           recipient,
           amount: 1n,
-          changeType: 2 as any,
+          changeType: 2 as BalanceChangeType,
         }),
       ).toThrow('Invalid changeType: must be either Increase or Decrease');
     });

--- a/packages/delegation-core/test/caveats/nativeBalanceChange.test.ts
+++ b/packages/delegation-core/test/caveats/nativeBalanceChange.test.ts
@@ -49,7 +49,7 @@ describe('NativeBalanceChange', () => {
         createNativeBalanceChangeTerms({
           recipient,
           balance: 1n,
-          changeType: 2 as any,
+          changeType: 2 as BalanceChangeType,
         }),
       ).toThrow('Invalid changeType: must be either Increase or Decrease');
     });

--- a/packages/smart-accounts-kit/src/caveatBuilder/erc1155BalanceChangeBuilder.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/erc1155BalanceChangeBuilder.ts
@@ -1,8 +1,10 @@
-import { createERC1155BalanceChangeTerms } from '@metamask/delegation-core';
+import {
+  createERC1155BalanceChangeTerms,
+  BalanceChangeType,
+} from '@metamask/delegation-core';
 import { type Address, isAddress } from 'viem';
 
 import type { SmartAccountsEnvironment, Caveat } from '../types';
-import { BalanceChangeType } from './types';
 
 export const erc1155BalanceChange = 'erc1155BalanceChange';
 

--- a/packages/smart-accounts-kit/src/caveatBuilder/erc20BalanceChangeBuilder.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/erc20BalanceChangeBuilder.ts
@@ -1,8 +1,10 @@
-import { createERC20BalanceChangeTerms } from '@metamask/delegation-core';
+import {
+  createERC20BalanceChangeTerms,
+  BalanceChangeType,
+} from '@metamask/delegation-core';
 import { type Address, isAddress } from 'viem';
 
 import type { SmartAccountsEnvironment, Caveat } from '../types';
-import { BalanceChangeType } from './types';
 
 export const erc20BalanceChange = 'erc20BalanceChange';
 

--- a/packages/smart-accounts-kit/src/caveatBuilder/erc721BalanceChangeBuilder.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/erc721BalanceChangeBuilder.ts
@@ -1,8 +1,10 @@
-import { createERC721BalanceChangeTerms } from '@metamask/delegation-core';
+import {
+  createERC721BalanceChangeTerms,
+  BalanceChangeType,
+} from '@metamask/delegation-core';
 import { type Address, isAddress } from 'viem';
 
 import type { SmartAccountsEnvironment, Caveat } from '../types';
-import { BalanceChangeType } from './types';
 
 export const erc721BalanceChange = 'erc721BalanceChange';
 

--- a/packages/smart-accounts-kit/src/caveatBuilder/nativeBalanceChangeBuilder.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/nativeBalanceChangeBuilder.ts
@@ -1,8 +1,10 @@
-import { createNativeBalanceChangeTerms } from '@metamask/delegation-core';
+import {
+  createNativeBalanceChangeTerms,
+  BalanceChangeType,
+} from '@metamask/delegation-core';
 import { type Address, isAddress } from 'viem';
 
 import type { SmartAccountsEnvironment, Caveat } from '../types';
-import { BalanceChangeType } from './types';
 
 export const nativeBalanceChange = 'nativeBalanceChange';
 

--- a/packages/smart-accounts-kit/src/caveatBuilder/types.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/types.ts
@@ -1,10 +1,5 @@
 import type { SmartAccountsEnvironment } from '../types';
 
-export enum BalanceChangeType {
-  Increase = 0x0,
-  Decrease = 0x1,
-}
-
 export type UnitOfAuthorityBaseConfig = {
   environment: SmartAccountsEnvironment;
 };

--- a/packages/smart-accounts-kit/src/index.ts
+++ b/packages/smart-accounts-kit/src/index.ts
@@ -52,7 +52,7 @@ export type { Caveats } from './caveatBuilder';
 
 export { createCaveat } from './caveats';
 
-export { BalanceChangeType } from './caveatBuilder/types';
+export { BalanceChangeType } from '@metamask/delegation-core';
 
 export { aggregateSignature } from './signatures';
 

--- a/packages/smart-accounts-kit/test/caveatBuilder/createCaveatBuilder.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/createCaveatBuilder.test.ts
@@ -1,9 +1,9 @@
+import { BalanceChangeType } from '@metamask/delegation-core';
 import { concat, encodePacked, isAddress, pad, toHex } from 'viem';
 import type { Address } from 'viem/accounts';
 import { expect, describe, it } from 'vitest';
 
 import { createCaveatBuilder, CaveatBuilder } from '../../src/caveatBuilder';
-import { BalanceChangeType } from '../../src/caveatBuilder/types';
 import { CaveatType } from '../../src/constants';
 import type { SmartAccountsEnvironment } from '../../src/types';
 import { randomAddress, randomBytes } from '../utils';

--- a/packages/smart-accounts-kit/test/caveatBuilder/erc1155BalanceChangeBuilder.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/erc1155BalanceChangeBuilder.test.ts
@@ -1,8 +1,8 @@
+import { BalanceChangeType } from '@metamask/delegation-core';
 import { encodePacked, size, type Address } from 'viem';
 import { expect, describe, it } from 'vitest';
 
 import { erc1155BalanceChangeBuilder } from '../../src/caveatBuilder/erc1155BalanceChangeBuilder';
-import { BalanceChangeType } from '../../src/caveatBuilder/types';
 import type { SmartAccountsEnvironment } from '../../src/types';
 import { randomAddress } from '../utils';
 

--- a/packages/smart-accounts-kit/test/caveatBuilder/erc20BalanceChangeBuilder.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/erc20BalanceChangeBuilder.test.ts
@@ -1,8 +1,8 @@
+import { BalanceChangeType } from '@metamask/delegation-core';
 import { encodePacked, size, type Address } from 'viem';
 import { expect, describe, it } from 'vitest';
 
 import { erc20BalanceChangeBuilder } from '../../src/caveatBuilder/erc20BalanceChangeBuilder';
-import { BalanceChangeType } from '../../src/caveatBuilder/types';
 import type { SmartAccountsEnvironment } from '../../src/types';
 import { randomAddress } from '../utils';
 

--- a/packages/smart-accounts-kit/test/caveatBuilder/erc721BalanceChangeBuilder.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/erc721BalanceChangeBuilder.test.ts
@@ -1,9 +1,9 @@
+import { BalanceChangeType } from '@metamask/delegation-core';
 import { encodePacked } from 'viem';
 import type { Address } from 'viem';
 import { expect, describe, it } from 'vitest';
 
 import { erc721BalanceChangeBuilder } from '../../src/caveatBuilder/erc721BalanceChangeBuilder';
-import { BalanceChangeType } from '../../src/caveatBuilder/types';
 import type { SmartAccountsEnvironment } from '../../src/types';
 import { randomAddress } from '../utils';
 

--- a/packages/smart-accounts-kit/test/caveatBuilder/nativeBalanceChangeBuilder.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/nativeBalanceChangeBuilder.test.ts
@@ -1,8 +1,8 @@
+import { BalanceChangeType } from '@metamask/delegation-core';
 import { encodePacked, size, type Address } from 'viem';
 import { expect, describe, it } from 'vitest';
 
 import { nativeBalanceChangeBuilder } from '../../src/caveatBuilder/nativeBalanceChangeBuilder';
-import { BalanceChangeType } from '../../src/caveatBuilder/types';
 import type { SmartAccountsEnvironment } from '../../src/types';
 import { randomAddress } from '../utils';
 


### PR DESCRIPTION
## 📝 Description

Encoding terms for balance change type enforcers previously required a `changeType: number` parameter. Now these terms builders require a `changeType: BalanceChangeType` parameter.

## 🔄 What Changed?

List the specific changes made:
- Export `BalanceChangeType` type from @metamask/delegation-core
- The following terms encoders now require `changeType` to be passed as `BalanceChangeType` instead of `number`
  - `erc1155BalanceChange`
  - `erc20BalanceChange`
  - `erc721BalanceChange`
  - `nativeBalanceChange`


## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API types for balance-change caveat term builders change from `number` to `BalanceChangeType`, which is potentially breaking for downstream callers. Encoding logic is largely unchanged, but callers and tests must update imports/usages accordingly.
> 
> **Overview**
> **Tightens the public API for balance-change caveat term encoding** by requiring `changeType: BalanceChangeType` (instead of `number`) in the `create*BalanceChangeTerms` helpers for ERC-20/721/1155 and native balance change caveats.
> 
> `BalanceChangeType` is now re-exported from `@metamask/delegation-core`, and `smart-accounts-kit` removes its local `BalanceChangeType` enum and switches builders/tests to import the shared enum. Tests are updated to use the enum values and add explicit coverage for rejecting invalid `changeType` inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437148e09184f9d6ad954488a3db9b820df114f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->