### PR TITLE
feat: add support for redelegating from permission contexts

### DIFF
--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add utils and wallet actions for redelegating a `permissionContext`: ([#217](https://github.com/metamask/smart-accounts-kit/pull/217))
+
 ## [1.4.0]
 
 ### Added

--- a/packages/smart-accounts-kit/src/actions/index.ts
+++ b/packages/smart-accounts-kit/src/actions/index.ts
@@ -50,6 +50,14 @@ export {
   type SignUserOperationReturnType,
 } from './signUserOperation';
 
+// Redelegation actions
+export {
+  redelegatePermissionContext,
+  redelegatePermissionContextActions,
+  type RedelegatePermissionContextParameters,
+  type RedelegatePermissionContextReturnType,
+} from './redelegatePermissionContext';
+
 export {
   erc7715RequestExecutionPermissionsAction as requestExecutionPermissions,
   type MetaMaskExtensionClient,

--- a/packages/smart-accounts-kit/src/actions/index.ts
+++ b/packages/smart-accounts-kit/src/actions/index.ts
@@ -53,8 +53,10 @@ export {
 // Redelegation actions
 export {
   redelegatePermissionContext,
+  redelegatePermissionContextOpen,
   redelegatePermissionContextActions,
   type RedelegatePermissionContextParameters,
+  type RedelegatePermissionContextOpenParameters,
   type RedelegatePermissionContextReturnType,
 } from './redelegatePermissionContext';
 

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -1,0 +1,265 @@
+import type {
+  Account,
+  Address,
+  Chain,
+  Client,
+  Hex,
+  Transport,
+  WalletClient,
+} from 'viem';
+import { BaseError } from 'viem';
+import { parseAccount } from 'viem/accounts';
+
+import { trackSmartAccountsKitFunctionCall } from '../analytics';
+import {
+  createDelegation,
+  createOpenDelegation,
+  decodeDelegations,
+  encodeDelegations,
+  type CreateDelegationOptions,
+  type CreateOpenDelegationOptions,
+} from '../delegation';
+import type {
+  Delegation,
+  PermissionContext,
+  SmartAccountsEnvironment,
+} from '../types';
+import type { Caveats } from '../caveatBuilder';
+import type { ScopeConfig } from '../caveatBuilder/scope';
+import { signDelegation } from './signDelegation';
+
+export type RedelegatePermissionContextParameters = {
+  /** Account to sign the delegation with */
+  account?: Account | Address;
+  /** Environment configuration */
+  environment: SmartAccountsEnvironment;
+  /** The permission context to redelegate from (from ERC-7715 response) */
+  permissionContext: PermissionContext;
+  /** The address of the delegation manager contract */
+  delegationManager: Address;
+  /** The chain ID for the signature */
+  chainId: number;
+  /** Optional scope - if not provided, inherits from parent */
+  scope?: ScopeConfig;
+  /** Additional caveats to apply to the redelegation */
+  caveats?: Caveats;
+  /** Optional salt for uniqueness */
+  salt?: Hex;
+  /** Name of the DelegationManager contract */
+  name?: string;
+  /** Version of the DelegationManager contract */
+  version?: string;
+  /** Whether to allow insecure unrestricted delegation */
+  allowInsecureUnrestrictedDelegation?: boolean;
+} & (
+  | { delegate: Address } // Specific delegate
+  | { delegate?: never } // Open delegation
+);
+
+export type RedelegatePermissionContextReturnType = {
+  /** The signed delegation that was created */
+  delegation: Delegation;
+  /** The new permission context with the redelegation prepended (encoded) */
+  permissionContext: Hex;
+};
+
+/**
+ * Creates a redelegation from an existing permission context and returns
+ * both the signed delegation and the updated permission context.
+ *
+ * This action handles the complete redelegation workflow:
+ * 1. Extracts the leaf delegation from the permission context
+ * 2. Creates a new delegation inheriting from it
+ * 3. Signs the new delegation
+ * 4. Prepends it to the delegation chain
+ * 5. Returns the encoded permission context
+ *
+ * @param client - Wallet client with signing capability
+ * @param parameters - Redelegation parameters
+ * @returns Object containing the signed delegation and new permission context
+ *
+ * @example
+ * ```ts
+ * // Redelegate to a specific address
+ * const result = await redelegatePermissionContext(walletClient, {
+ *   permissionContext: erc7715Response.context,
+ *   delegationManager: environment.DelegationManager,
+ *   chainId: 11155111,
+ *   environment,
+ *   delegate: charlie.address,
+ *   caveats: [timestampCaveat],
+ * });
+ *
+ * // Use the new permission context in a transaction
+ * await client.sendUserOperationWithDelegation({
+ *   calls: [{
+ *     to: contractAddress,
+ *     data: callData,
+ *     permissionContext: result.permissionContext,
+ *     delegationManager: environment.DelegationManager,
+ *   }],
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Create an open redelegation (anyone can use it)
+ * const result = await redelegatePermissionContext(walletClient, {
+ *   permissionContext: erc7715Response.context,
+ *   delegationManager: environment.DelegationManager,
+ *   chainId: 11155111,
+ *   environment,
+ *   // No delegate = open delegation
+ *   caveats: [limitedCallsCaveat],
+ * });
+ * ```
+ */
+export async function redelegatePermissionContext<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
+  client: Client<Transport, TChain, TAccount> & {
+    signTypedData: WalletClient['signTypedData'];
+  },
+  parameters: RedelegatePermissionContextParameters,
+): Promise<RedelegatePermissionContextReturnType> {
+  const {
+    account: accountParam = client.account,
+    environment,
+    permissionContext,
+    delegationManager,
+    chainId,
+    scope,
+    caveats,
+    salt,
+    name = 'DelegationManager',
+    version = '1',
+    allowInsecureUnrestrictedDelegation = false,
+  } = parameters;
+
+  if (!accountParam) {
+    throw new BaseError('Account not found. Please provide an account.');
+  }
+
+  const account = parseAccount(accountParam);
+
+  trackSmartAccountsKitFunctionCall('redelegatePermissionContext', {
+    chainId,
+    hasDelegate: 'delegate' in parameters && parameters.delegate !== undefined,
+    hasScope: scope !== undefined,
+    hasCaveats: caveats !== undefined,
+  });
+
+  // Decode the permission context to get the delegation chain
+  const delegations = decodeDelegations(permissionContext);
+
+  if (delegations.length === 0) {
+    throw new BaseError(
+      'Permission context must contain at least one delegation',
+    );
+  }
+
+  // The leaf delegation is the first element (chain ordered leaf to root)
+  const leafDelegation = delegations[0];
+
+  // Create the unsigned delegation
+  // We always pass parentDelegation as the leaf delegation
+  // TypeScript struggles with the discriminated union, so we build the object explicitly
+  let unsignedDelegation: Omit<Delegation, 'signature'>;
+
+  const commonOptions = {
+    environment,
+    from: account.address,
+    parentDelegation: leafDelegation as Delegation | Hex,
+    ...(scope !== undefined && { scope }),
+    ...(caveats !== undefined && { caveats }),
+    ...(salt !== undefined && { salt }),
+  };
+
+  if ('delegate' in parameters && parameters.delegate) {
+    unsignedDelegation = createDelegation({
+      ...commonOptions,
+      to: parameters.delegate,
+    } as CreateDelegationOptions);
+  } else {
+    unsignedDelegation = createOpenDelegation(
+      commonOptions as CreateOpenDelegationOptions,
+    );
+  }
+
+  // Sign the delegation
+  const signature = await signDelegation(client, {
+    account: accountParam,
+    delegation: unsignedDelegation,
+    delegationManager,
+    chainId,
+    name,
+    version,
+    allowInsecureUnrestrictedDelegation,
+  });
+
+  // Create the signed delegation
+  const signedDelegation: Delegation = {
+    ...unsignedDelegation,
+    signature,
+  };
+
+  // Prepend the new delegation to create the new chain
+  const newDelegationChain = [signedDelegation, ...delegations];
+
+  // Return both the delegation and the encoded permission context
+  return {
+    delegation: signedDelegation,
+    permissionContext: encodeDelegations(newDelegationChain),
+  };
+}
+
+/**
+ * Creates redelegation actions that can be used to extend a wallet client.
+ *
+ * @returns A function that can be used with wallet client extend method.
+ * @example
+ * ```ts
+ * const walletClient = createWalletClient({
+ *   chain: sepolia,
+ *   transport: http()
+ * }).extend(redelegatePermissionContextActions());
+ *
+ * // Now you can call it directly on the client
+ * const result = await walletClient.redelegatePermissionContext({
+ *   permissionContext: erc7715Response.context,
+ *   delegate: charlie.address,
+ *   environment,
+ *   delegationManager: environment.DelegationManager,
+ * });
+ * ```
+ */
+export function redelegatePermissionContextActions() {
+  return <
+    TChain extends Chain | undefined,
+    TAccount extends Account | undefined,
+  >(
+    client: Client<Transport, TChain, TAccount> & {
+      signTypedData: WalletClient['signTypedData'];
+    },
+  ) => ({
+    redelegatePermissionContext: async (
+      parameters: Omit<RedelegatePermissionContextParameters, 'chainId'> & {
+        chainId?: number;
+      },
+    ) =>
+      redelegatePermissionContext(client, {
+        chainId:
+          parameters.chainId ??
+          (() => {
+            if (!client.chain?.id) {
+              throw new BaseError(
+                'Chain ID is required. Either provide it in parameters or configure the client with a chain.',
+              );
+            }
+            return client.chain.id;
+          })(),
+        ...parameters,
+      }),
+  });
+}

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -11,6 +11,8 @@ import { BaseError } from 'viem';
 import { parseAccount } from 'viem/accounts';
 
 import { trackSmartAccountsKitFunctionCall } from '../analytics';
+import type { Caveats } from '../caveatBuilder';
+import type { ScopeConfig } from '../caveatBuilder/scope';
 import {
   createDelegation,
   createOpenDelegation,
@@ -24,8 +26,6 @@ import type {
   PermissionContext,
   SmartAccountsEnvironment,
 } from '../types';
-import type { Caveats } from '../caveatBuilder';
-import type { ScopeConfig } from '../caveatBuilder/scope';
 import { signDelegation } from './signDelegation';
 
 export type RedelegatePermissionContextParameters = {

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -18,6 +18,7 @@ import {
   createOpenDelegation,
   decodeDelegations,
   encodeDelegations,
+  ROOT_AUTHORITY,
 } from '../delegation';
 import type {
   Delegation,
@@ -99,7 +100,7 @@ async function signAndPrependRedelegation(
     delegationManager: environment.DelegationManager,
     chainId,
     // Redelegations always inherit from a parent delegation (enforced by
-    // `resolveRedelegationInputs`), so the parent's caveats provide the
+    // `resolveRedelegationArgs`), so the parent's caveats provide the
     // restriction even when the redelegation itself adds no extra caveats.
     // This mirrors `resolveCaveats`, which also allows empty caveats in this
     // case.
@@ -129,7 +130,7 @@ async function signAndPrependRedelegation(
  * @param parameters - The base redelegation parameters.
  * @returns The resolved account, decoded chain and parent (leaf) delegation.
  */
-function resolveRedelegationInputs<
+function resolveRedelegationArgs<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
 >(
@@ -139,6 +140,7 @@ function resolveRedelegationInputs<
   account: Account;
   delegations: Delegation[];
   parentDelegation: Delegation;
+  from: Hex;
 } {
   const { account: accountParam = client.account, permissionContext } =
     parameters;
@@ -157,7 +159,14 @@ function resolveRedelegationInputs<
     );
   }
 
-  return { account, delegations, parentDelegation };
+  const isParentOpenDelegation =
+    parentDelegation.authority.toLowerCase() === ROOT_AUTHORITY.toLowerCase();
+
+  const from = isParentOpenDelegation
+    ? account.address
+    : parentDelegation.delegate;
+
+  return { account, delegations, parentDelegation, from };
 }
 
 /**
@@ -208,10 +217,8 @@ export async function redelegatePermissionContext<
 ): Promise<RedelegatePermissionContextReturnType> {
   const { environment, chainId, scope, caveats, salt, to } = parameters;
 
-  const { account, delegations, parentDelegation } = resolveRedelegationInputs(
-    client,
-    parameters,
-  );
+  const { account, delegations, parentDelegation, from } =
+    resolveRedelegationArgs(client, parameters);
 
   trackSmartAccountsKitFunctionCall('redelegatePermissionContext', {
     chainId,
@@ -221,7 +228,7 @@ export async function redelegatePermissionContext<
 
   const unsignedDelegation = createDelegation({
     environment,
-    from: parentDelegation.delegate,
+    from,
     to,
     scope,
     caveats,
@@ -269,10 +276,8 @@ export async function redelegatePermissionContextOpen<
 ): Promise<RedelegatePermissionContextReturnType> {
   const { environment, chainId, scope, caveats, salt } = parameters;
 
-  const { account, delegations, parentDelegation } = resolveRedelegationInputs(
-    client,
-    parameters,
-  );
+  const { account, delegations, parentDelegation, from } =
+    resolveRedelegationArgs(client, parameters);
 
   trackSmartAccountsKitFunctionCall('redelegatePermissionContextOpen', {
     chainId,
@@ -282,7 +287,7 @@ export async function redelegatePermissionContextOpen<
 
   const unsignedDelegation = createOpenDelegation({
     environment,
-    from: parentDelegation.delegate,
+    from,
     scope,
     caveats,
     parentDelegation,

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -14,11 +14,11 @@ import { trackSmartAccountsKitFunctionCall } from '../analytics';
 import type { Caveats } from '../caveatBuilder';
 import type { ScopeConfig } from '../caveatBuilder/scope';
 import {
+  ANY_BENEFICIARY,
   createDelegation,
   createOpenDelegation,
   decodeDelegations,
   encodeDelegations,
-  ROOT_AUTHORITY,
 } from '../delegation';
 import type {
   Delegation,
@@ -160,7 +160,7 @@ function resolveRedelegationArgs<
   }
 
   const isParentOpenDelegation =
-    parentDelegation.authority.toLowerCase() === ROOT_AUTHORITY.toLowerCase();
+    parentDelegation.delegate.toLowerCase() === ANY_BENEFICIARY.toLowerCase();
 
   const from = isParentOpenDelegation
     ? account.address

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -26,7 +26,7 @@ import type {
 } from '../types';
 import { signDelegation } from './signDelegation';
 
-export type RedelegatePermissionContextParameters = {
+type BaseRedelegatePermissionContextParameters = {
   /** Account to sign the delegation with */
   account?: Account | Address;
   /** Environment configuration */
@@ -41,9 +41,16 @@ export type RedelegatePermissionContextParameters = {
   caveats?: Caveats;
   /** Optional salt for uniqueness */
   salt?: Hex;
-  /** The address of the delegate to redelegate to */
-  to?: Address;
 };
+
+export type RedelegatePermissionContextParameters =
+  BaseRedelegatePermissionContextParameters & {
+    /** The address of the delegate to redelegate to */
+    to: Address;
+  };
+
+export type RedelegatePermissionContextOpenParameters =
+  BaseRedelegatePermissionContextParameters;
 
 export type RedelegatePermissionContextReturnType = {
   /** The signed delegation that was created */
@@ -52,115 +59,39 @@ export type RedelegatePermissionContextReturnType = {
   permissionContext: Hex;
 };
 
-/**
- * Creates a redelegation from an existing permission context and returns
- * both the signed delegation and the updated permission context.
- *
- * This action handles the complete redelegation workflow:
- * 1. Extracts the leaf delegation from the permission context
- * 2. Creates a new delegation inheriting from it
- * 3. Signs the new delegation
- * 4. Prepends it to the delegation chain
- * 5. Returns the encoded permission context
- *
- * @param client - Wallet client with signing capability
- * @param parameters - Redelegation parameters
- * @returns Object containing the signed delegation and new permission context
- *
- * @example
- * ```ts
- * // Redelegate to a specific address
- * const result = await redelegatePermissionContext(walletClient, {
- *   permissionContext: erc7715Response.context,
- *   delegationManager: environment.DelegationManager,
- *   chainId: 11155111,
- *   environment,
- *   delegate: charlie.address,
- *   caveats: [timestampCaveat],
- * });
- *
- * // Use the new permission context in a transaction
- * await client.sendUserOperationWithDelegation({
- *   calls: [{
- *     to: contractAddress,
- *     data: callData,
- *     permissionContext: result.permissionContext,
- *     delegationManager: environment.DelegationManager,
- *   }],
- * });
- * ```
- *
- * @example
- * ```ts
- * // Create an open redelegation (anyone can use it)
- * const result = await redelegatePermissionContext(walletClient, {
- *   permissionContext: erc7715Response.context,
- *   delegationManager: environment.DelegationManager,
- *   chainId: 11155111,
- *   environment,
- *   // No delegate = open delegation
- *   caveats: [limitedCallsCaveat],
- * });
- * ```
- */
-export async function redelegatePermissionContext<
+type SigningClient<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
->(
-  client: Client<Transport, TChain, TAccount> & {
-    signTypedData: WalletClient['signTypedData'];
+> = Client<Transport, TChain, TAccount> & {
+  signTypedData: WalletClient['signTypedData'];
+};
+
+/**
+ * Shared workflow for creating, signing and prepending a redelegation to a
+ * permission context. The caller decides whether to produce a specific or open
+ * redelegation by supplying the appropriate `unsignedDelegation`.
+ *
+ * @param client - Wallet client with signing capability.
+ * @param options - Workflow options.
+ * @param options.account - Account to sign the delegation with.
+ * @param options.environment - Environment configuration.
+ * @param options.delegations - The decoded delegation chain (leaf first).
+ * @param options.unsignedDelegation - The new (unsigned) redelegation to prepend.
+ * @param options.chainId - The chain ID for the signature.
+ * @returns The signed delegation and updated, encoded permission context.
+ */
+async function signAndPrependRedelegation(
+  client: SigningClient<Chain | undefined, Account | undefined>,
+  options: {
+    account: Account;
+    environment: SmartAccountsEnvironment;
+    delegations: Delegation[];
+    unsignedDelegation: Delegation;
+    chainId: number;
   },
-  parameters: RedelegatePermissionContextParameters,
 ): Promise<RedelegatePermissionContextReturnType> {
-  const {
-    account: accountParam = client.account,
-    environment,
-    permissionContext,
-    chainId,
-    scope,
-    caveats,
-    salt,
-    to,
-  } = parameters;
-
-  if (!accountParam) {
-    throw new BaseError('Account not found. Please provide an account.');
-  }
-
-  const account = parseAccount(accountParam);
-
-  trackSmartAccountsKitFunctionCall('redelegatePermissionContext', {
-    chainId,
-    hasDelegate: Boolean(parameters.to),
-    hasScope: scope !== undefined,
-    hasCaveats: caveats !== undefined,
-  });
-
-  const delegations = decodeDelegations(permissionContext);
-
-  const parentDelegation = delegations[0];
-
-  if (!parentDelegation) {
-    throw new BaseError(
-      'Permission context must contain at least one delegation',
-    );
-  }
-
-  const createDelegationOptions = {
-    environment,
-    from: account.address,
-    scope,
-    caveats,
-    parentDelegation,
-    salt,
-  };
-
-  const unsignedDelegation = to
-    ? createDelegation({
-        ...createDelegationOptions,
-        to,
-      })
-    : createOpenDelegation(createDelegationOptions);
+  const { account, environment, delegations, unsignedDelegation, chainId } =
+    options;
 
   const signature = await signDelegation(client, {
     account,
@@ -186,21 +117,231 @@ export async function redelegatePermissionContext<
 }
 
 /**
+ * Resolves and validates shared inputs used by both redelegation actions.
+ *
+ * @param client - Wallet client with signing capability.
+ * @param parameters - The base redelegation parameters.
+ * @returns The resolved account, decoded chain and parent (leaf) delegation.
+ */
+function resolveRedelegationInputs<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
+  client: SigningClient<TChain, TAccount>,
+  parameters: BaseRedelegatePermissionContextParameters,
+): {
+  account: Account;
+  delegations: Delegation[];
+  parentDelegation: Delegation;
+} {
+  const { account: accountParam = client.account, permissionContext } =
+    parameters;
+
+  if (!accountParam) {
+    throw new BaseError('Account not found. Please provide an account.');
+  }
+
+  const account = parseAccount(accountParam);
+  const delegations = decodeDelegations(permissionContext);
+  const parentDelegation = delegations[0];
+
+  if (!parentDelegation) {
+    throw new BaseError(
+      'Permission context must contain at least one delegation',
+    );
+  }
+
+  return { account, delegations, parentDelegation };
+}
+
+/**
+ * Creates a redelegation to a specific delegate from an existing permission
+ * context and returns both the signed delegation and the updated permission
+ * context.
+ *
+ * This action handles the complete redelegation workflow:
+ * 1. Extracts the leaf delegation from the permission context
+ * 2. Creates a new delegation inheriting from it
+ * 3. Signs the new delegation
+ * 4. Prepends it to the delegation chain
+ * 5. Returns the encoded permission context
+ *
+ * Use {@link redelegatePermissionContextOpen} to create an open redelegation
+ * (delegate set to `ANY_BENEFICIARY`).
+ *
+ * @param client - Wallet client with signing capability.
+ * @param parameters - Redelegation parameters.
+ * @returns Object containing the signed delegation and new permission context.
+ *
+ * @example
+ * ```ts
+ * const result = await redelegatePermissionContext(walletClient, {
+ *   environment,
+ *   permissionContext: erc7715Response.context,
+ *   chainId: 11155111,
+ *   to: charlie.address,
+ *   caveats: [timestampCaveat],
+ * });
+ *
+ * await client.sendUserOperationWithDelegation({
+ *   calls: [{
+ *     to: contractAddress,
+ *     data: callData,
+ *     permissionContext: result.permissionContext,
+ *     delegationManager: environment.DelegationManager,
+ *   }],
+ * });
+ * ```
+ */
+export async function redelegatePermissionContext<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
+  client: SigningClient<TChain, TAccount>,
+  parameters: RedelegatePermissionContextParameters,
+): Promise<RedelegatePermissionContextReturnType> {
+  const { environment, chainId, scope, caveats, salt, to } = parameters;
+
+  const { account, delegations, parentDelegation } = resolveRedelegationInputs(
+    client,
+    parameters,
+  );
+
+  trackSmartAccountsKitFunctionCall('redelegatePermissionContext', {
+    chainId,
+    hasScope: scope !== undefined,
+    hasCaveats: caveats !== undefined,
+  });
+
+  const unsignedDelegation = createDelegation({
+    environment,
+    from: account.address,
+    to,
+    scope,
+    caveats,
+    parentDelegation,
+    salt,
+  });
+
+  return signAndPrependRedelegation(client, {
+    account,
+    environment,
+    delegations,
+    unsignedDelegation,
+    chainId,
+  });
+}
+
+/**
+ * Creates an open redelegation (delegate set to `ANY_BENEFICIARY`) from an
+ * existing permission context and returns both the signed delegation and the
+ * updated permission context.
+ *
+ * Use {@link redelegatePermissionContext} when you want to delegate to a
+ * specific address.
+ *
+ * @param client - Wallet client with signing capability.
+ * @param parameters - Open redelegation parameters.
+ * @returns Object containing the signed delegation and new permission context.
+ *
+ * @example
+ * ```ts
+ * const result = await redelegatePermissionContextOpen(walletClient, {
+ *   environment,
+ *   permissionContext: erc7715Response.context,
+ *   chainId: 11155111,
+ *   caveats: [limitedCallsCaveat],
+ * });
+ * ```
+ */
+export async function redelegatePermissionContextOpen<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
+  client: SigningClient<TChain, TAccount>,
+  parameters: RedelegatePermissionContextOpenParameters,
+): Promise<RedelegatePermissionContextReturnType> {
+  const { environment, chainId, scope, caveats, salt } = parameters;
+
+  const { account, delegations, parentDelegation } = resolveRedelegationInputs(
+    client,
+    parameters,
+  );
+
+  trackSmartAccountsKitFunctionCall('redelegatePermissionContextOpen', {
+    chainId,
+    hasScope: scope !== undefined,
+    hasCaveats: caveats !== undefined,
+  });
+
+  const unsignedDelegation = createOpenDelegation({
+    environment,
+    from: account.address,
+    scope,
+    caveats,
+    parentDelegation,
+    salt,
+  });
+
+  return signAndPrependRedelegation(client, {
+    account,
+    environment,
+    delegations,
+    unsignedDelegation,
+    chainId,
+  });
+}
+
+/**
+ * Resolves the chain id, falling back to the client's configured chain.
+ *
+ * @param client - The client to read the chain id from.
+ * @param client.chain - The client's configured chain.
+ * @param chainId - The explicit chain id, if provided.
+ * @returns The resolved chain id.
+ */
+function resolveChainId(
+  client: { chain?: { id: number } | undefined },
+  chainId: number | undefined,
+): number {
+  if (chainId !== undefined) {
+    return chainId;
+  }
+  if (!client.chain?.id) {
+    throw new BaseError(
+      'Chain ID is required. Either provide it in parameters or configure the client with a chain.',
+    );
+  }
+  return client.chain.id;
+}
+
+/**
  * Creates redelegation actions that can be used to extend a wallet client.
  *
- * @returns A function that can be used with wallet client extend method.
+ * Adds two actions:
+ * - `redelegatePermissionContext` for redelegating to a specific delegate.
+ * - `redelegatePermissionContextOpen` for creating an open redelegation.
+ *
+ * @returns A function that can be used with the wallet client `extend` method.
+ *
  * @example
  * ```ts
  * const walletClient = createWalletClient({
  *   chain: sepolia,
- *   transport: http()
+ *   transport: http(),
  * }).extend(redelegatePermissionContextActions());
  *
- * // Now you can call it directly on the client
- * const result = await walletClient.redelegatePermissionContext({
+ * // Specific redelegation
+ * const specific = await walletClient.redelegatePermissionContext({
  *   environment,
  *   permissionContext: erc7715Response.context,
  *   to: charlie.address,
+ * });
+ *
+ * // Open redelegation
+ * const open = await walletClient.redelegatePermissionContextOpen({
+ *   environment,
+ *   permissionContext: erc7715Response.context,
  * });
  * ```
  */
@@ -209,9 +350,7 @@ export function redelegatePermissionContextActions() {
     TChain extends Chain | undefined,
     TAccount extends Account | undefined,
   >(
-    client: Client<Transport, TChain, TAccount> & {
-      signTypedData: WalletClient['signTypedData'];
-    },
+    client: SigningClient<TChain, TAccount>,
   ) => ({
     redelegatePermissionContext: async (
       parameters: Omit<RedelegatePermissionContextParameters, 'chainId'> & {
@@ -219,17 +358,17 @@ export function redelegatePermissionContextActions() {
       },
     ) =>
       redelegatePermissionContext(client, {
-        chainId:
-          parameters.chainId ??
-          (() => {
-            if (!client.chain?.id) {
-              throw new BaseError(
-                'Chain ID is required. Either provide it in parameters or configure the client with a chain.',
-              );
-            }
-            return client.chain.id;
-          })(),
         ...parameters,
+        chainId: resolveChainId(client, parameters.chainId),
+      }),
+    redelegatePermissionContextOpen: async (
+      parameters: Omit<RedelegatePermissionContextOpenParameters, 'chainId'> & {
+        chainId?: number;
+      },
+    ) =>
+      redelegatePermissionContextOpen(client, {
+        ...parameters,
+        chainId: resolveChainId(client, parameters.chainId),
       }),
   });
 }

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -98,6 +98,12 @@ async function signAndPrependRedelegation(
     delegation: unsignedDelegation,
     delegationManager: environment.DelegationManager,
     chainId,
+    // Redelegations always inherit from a parent delegation (enforced by
+    // `resolveRedelegationInputs`), so the parent's caveats provide the
+    // restriction even when the redelegation itself adds no extra caveats.
+    // This mirrors `resolveCaveats`, which also allows empty caveats in this
+    // case.
+    allowInsecureUnrestrictedDelegation: true,
   });
 
   const signedDelegation: Delegation = {

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -18,8 +18,6 @@ import {
   createOpenDelegation,
   decodeDelegations,
   encodeDelegations,
-  type CreateDelegationOptions,
-  type CreateOpenDelegationOptions,
 } from '../delegation';
 import type {
   Delegation,
@@ -33,10 +31,8 @@ export type RedelegatePermissionContextParameters = {
   account?: Account | Address;
   /** Environment configuration */
   environment: SmartAccountsEnvironment;
-  /** The permission context to redelegate from (from ERC-7715 response) */
+  /** The permission context to redelegate from (i.e., from ERC-7715 response) */
   permissionContext: PermissionContext;
-  /** The address of the delegation manager contract */
-  delegationManager: Address;
   /** The chain ID for the signature */
   chainId: number;
   /** Optional scope - if not provided, inherits from parent */
@@ -45,16 +41,9 @@ export type RedelegatePermissionContextParameters = {
   caveats?: Caveats;
   /** Optional salt for uniqueness */
   salt?: Hex;
-  /** Name of the DelegationManager contract */
-  name?: string;
-  /** Version of the DelegationManager contract */
-  version?: string;
-  /** Whether to allow insecure unrestricted delegation */
-  allowInsecureUnrestrictedDelegation?: boolean;
-} & (
-  | { delegate: Address } // Specific delegate
-  | { delegate?: never } // Open delegation
-);
+  /** The address of the delegate to redelegate to */
+  to?: Address;
+};
 
 export type RedelegatePermissionContextReturnType = {
   /** The signed delegation that was created */
@@ -127,14 +116,11 @@ export async function redelegatePermissionContext<
     account: accountParam = client.account,
     environment,
     permissionContext,
-    delegationManager,
     chainId,
     scope,
     caveats,
     salt,
-    name = 'DelegationManager',
-    version = '1',
-    allowInsecureUnrestrictedDelegation = false,
+    to,
   } = parameters;
 
   if (!accountParam) {
@@ -145,72 +131,57 @@ export async function redelegatePermissionContext<
 
   trackSmartAccountsKitFunctionCall('redelegatePermissionContext', {
     chainId,
-    hasDelegate: 'delegate' in parameters && parameters.delegate !== undefined,
+    hasDelegate: Boolean(parameters.to),
     hasScope: scope !== undefined,
     hasCaveats: caveats !== undefined,
   });
 
-  // Decode the permission context to get the delegation chain
   const delegations = decodeDelegations(permissionContext);
 
-  if (delegations.length === 0) {
+  const parentDelegation = delegations[0];
+
+  if (!parentDelegation) {
     throw new BaseError(
       'Permission context must contain at least one delegation',
     );
   }
 
-  // The leaf delegation is the first element (chain ordered leaf to root)
-  const leafDelegation = delegations[0];
-
-  // Create the unsigned delegation
-  // We always pass parentDelegation as the leaf delegation
-  // TypeScript struggles with the discriminated union, so we build the object explicitly
-  let unsignedDelegation: Omit<Delegation, 'signature'>;
-
-  const commonOptions = {
+  const createDelegationOptions = {
     environment,
     from: account.address,
-    parentDelegation: leafDelegation as Delegation | Hex,
-    ...(scope !== undefined && { scope }),
-    ...(caveats !== undefined && { caveats }),
-    ...(salt !== undefined && { salt }),
+    scope,
+    caveats,
+    parentDelegation,
+    salt,
   };
 
-  if ('delegate' in parameters && parameters.delegate) {
-    unsignedDelegation = createDelegation({
-      ...commonOptions,
-      to: parameters.delegate,
-    } as CreateDelegationOptions);
-  } else {
-    unsignedDelegation = createOpenDelegation(
-      commonOptions as CreateOpenDelegationOptions,
-    );
-  }
+  const unsignedDelegation = to
+    ? createDelegation({
+        ...createDelegationOptions,
+        to,
+      })
+    : createOpenDelegation(createDelegationOptions);
 
-  // Sign the delegation
   const signature = await signDelegation(client, {
-    account: accountParam,
+    account,
     delegation: unsignedDelegation,
-    delegationManager,
+    delegationManager: environment.DelegationManager,
     chainId,
-    name,
-    version,
-    allowInsecureUnrestrictedDelegation,
   });
 
-  // Create the signed delegation
   const signedDelegation: Delegation = {
     ...unsignedDelegation,
     signature,
   };
 
-  // Prepend the new delegation to create the new chain
-  const newDelegationChain = [signedDelegation, ...delegations];
+  const newPermissionContext = encodeDelegations([
+    signedDelegation,
+    ...delegations,
+  ]);
 
-  // Return both the delegation and the encoded permission context
   return {
     delegation: signedDelegation,
-    permissionContext: encodeDelegations(newDelegationChain),
+    permissionContext: newPermissionContext,
   };
 }
 
@@ -227,10 +198,9 @@ export async function redelegatePermissionContext<
  *
  * // Now you can call it directly on the client
  * const result = await walletClient.redelegatePermissionContext({
- *   permissionContext: erc7715Response.context,
- *   delegate: charlie.address,
  *   environment,
- *   delegationManager: environment.DelegationManager,
+ *   permissionContext: erc7715Response.context,
+ *   to: charlie.address,
  * });
  * ```
  */

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -221,7 +221,7 @@ export async function redelegatePermissionContext<
 
   const unsignedDelegation = createDelegation({
     environment,
-    from: account.address,
+    from: parentDelegation.delegate,
     to,
     scope,
     caveats,
@@ -282,7 +282,7 @@ export async function redelegatePermissionContextOpen<
 
   const unsignedDelegation = createOpenDelegation({
     environment,
-    from: account.address,
+    from: parentDelegation.delegate,
     scope,
     caveats,
     parentDelegation,

--- a/packages/smart-accounts-kit/src/caveatBuilder/resolveCaveats.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/resolveCaveats.ts
@@ -1,5 +1,8 @@
 import type { CaveatBuilder } from './caveatBuilder';
-import type { CoreCaveatConfiguration } from './coreCaveatBuilder';
+import {
+  createCaveatBuilder,
+  type CoreCaveatConfiguration,
+} from './coreCaveatBuilder';
 import { createCaveatBuilderFromScope, type ScopeConfig } from './scope';
 import type { Caveat, SmartAccountsEnvironment } from '../types';
 
@@ -10,7 +13,7 @@ export type Caveats = CaveatBuilder | (Caveat | CoreCaveatConfiguration)[];
  *
  * @param config - The configuration for the caveat builder.
  * @param config.environment - The environment to be used for the caveat builder.
- * @param config.scope - The scope to be used for the caveat builder.
+ * @param config.scope - The scope to be used for the caveat builder. Optional - when not provided and redelegating, scope is inherited from the parent delegation.
  * @param config.caveats - The caveats to be resolved, which can be either a CaveatBuilder or an array of Caveat or CaveatConfiguration. Optional - if not provided, only scope caveats will be used.
  * @returns The resolved array of caveats.
  */
@@ -20,10 +23,15 @@ export const resolveCaveats = ({
   caveats,
 }: {
   environment: SmartAccountsEnvironment;
-  scope: ScopeConfig;
+  scope?: ScopeConfig;
   caveats?: Caveats;
 }) => {
-  const scopeCaveatBuilder = createCaveatBuilderFromScope(environment, scope);
+  // Create base caveat builder from scope if provided, otherwise use core caveat builder
+  const scopeCaveatBuilder = scope
+    ? createCaveatBuilderFromScope(environment, scope)
+    : createCaveatBuilder(environment, {
+        allowInsecureUnrestrictedDelegation: true,
+      });
 
   if (caveats) {
     if ('build' in caveats && typeof caveats.build === 'function') {
@@ -35,7 +43,7 @@ export const resolveCaveats = ({
         try {
           if ('type' in caveat) {
             const { type, ...config } = caveat;
-            scopeCaveatBuilder.addCaveat(type, config);
+            (scopeCaveatBuilder as any).addCaveat(type, config);
           } else {
             scopeCaveatBuilder.addCaveat(caveat);
           }

--- a/packages/smart-accounts-kit/src/caveatBuilder/resolveCaveats.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/resolveCaveats.ts
@@ -15,17 +15,24 @@ export type Caveats = CaveatBuilder | (Caveat | CoreCaveatConfiguration)[];
  * @param config.environment - The environment to be used for the caveat builder.
  * @param config.scope - The scope to be used for the caveat builder. Optional - when not provided and redelegating, scope is inherited from the parent delegation.
  * @param config.caveats - The caveats to be resolved, which can be either a CaveatBuilder or an array of Caveat or CaveatConfiguration. Optional - if not provided, only scope caveats will be used.
+ * @param config.hasInheritance - Whether the delegation has inheritance.
  * @returns The resolved array of caveats.
  */
 export const resolveCaveats = ({
   environment,
   scope,
   caveats,
+  hasInheritance,
 }: {
   environment: SmartAccountsEnvironment;
   scope?: ScopeConfig;
   caveats?: Caveats;
+  hasInheritance: boolean;
 }) => {
+  if (!scope && !hasInheritance) {
+    throw new Error('Scope is required when the delegation has no inheritance');
+  }
+
   // Create base caveat builder from scope if provided, otherwise use core caveat builder
   const scopeCaveatBuilder = scope
     ? createCaveatBuilderFromScope(environment, scope)

--- a/packages/smart-accounts-kit/src/caveatBuilder/resolveCaveats.ts
+++ b/packages/smart-accounts-kit/src/caveatBuilder/resolveCaveats.ts
@@ -15,22 +15,22 @@ export type Caveats = CaveatBuilder | (Caveat | CoreCaveatConfiguration)[];
  * @param config.environment - The environment to be used for the caveat builder.
  * @param config.scope - The scope to be used for the caveat builder. Optional - when not provided and redelegating, scope is inherited from the parent delegation.
  * @param config.caveats - The caveats to be resolved, which can be either a CaveatBuilder or an array of Caveat or CaveatConfiguration. Optional - if not provided, only scope caveats will be used.
- * @param config.hasInheritance - Whether the delegation has inheritance.
+ * @param config.isScopeOptional - Whether the scope is optional.
  * @returns The resolved array of caveats.
  */
 export const resolveCaveats = ({
   environment,
   scope,
   caveats,
-  hasInheritance,
+  isScopeOptional,
 }: {
   environment: SmartAccountsEnvironment;
   scope?: ScopeConfig;
   caveats?: Caveats;
-  hasInheritance: boolean;
+  isScopeOptional: boolean;
 }) => {
-  if (!scope && !hasInheritance) {
-    throw new Error('Scope is required when the delegation has no inheritance');
+  if (!scope && !isScopeOptional) {
+    throw new Error('Scope is required');
   }
 
   // Create base caveat builder from scope if provided, otherwise use core caveat builder

--- a/packages/smart-accounts-kit/src/delegation.ts
+++ b/packages/smart-accounts-kit/src/delegation.ts
@@ -211,12 +211,26 @@ export const hashDelegation = (input: Delegation): Hex => {
 
 type BaseCreateDelegationOptions = {
   environment: SmartAccountsEnvironment;
-  scope: ScopeConfig;
   from: Hex;
   caveats?: Caveats;
-  parentDelegation?: Delegation | Hex;
   salt?: Hex;
-};
+} & (
+  | {
+      scope: ScopeConfig;
+      parentDelegation?: never;
+      parentPermissionContext?: never;
+    }
+  | {
+      scope?: ScopeConfig;
+      parentDelegation: Delegation | Hex;
+      parentPermissionContext?: never;
+    }
+  | {
+      scope?: ScopeConfig;
+      parentDelegation?: never;
+      parentPermissionContext: PermissionContext;
+    }
+);
 
 /**
  * Options for creating a specific delegation
@@ -229,6 +243,46 @@ export type CreateDelegationOptions = BaseCreateDelegationOptions & {
  * Options for creating an open delegation
  */
 export type CreateOpenDelegationOptions = BaseCreateDelegationOptions;
+
+/**
+ * Extracts the leaf delegation from a permission context.
+ * The leaf delegation is the first element in the array (chain is ordered leaf to root).
+ *
+ * @param permissionContext - The permission context containing the delegation chain.
+ * @returns The leaf delegation.
+ * @internal
+ */
+const extractLeafDelegation = (
+  permissionContext: PermissionContext,
+): Delegation => {
+  const delegations = decodeDelegations(permissionContext);
+
+  if (delegations.length === 0) {
+    throw new Error('Permission context must contain at least one delegation');
+  }
+
+  // We've verified the array is not empty, so delegations[0] is guaranteed to exist
+  return delegations[0]!;
+};
+
+/**
+ * Resolves the parent delegation from either a direct delegation or permission context.
+ *
+ * @param parentDelegation - The parent delegation or its hash.
+ * @param parentPermissionContext - The permission context containing the parent delegation.
+ * @returns The resolved parent delegation, or undefined if neither is provided.
+ * @internal
+ */
+const resolveParentDelegation = (
+  parentDelegation?: Delegation | Hex,
+  parentPermissionContext?: PermissionContext,
+): Delegation | Hex | undefined => {
+  if (parentPermissionContext) {
+    return extractLeafDelegation(parentPermissionContext);
+  }
+
+  return parentDelegation;
+};
 
 /**
  * Resolves the authority for a delegation based on the parent delegation.
@@ -281,11 +335,25 @@ const getCaveatNames = ({
 export const createDelegation = (
   options: CreateDelegationOptions,
 ): Delegation => {
-  const caveats = resolveCaveats(options);
+  const parentDelegation = resolveParentDelegation(
+    'parentDelegation' in options ? options.parentDelegation : undefined,
+    'parentPermissionContext' in options
+      ? options.parentPermissionContext
+      : undefined,
+  );
+
+  const caveats = resolveCaveats({
+    environment: options.environment,
+    scope: options.scope,
+    caveats: options.caveats,
+  });
 
   trackSmartAccountsKitFunctionCall('createDelegation', {
-    hasParentDelegation: options.parentDelegation !== undefined,
-    scope: options.scope.type,
+    hasParentDelegation:
+      ('parentDelegation' in options && options.parentDelegation !== undefined) ||
+      ('parentPermissionContext' in options &&
+        options.parentPermissionContext !== undefined),
+    scope: options.scope?.type ?? null,
     caveatNames: getCaveatNames({
       caveats,
       environment: options.environment,
@@ -295,7 +363,7 @@ export const createDelegation = (
   return {
     delegate: options.to,
     delegator: options.from,
-    authority: resolveAuthority(options.parentDelegation),
+    authority: resolveAuthority(parentDelegation),
     caveats,
     salt: options.salt ?? '0x00',
     signature: '0x',
@@ -311,11 +379,25 @@ export const createDelegation = (
 export const createOpenDelegation = (
   options: CreateOpenDelegationOptions,
 ): Delegation => {
-  const caveats = resolveCaveats(options);
+  const parentDelegation = resolveParentDelegation(
+    'parentDelegation' in options ? options.parentDelegation : undefined,
+    'parentPermissionContext' in options
+      ? options.parentPermissionContext
+      : undefined,
+  );
+
+  const caveats = resolveCaveats({
+    environment: options.environment,
+    scope: options.scope,
+    caveats: options.caveats,
+  });
 
   trackSmartAccountsKitFunctionCall('createOpenDelegation', {
-    hasParentDelegation: options.parentDelegation !== undefined,
-    scope: options.scope.type,
+    hasParentDelegation:
+      ('parentDelegation' in options && options.parentDelegation !== undefined) ||
+      ('parentPermissionContext' in options &&
+        options.parentPermissionContext !== undefined),
+    scope: options.scope?.type ?? null,
     caveatNames: getCaveatNames({
       caveats,
       environment: options.environment,
@@ -325,7 +407,7 @@ export const createOpenDelegation = (
   return {
     delegate: ANY_BENEFICIARY,
     delegator: options.from,
-    authority: resolveAuthority(options.parentDelegation),
+    authority: resolveAuthority(parentDelegation),
     caveats,
     salt: options.salt ?? '0x00',
     signature: '0x',

--- a/packages/smart-accounts-kit/src/delegation.ts
+++ b/packages/smart-accounts-kit/src/delegation.ts
@@ -261,8 +261,12 @@ const extractLeafDelegation = (
     throw new Error('Permission context must contain at least one delegation');
   }
 
-  // We've verified the array is not empty, so delegations[0] is guaranteed to exist
-  return delegations[0]!;
+  const leafDelegation = delegations[0];
+  if (!leafDelegation) {
+    throw new Error('Failed to extract leaf delegation');
+  }
+
+  return leafDelegation;
 };
 
 /**
@@ -350,7 +354,8 @@ export const createDelegation = (
 
   trackSmartAccountsKitFunctionCall('createDelegation', {
     hasParentDelegation:
-      ('parentDelegation' in options && options.parentDelegation !== undefined) ||
+      ('parentDelegation' in options &&
+        options.parentDelegation !== undefined) ||
       ('parentPermissionContext' in options &&
         options.parentPermissionContext !== undefined),
     scope: options.scope?.type ?? null,
@@ -394,7 +399,8 @@ export const createOpenDelegation = (
 
   trackSmartAccountsKitFunctionCall('createOpenDelegation', {
     hasParentDelegation:
-      ('parentDelegation' in options && options.parentDelegation !== undefined) ||
+      ('parentDelegation' in options &&
+        options.parentDelegation !== undefined) ||
       ('parentPermissionContext' in options &&
         options.parentPermissionContext !== undefined),
     scope: options.scope?.type ?? null,

--- a/packages/smart-accounts-kit/src/delegation.ts
+++ b/packages/smart-accounts-kit/src/delegation.ts
@@ -18,6 +18,7 @@ import { type Caveats, resolveCaveats } from './caveatBuilder';
 import type { ScopeConfig } from './caveatBuilder/scope';
 import { CAVEAT_ABI_TYPE_COMPONENTS } from './caveats';
 import type {
+  Caveat,
   Delegation,
   PermissionContext,
   SmartAccountsEnvironment,
@@ -270,44 +271,6 @@ const extractLeafDelegation = (
 };
 
 /**
- * Resolves the parent delegation from either a direct delegation or permission context.
- *
- * @param options - The options for resolving the parent delegation.
- * @param options.parentDelegation - The parent delegation or its hash.
- * @param options.parentPermissionContext - The permission context containing the parent delegation.
- * @param options.scope - The scope to be used for the delegation.
- * @returns The resolved parent delegation, or undefined if neither is provided.
- * @internal
- */
-const resolveParentDelegation = ({
-  parentDelegation,
-  parentPermissionContext,
-  scope,
-}: Pick<
-  BaseCreateDelegationOptions,
-  'parentDelegation' | 'parentPermissionContext' | 'scope'
->): Delegation | Hex | undefined => {
-  if (parentPermissionContext) {
-    return extractLeafDelegation(parentPermissionContext);
-  }
-
-  if (
-    typeof parentDelegation === 'string' &&
-    parentDelegation.toLowerCase() === ROOT_AUTHORITY.toLowerCase()
-  ) {
-    throw new Error(`Invalid parent delegation - cannot be ${ROOT_AUTHORITY}`);
-  }
-
-  if (!parentDelegation && !scope) {
-    throw new Error(
-      'Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope',
-    );
-  }
-
-  return parentDelegation;
-};
-
-/**
  * Resolves the authority for a delegation based on the parent delegation.
  *
  * @param parentDelegation - The parent delegation or its hash.
@@ -350,6 +313,62 @@ const getCaveatNames = ({
 };
 
 /**
+ * Resolves the delegation arguments from the options.
+ *
+ * @param options - The options for creating the delegation.
+ * @returns The resolved delegation arguments.
+ */
+const resolveDelegationArgs = (
+  options: BaseCreateDelegationOptions,
+): {
+  authority: Hex;
+  caveats: Caveat[];
+  hasInheritance: boolean;
+  salt: Hex;
+} => {
+  const optionsHasParentPermissionContext =
+    'parentPermissionContext' in options && options.parentPermissionContext;
+
+  const resolvedParentDelegation = optionsHasParentPermissionContext
+    ? extractLeafDelegation(options.parentPermissionContext)
+    : options.parentDelegation;
+
+  const authority = (() => {
+    if (!resolvedParentDelegation) {
+      if (!options.scope) {
+        throw new Error('Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope');
+      }
+      return ROOT_AUTHORITY;
+    }
+
+    if (typeof resolvedParentDelegation === 'string') {
+      if (resolvedParentDelegation.toLowerCase() === ROOT_AUTHORITY.toLowerCase()) {
+        throw new Error(`Invalid parent delegation - cannot be ${ROOT_AUTHORITY}`);
+      }
+      return resolvedParentDelegation;
+    }
+
+    return hashDelegation(resolvedParentDelegation);
+  })();
+
+  const hasInheritance = resolvedParentDelegation !== undefined;
+
+  const caveats = resolveCaveats({
+    environment: options.environment,
+    scope: options.scope,
+    caveats: options.caveats,
+    isScopeOptional: hasInheritance,
+  });
+
+  return {
+    authority,
+    caveats,
+    hasInheritance,
+    salt: options.salt ?? '0x00',
+  };
+};
+
+/**
  * Creates a delegation with specific delegate.
  *
  * @param options - The options for creating the delegation.
@@ -358,16 +377,8 @@ const getCaveatNames = ({
 export const createDelegation = (
   options: CreateDelegationOptions,
 ): Delegation => {
-  const parentDelegation = resolveParentDelegation(options);
-
-  const hasInheritance = parentDelegation !== undefined;
-
-  const caveats = resolveCaveats({
-    environment: options.environment,
-    scope: options.scope,
-    caveats: options.caveats,
-    isScopeOptional: hasInheritance,
-  });
+  const { authority, caveats, hasInheritance, salt } =
+    resolveDelegationArgs(options);
 
   trackSmartAccountsKitFunctionCall('createDelegation', {
     hasInheritance,
@@ -381,9 +392,9 @@ export const createDelegation = (
   return {
     delegate: options.to,
     delegator: options.from,
-    authority: resolveAuthority(parentDelegation),
+    authority,
     caveats,
-    salt: options.salt ?? '0x00',
+    salt,
     signature: '0x',
   };
 };
@@ -397,16 +408,8 @@ export const createDelegation = (
 export const createOpenDelegation = (
   options: CreateOpenDelegationOptions,
 ): Delegation => {
-  const parentDelegation = resolveParentDelegation(options);
-
-  const hasInheritance = parentDelegation !== undefined;
-
-  const caveats = resolveCaveats({
-    environment: options.environment,
-    scope: options.scope,
-    caveats: options.caveats,
-    isScopeOptional: hasInheritance,
-  });
+  const { authority, caveats, hasInheritance, salt } =
+    resolveDelegationArgs(options);
 
   trackSmartAccountsKitFunctionCall('createOpenDelegation', {
     hasInheritance,
@@ -420,9 +423,9 @@ export const createOpenDelegation = (
   return {
     delegate: ANY_BENEFICIARY,
     delegator: options.from,
-    authority: resolveAuthority(parentDelegation),
+    authority,
     caveats,
-    salt: options.salt ?? '0x00',
+    salt,
     signature: '0x',
   };
 };

--- a/packages/smart-accounts-kit/src/delegation.ts
+++ b/packages/smart-accounts-kit/src/delegation.ts
@@ -272,15 +272,19 @@ const extractLeafDelegation = (
 /**
  * Resolves the parent delegation from either a direct delegation or permission context.
  *
- * @param parentDelegation - The parent delegation or its hash.
- * @param parentPermissionContext - The permission context containing the parent delegation.
+ * @param options - The options for resolving the parent delegation.
+ * @param options.parentDelegation - The parent delegation or its hash.
+ * @param options.parentPermissionContext - The permission context containing the parent delegation.
  * @returns The resolved parent delegation, or undefined if neither is provided.
  * @internal
  */
-const resolveParentDelegation = (
-  parentDelegation?: Delegation | Hex,
-  parentPermissionContext?: PermissionContext,
-): Delegation | Hex | undefined => {
+const resolveParentDelegation = ({
+  parentDelegation,
+  parentPermissionContext,
+}: Pick<
+  BaseCreateDelegationOptions,
+  'parentDelegation' | 'parentPermissionContext'
+>): Delegation | Hex | undefined => {
   if (parentPermissionContext) {
     return extractLeafDelegation(parentPermissionContext);
   }
@@ -339,12 +343,7 @@ const getCaveatNames = ({
 export const createDelegation = (
   options: CreateDelegationOptions,
 ): Delegation => {
-  const parentDelegation = resolveParentDelegation(
-    'parentDelegation' in options ? options.parentDelegation : undefined,
-    'parentPermissionContext' in options
-      ? options.parentPermissionContext
-      : undefined,
-  );
+  const parentDelegation = resolveParentDelegation(options);
 
   const caveats = resolveCaveats({
     environment: options.environment,
@@ -354,10 +353,8 @@ export const createDelegation = (
 
   trackSmartAccountsKitFunctionCall('createDelegation', {
     hasParentDelegation:
-      ('parentDelegation' in options &&
-        options.parentDelegation !== undefined) ||
-      ('parentPermissionContext' in options &&
-        options.parentPermissionContext !== undefined),
+      options.parentDelegation !== undefined ||
+      options.parentPermissionContext !== undefined,
     scope: options.scope?.type ?? null,
     caveatNames: getCaveatNames({
       caveats,
@@ -384,12 +381,7 @@ export const createDelegation = (
 export const createOpenDelegation = (
   options: CreateOpenDelegationOptions,
 ): Delegation => {
-  const parentDelegation = resolveParentDelegation(
-    'parentDelegation' in options ? options.parentDelegation : undefined,
-    'parentPermissionContext' in options
-      ? options.parentPermissionContext
-      : undefined,
-  );
+  const parentDelegation = resolveParentDelegation(options);
 
   const caveats = resolveCaveats({
     environment: options.environment,
@@ -399,10 +391,8 @@ export const createOpenDelegation = (
 
   trackSmartAccountsKitFunctionCall('createOpenDelegation', {
     hasParentDelegation:
-      ('parentDelegation' in options &&
-        options.parentDelegation !== undefined) ||
-      ('parentPermissionContext' in options &&
-        options.parentPermissionContext !== undefined),
+      options.parentDelegation !== undefined ||
+      options.parentPermissionContext !== undefined,
     scope: options.scope?.type ?? null,
     caveatNames: getCaveatNames({
       caveats,

--- a/packages/smart-accounts-kit/src/delegation.ts
+++ b/packages/smart-accounts-kit/src/delegation.ts
@@ -349,6 +349,7 @@ export const createDelegation = (
     environment: options.environment,
     scope: options.scope,
     caveats: options.caveats,
+    hasInheritance: Boolean(parentDelegation),
   });
 
   trackSmartAccountsKitFunctionCall('createDelegation', {
@@ -387,6 +388,7 @@ export const createOpenDelegation = (
     environment: options.environment,
     scope: options.scope,
     caveats: options.caveats,
+    hasInheritance: Boolean(parentDelegation),
   });
 
   trackSmartAccountsKitFunctionCall('createOpenDelegation', {

--- a/packages/smart-accounts-kit/src/delegation.ts
+++ b/packages/smart-accounts-kit/src/delegation.ts
@@ -336,14 +336,20 @@ const resolveDelegationArgs = (
   const authority = (() => {
     if (!resolvedParentDelegation) {
       if (!options.scope) {
-        throw new Error('Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope');
+        throw new Error(
+          'Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope',
+        );
       }
       return ROOT_AUTHORITY;
     }
 
     if (typeof resolvedParentDelegation === 'string') {
-      if (resolvedParentDelegation.toLowerCase() === ROOT_AUTHORITY.toLowerCase()) {
-        throw new Error(`Invalid parent delegation - cannot be ${ROOT_AUTHORITY}`);
+      if (
+        resolvedParentDelegation.toLowerCase() === ROOT_AUTHORITY.toLowerCase()
+      ) {
+        throw new Error(
+          `Invalid parent delegation - cannot be ${ROOT_AUTHORITY}`,
+        );
       }
       return resolvedParentDelegation;
     }

--- a/packages/smart-accounts-kit/src/delegation.ts
+++ b/packages/smart-accounts-kit/src/delegation.ts
@@ -275,18 +275,33 @@ const extractLeafDelegation = (
  * @param options - The options for resolving the parent delegation.
  * @param options.parentDelegation - The parent delegation or its hash.
  * @param options.parentPermissionContext - The permission context containing the parent delegation.
+ * @param options.scope - The scope to be used for the delegation.
  * @returns The resolved parent delegation, or undefined if neither is provided.
  * @internal
  */
 const resolveParentDelegation = ({
   parentDelegation,
   parentPermissionContext,
+  scope,
 }: Pick<
   BaseCreateDelegationOptions,
-  'parentDelegation' | 'parentPermissionContext'
+  'parentDelegation' | 'parentPermissionContext' | 'scope'
 >): Delegation | Hex | undefined => {
   if (parentPermissionContext) {
     return extractLeafDelegation(parentPermissionContext);
+  }
+
+  if (
+    typeof parentDelegation === 'string' &&
+    parentDelegation.toLowerCase() === ROOT_AUTHORITY.toLowerCase()
+  ) {
+    throw new Error(`Invalid parent delegation - cannot be ${ROOT_AUTHORITY}`);
+  }
+
+  if (!parentDelegation && !scope) {
+    throw new Error(
+      'Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope',
+    );
   }
 
   return parentDelegation;
@@ -345,17 +360,17 @@ export const createDelegation = (
 ): Delegation => {
   const parentDelegation = resolveParentDelegation(options);
 
+  const hasInheritance = parentDelegation !== undefined;
+
   const caveats = resolveCaveats({
     environment: options.environment,
     scope: options.scope,
     caveats: options.caveats,
-    hasInheritance: Boolean(parentDelegation),
+    isScopeOptional: hasInheritance,
   });
 
   trackSmartAccountsKitFunctionCall('createDelegation', {
-    hasParentDelegation:
-      options.parentDelegation !== undefined ||
-      options.parentPermissionContext !== undefined,
+    hasInheritance,
     scope: options.scope?.type ?? null,
     caveatNames: getCaveatNames({
       caveats,
@@ -384,17 +399,17 @@ export const createOpenDelegation = (
 ): Delegation => {
   const parentDelegation = resolveParentDelegation(options);
 
+  const hasInheritance = parentDelegation !== undefined;
+
   const caveats = resolveCaveats({
     environment: options.environment,
     scope: options.scope,
     caveats: options.caveats,
-    hasInheritance: Boolean(parentDelegation),
+    isScopeOptional: hasInheritance,
   });
 
   trackSmartAccountsKitFunctionCall('createOpenDelegation', {
-    hasParentDelegation:
-      options.parentDelegation !== undefined ||
-      options.parentPermissionContext !== undefined,
+    hasInheritance,
     scope: options.scope?.type ?? null,
     caveatNames: getCaveatNames({
       caveats,

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -1,0 +1,382 @@
+import { createWalletClient, http, type Address, type Hex } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { sepolia } from 'viem/chains';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  redelegatePermissionContext,
+  redelegatePermissionContextActions,
+} from '../../src/actions/redelegatePermissionContext';
+import { createDelegation, encodeDelegations } from '../../src/delegation';
+import { ScopeType } from '../../src/constants';
+import type { SmartAccountsEnvironment } from '../../src/types';
+
+const mockPrivateKey =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as Hex;
+const account = privateKeyToAccount(mockPrivateKey);
+
+const mockEnvironment: SmartAccountsEnvironment = {
+  DelegationManager: '0x1234567890123456789012345678901234567890',
+  EntryPoint: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
+  SimpleFactory: '0x9876543210987654321098765432109876543210',
+  implementations: {},
+  caveatEnforcers: {
+    ValueLteEnforcer: '0x1111111111111111111111111111111111111111',
+    ERC20TransferAmountEnforcer: '0x2222222222222222222222222222222222222222',
+    AllowedTargets: '0x3333333333333333333333333333333333333333',
+    AllowedMethods: '0x4444444444444444444444444444444444444444',
+    TimestampEnforcer: '0x5555555555555555555555555555555555555555',
+    ExactCalldataEnforcer: '0x6666666666666666666666666666666666666666',
+    NativeTokenTransferAmountEnforcer:
+      '0x7777777777777777777777777777777777777777',
+  },
+};
+
+const mockDelegationManager: Address =
+  '0x1234567890123456789012345678901234567890';
+const mockChainId = sepolia.id;
+
+describe('redelegatePermissionContext', () => {
+  let client: ReturnType<typeof createWalletClient>;
+
+  beforeEach(() => {
+    client = createWalletClient({
+      account,
+      chain: sepolia,
+      transport: http('https://rpc.sepolia.org'),
+    });
+  });
+
+  it('should create a redelegation with a specific delegate', async () => {
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 1000n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const timestampCaveat = {
+      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
+      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      args: '0x00' as Hex,
+    };
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      delegationManager: mockDelegationManager,
+      chainId: mockChainId,
+      delegate: newDelegate,
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.delegate).to.equal(newDelegate);
+    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
+    expect(result.permissionContext).to.match(/^0x[a-fA-F0-9]+$/u);
+
+    // Verify the permission context is valid and longer than the original
+    expect(result.permissionContext.length).to.be.greaterThan(
+      permissionContext.length,
+    );
+  });
+
+  it('should create an open redelegation when no delegate is specified', async () => {
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 500n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+
+    const timestampCaveat = {
+      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
+      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      args: '0x00' as Hex,
+    };
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      delegationManager: mockDelegationManager,
+      chainId: mockChainId,
+      // No delegate specified
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.delegate).to.equal(
+      '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
+    );
+    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
+  });
+
+  it('should add additional caveats to the redelegation', async () => {
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 1000n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const timestampCaveat = {
+      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
+      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      args: '0x00' as Hex,
+    };
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      delegationManager: mockDelegationManager,
+      chainId: mockChainId,
+      delegate: newDelegate,
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.caveats).to.deep.include(timestampCaveat);
+  });
+
+  it('should inherit scope from parent when no scope is provided', async () => {
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 1000n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const timestampCaveat = {
+      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
+      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      args: '0x00' as Hex,
+    };
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      delegationManager: mockDelegationManager,
+      chainId: mockChainId,
+      delegate: newDelegate,
+      // No scope provided - should inherit from parent
+      caveats: [timestampCaveat], // Add a caveat so signature doesn't fail
+    });
+
+    expect(result.delegation.delegate).to.equal(newDelegate);
+    // Should have the additional caveat we added
+    expect(result.delegation.caveats).to.deep.include(timestampCaveat);
+  });
+
+  it('should allow scope override even with parent', async () => {
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 1000n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      delegationManager: mockDelegationManager,
+      chainId: mockChainId,
+      delegate: newDelegate,
+      scope: {
+        type: ScopeType.NativeTokenTransferAmount,
+        maxAmount: 500n,
+      },
+    });
+
+    expect(result.delegation.delegate).to.equal(newDelegate);
+    // Should have caveats from the new scope
+    expect(result.delegation.caveats.length).to.be.greaterThan(0);
+  });
+
+  it('should throw error if permission context is empty', async () => {
+    const emptyContext = encodeDelegations([]);
+
+    await expect(
+      redelegatePermissionContext(client, {
+        environment: mockEnvironment,
+        permissionContext: emptyContext,
+        delegationManager: mockDelegationManager,
+        chainId: mockChainId,
+        delegate: '0x2000000000000000000000000000000000000002',
+      }),
+    ).rejects.toThrow('Permission context must contain at least one delegation');
+  });
+
+  it('should throw error if no account is provided', async () => {
+    const clientWithoutAccount = createWalletClient({
+      chain: sepolia,
+      transport: http(),
+    });
+
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 1000n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+
+    await expect(
+      redelegatePermissionContext(clientWithoutAccount, {
+        environment: mockEnvironment,
+        permissionContext,
+        delegationManager: mockDelegationManager,
+        chainId: mockChainId,
+        delegate: '0x2000000000000000000000000000000000000002',
+      }),
+    ).rejects.toThrow('Account not found');
+  });
+
+  it('should work with explicit account parameter', async () => {
+    const clientWithoutAccount = createWalletClient({
+      chain: sepolia,
+      transport: http('https://rpc.sepolia.org'),
+    });
+
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 1000n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const timestampCaveat = {
+      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
+      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      args: '0x00' as Hex,
+    };
+
+    const result = await redelegatePermissionContext(clientWithoutAccount, {
+      account,
+      environment: mockEnvironment,
+      permissionContext,
+      delegationManager: mockDelegationManager,
+      chainId: mockChainId,
+      delegate: newDelegate,
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.delegate).to.equal(newDelegate);
+    expect(result.delegation.delegator).to.equal(account.address);
+  });
+});
+
+describe('redelegatePermissionContextActions', () => {
+  it('should extend a wallet client with redelegatePermissionContext', async () => {
+    const client = createWalletClient({
+      account,
+      chain: sepolia,
+      transport: http('https://rpc.sepolia.org'),
+    }).extend(redelegatePermissionContextActions());
+
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 1000n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const timestampCaveat = {
+      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
+      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      args: '0x00' as Hex,
+    };
+
+    const result = await client.redelegatePermissionContext({
+      environment: mockEnvironment,
+      permissionContext,
+      delegationManager: mockDelegationManager,
+      delegate: newDelegate,
+      caveats: [timestampCaveat],
+      // chainId should be inferred from client
+    });
+
+    expect(result.delegation.delegate).to.equal(newDelegate);
+    expect(result.delegation.delegator).to.equal(account.address);
+  });
+
+  it('should throw error if chain is not configured and chainId is not provided', async () => {
+    const clientWithoutChain = createWalletClient({
+      account,
+      transport: http('https://rpc.sepolia.org'),
+    }).extend(redelegatePermissionContextActions());
+
+    const rootDelegation = createDelegation({
+      environment: mockEnvironment,
+      scope: {
+        type: ScopeType.Erc20TransferAmount,
+        tokenAddress: '0xabc0000000000000000000000000000000000000',
+        maxAmount: 1000n,
+      },
+      to: account.address,
+      from: '0x1000000000000000000000000000000000000001',
+    });
+
+    const permissionContext = encodeDelegations([rootDelegation]);
+
+    await expect(
+      clientWithoutChain.redelegatePermissionContext({
+        environment: mockEnvironment,
+        permissionContext,
+        delegationManager: mockDelegationManager,
+        delegate: '0x2000000000000000000000000000000000000002',
+      }),
+    ).rejects.toThrow('Chain ID is required');
+  });
+});

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -7,8 +7,8 @@ import {
   redelegatePermissionContext,
   redelegatePermissionContextActions,
 } from '../../src/actions/redelegatePermissionContext';
-import { createDelegation, encodeDelegations } from '../../src/delegation';
 import { ScopeType } from '../../src/constants';
+import { createDelegation, encodeDelegations } from '../../src/delegation';
 import type { SmartAccountsEnvironment } from '../../src/types';
 
 const mockPrivateKey =
@@ -64,7 +64,8 @@ describe('redelegatePermissionContext', () => {
 
     const timestampCaveat = {
       enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      terms:
+        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
       args: '0x00' as Hex,
     };
 
@@ -104,7 +105,8 @@ describe('redelegatePermissionContext', () => {
 
     const timestampCaveat = {
       enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      terms:
+        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
       args: '0x00' as Hex,
     };
 
@@ -141,7 +143,8 @@ describe('redelegatePermissionContext', () => {
 
     const timestampCaveat = {
       enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      terms:
+        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
       args: '0x00' as Hex,
     };
 
@@ -174,7 +177,8 @@ describe('redelegatePermissionContext', () => {
 
     const timestampCaveat = {
       enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      terms:
+        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
       args: '0x00' as Hex,
     };
 
@@ -236,7 +240,9 @@ describe('redelegatePermissionContext', () => {
         chainId: mockChainId,
         delegate: '0x2000000000000000000000000000000000000002',
       }),
-    ).rejects.toThrow('Permission context must contain at least one delegation');
+    ).rejects.toThrow(
+      'Permission context must contain at least one delegation',
+    );
   });
 
   it('should throw error if no account is provided', async () => {
@@ -291,7 +297,8 @@ describe('redelegatePermissionContext', () => {
 
     const timestampCaveat = {
       enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      terms:
+        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
       args: '0x00' as Hex,
     };
 
@@ -334,7 +341,8 @@ describe('redelegatePermissionContextActions', () => {
 
     const timestampCaveat = {
       enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      terms:
+        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
       args: '0x00' as Hex,
     };
 

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -109,6 +109,24 @@ const buildPermissionContextWithOpenLeafDelegation = ({
   return encodeDelegations([openDelegation]);
 };
 
+const buildPermissionContextWithRootAuthorityLeafDelegate = (
+  leafDelegate: Address,
+  { maxAmount = 1000n }: { maxAmount?: bigint } = {},
+) => {
+  const rootAuthorityLeafDelegation = createDelegation({
+    environment: mockEnvironment,
+    scope: {
+      type: ScopeType.Erc20TransferAmount,
+      tokenAddress: '0xabc0000000000000000000000000000000000000',
+      maxAmount,
+    },
+    to: leafDelegate,
+    from: '0x1000000000000000000000000000000000000001',
+  });
+
+  return encodeDelegations([rootAuthorityLeafDelegation]);
+};
+
 describe('redelegatePermissionContext', () => {
   let client: ReturnType<typeof createWalletClient>;
 
@@ -234,6 +252,23 @@ describe('redelegatePermissionContext', () => {
     expect(result.delegation.delegator.toLowerCase()).to.equal(
       account.address.toLowerCase(),
     );
+  });
+
+  it('should not treat ROOT_AUTHORITY leaf as open when delegate is not ANY_BENEFICIARY', async () => {
+    const leafDelegate: Address = '0x3000000000000000000000000000000000000003';
+    const permissionContext =
+      buildPermissionContextWithRootAuthorityLeafDelegate(leafDelegate);
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      to: newDelegate,
+    });
+
+    expect(result.delegation.delegator).to.equal(leafDelegate);
+    expect(result.delegation.delegator).to.not.equal(account.address);
   });
 
   it('should allow scope override even with parent', async () => {
@@ -420,6 +455,21 @@ describe('redelegatePermissionContextOpen', () => {
     expect(result.delegation.delegator.toLowerCase()).to.equal(
       account.address.toLowerCase(),
     );
+  });
+
+  it('should not treat ROOT_AUTHORITY leaf as open when delegate is not ANY_BENEFICIARY', async () => {
+    const leafDelegate: Address = '0x3000000000000000000000000000000000000003';
+    const permissionContext =
+      buildPermissionContextWithRootAuthorityLeafDelegate(leafDelegate);
+
+    const result = await redelegatePermissionContextOpen(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+    });
+
+    expect(result.delegation.delegator).to.equal(leafDelegate);
+    expect(result.delegation.delegator).to.not.equal(account.address);
   });
 
   it('should allow scope override on an open redelegation', async () => {

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -125,6 +125,29 @@ describe('redelegatePermissionContext', () => {
     expect(result.delegation.caveats).to.deep.include(timestampCaveat);
   });
 
+  it('should sign successfully when inheriting from parent without scope or caveats', async () => {
+    const permissionContext = buildRootPermissionContext();
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      to: newDelegate,
+      // No scope and no caveats - should inherit entirely from parent
+      // and still produce a valid signature.
+    });
+
+    expect(result.delegation.delegate).to.equal(newDelegate);
+    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.caveats).to.deep.equal([]);
+    expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
+    expect(result.permissionContext).to.match(/^0x[a-fA-F0-9]+$/u);
+    expect(result.permissionContext.length).to.be.greaterThan(
+      permissionContext.length,
+    );
+  });
+
   it('should allow scope override even with parent', async () => {
     const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
@@ -254,6 +277,25 @@ describe('redelegatePermissionContextOpen', () => {
     });
 
     expect(result.delegation.caveats).to.deep.include(timestampCaveat);
+  });
+
+  it('should sign successfully when inheriting from parent without scope or caveats', async () => {
+    const permissionContext = buildRootPermissionContext();
+
+    const result = await redelegatePermissionContextOpen(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      // No scope and no caveats - should inherit entirely from parent
+      // and still produce a valid signature.
+    });
+
+    expect(result.delegation.delegate).to.equal(
+      '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
+    );
+    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.caveats).to.deep.equal([]);
+    expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
   });
 
   it('should allow scope override on an open redelegation', async () => {

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -9,7 +9,11 @@ import {
   redelegatePermissionContextActions,
 } from '../../src/actions/redelegatePermissionContext';
 import { ScopeType } from '../../src/constants';
-import { createDelegation, encodeDelegations } from '../../src/delegation';
+import {
+  createDelegation,
+  createOpenDelegation,
+  encodeDelegations,
+} from '../../src/delegation';
 import type { SmartAccountsEnvironment } from '../../src/types';
 
 const mockPrivateKey =
@@ -74,7 +78,35 @@ const buildPermissionContextWithParentDelegate = (
     from: '0x1000000000000000000000000000000000000001',
   });
 
-  return encodeDelegations([rootDelegation]);
+  const leafDelegation = createDelegation({
+    environment: mockEnvironment,
+    scope: {
+      type: ScopeType.Erc20TransferAmount,
+      tokenAddress: '0xabc0000000000000000000000000000000000000',
+      maxAmount,
+    },
+    to: parentDelegate,
+    from: '0x2000000000000000000000000000000000000002',
+    parentDelegation: rootDelegation,
+  });
+
+  return encodeDelegations([leafDelegation, rootDelegation]);
+};
+
+const buildPermissionContextWithOpenLeafDelegation = ({
+  maxAmount = 1000n,
+}: { maxAmount?: bigint } = {}) => {
+  const openDelegation = createOpenDelegation({
+    environment: mockEnvironment,
+    scope: {
+      type: ScopeType.Erc20TransferAmount,
+      tokenAddress: '0xabc0000000000000000000000000000000000000',
+      maxAmount,
+    },
+    from: '0x1000000000000000000000000000000000000001',
+  });
+
+  return encodeDelegations([openDelegation]);
 };
 
 describe('redelegatePermissionContext', () => {
@@ -186,6 +218,22 @@ describe('redelegatePermissionContext', () => {
 
     expect(result.delegation.delegator).to.equal(parentDelegate);
     expect(result.delegation.delegator).to.not.equal(account.address);
+  });
+
+  it('should use the account address as from when the leaf delegation is open', async () => {
+    const permissionContext = buildPermissionContextWithOpenLeafDelegation();
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      to: newDelegate,
+    });
+
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
   });
 
   it('should allow scope override even with parent', async () => {
@@ -358,6 +406,20 @@ describe('redelegatePermissionContextOpen', () => {
 
     expect(result.delegation.delegator).to.equal(parentDelegate);
     expect(result.delegation.delegator).to.not.equal(account.address);
+  });
+
+  it('should use the account address as from when the leaf delegation is open', async () => {
+    const permissionContext = buildPermissionContextWithOpenLeafDelegation();
+
+    const result = await redelegatePermissionContextOpen(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+    });
+
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
   });
 
   it('should allow scope override on an open redelegation', async () => {

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -32,8 +32,6 @@ const mockEnvironment: SmartAccountsEnvironment = {
   },
 };
 
-const mockDelegationManager: Address =
-  '0x1234567890123456789012345678901234567890';
 const mockChainId = sepolia.id;
 
 describe('redelegatePermissionContext', () => {
@@ -72,9 +70,8 @@ describe('redelegatePermissionContext', () => {
     const result = await redelegatePermissionContext(client, {
       environment: mockEnvironment,
       permissionContext,
-      delegationManager: mockDelegationManager,
       chainId: mockChainId,
-      delegate: newDelegate,
+      to: newDelegate,
       caveats: [timestampCaveat],
     });
 
@@ -113,9 +110,8 @@ describe('redelegatePermissionContext', () => {
     const result = await redelegatePermissionContext(client, {
       environment: mockEnvironment,
       permissionContext,
-      delegationManager: mockDelegationManager,
       chainId: mockChainId,
-      // No delegate specified
+      // No `to` specified - creates an open delegation
       caveats: [timestampCaveat],
     });
 
@@ -151,9 +147,8 @@ describe('redelegatePermissionContext', () => {
     const result = await redelegatePermissionContext(client, {
       environment: mockEnvironment,
       permissionContext,
-      delegationManager: mockDelegationManager,
       chainId: mockChainId,
-      delegate: newDelegate,
+      to: newDelegate,
       caveats: [timestampCaveat],
     });
 
@@ -185,9 +180,8 @@ describe('redelegatePermissionContext', () => {
     const result = await redelegatePermissionContext(client, {
       environment: mockEnvironment,
       permissionContext,
-      delegationManager: mockDelegationManager,
       chainId: mockChainId,
-      delegate: newDelegate,
+      to: newDelegate,
       // No scope provided - should inherit from parent
       caveats: [timestampCaveat], // Add a caveat so signature doesn't fail
     });
@@ -215,9 +209,8 @@ describe('redelegatePermissionContext', () => {
     const result = await redelegatePermissionContext(client, {
       environment: mockEnvironment,
       permissionContext,
-      delegationManager: mockDelegationManager,
       chainId: mockChainId,
-      delegate: newDelegate,
+      to: newDelegate,
       scope: {
         type: ScopeType.NativeTokenTransferAmount,
         maxAmount: 500n,
@@ -236,9 +229,8 @@ describe('redelegatePermissionContext', () => {
       redelegatePermissionContext(client, {
         environment: mockEnvironment,
         permissionContext: emptyContext,
-        delegationManager: mockDelegationManager,
         chainId: mockChainId,
-        delegate: '0x2000000000000000000000000000000000000002',
+        to: '0x2000000000000000000000000000000000000002',
       }),
     ).rejects.toThrow(
       'Permission context must contain at least one delegation',
@@ -268,9 +260,8 @@ describe('redelegatePermissionContext', () => {
       redelegatePermissionContext(clientWithoutAccount, {
         environment: mockEnvironment,
         permissionContext,
-        delegationManager: mockDelegationManager,
         chainId: mockChainId,
-        delegate: '0x2000000000000000000000000000000000000002',
+        to: '0x2000000000000000000000000000000000000002',
       }),
     ).rejects.toThrow('Account not found');
   });
@@ -306,9 +297,8 @@ describe('redelegatePermissionContext', () => {
       account,
       environment: mockEnvironment,
       permissionContext,
-      delegationManager: mockDelegationManager,
       chainId: mockChainId,
-      delegate: newDelegate,
+      to: newDelegate,
       caveats: [timestampCaveat],
     });
 
@@ -349,8 +339,7 @@ describe('redelegatePermissionContextActions', () => {
     const result = await client.redelegatePermissionContext({
       environment: mockEnvironment,
       permissionContext,
-      delegationManager: mockDelegationManager,
-      delegate: newDelegate,
+      to: newDelegate,
       caveats: [timestampCaveat],
       // chainId should be inferred from client
     });
@@ -382,8 +371,7 @@ describe('redelegatePermissionContextActions', () => {
       clientWithoutChain.redelegatePermissionContext({
         environment: mockEnvironment,
         permissionContext,
-        delegationManager: mockDelegationManager,
-        delegate: '0x2000000000000000000000000000000000000002',
+        to: '0x2000000000000000000000000000000000000002',
       }),
     ).rejects.toThrow('Chain ID is required');
   });

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -59,6 +59,24 @@ const buildRootPermissionContext = ({
   return encodeDelegations([rootDelegation]);
 };
 
+const buildPermissionContextWithParentDelegate = (
+  parentDelegate: Address,
+  { maxAmount = 1000n }: { maxAmount?: bigint } = {},
+) => {
+  const rootDelegation = createDelegation({
+    environment: mockEnvironment,
+    scope: {
+      type: ScopeType.Erc20TransferAmount,
+      tokenAddress: '0xabc0000000000000000000000000000000000000',
+      maxAmount,
+    },
+    to: parentDelegate,
+    from: '0x1000000000000000000000000000000000000001',
+  });
+
+  return encodeDelegations([rootDelegation]);
+};
+
 describe('redelegatePermissionContext', () => {
   let client: ReturnType<typeof createWalletClient>;
 
@@ -83,7 +101,9 @@ describe('redelegatePermissionContext', () => {
     });
 
     expect(result.delegation.delegate).to.equal(newDelegate);
-    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
     expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
     expect(result.permissionContext).to.match(/^0x[a-fA-F0-9]+$/u);
 
@@ -139,13 +159,33 @@ describe('redelegatePermissionContext', () => {
     });
 
     expect(result.delegation.delegate).to.equal(newDelegate);
-    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
     expect(result.delegation.caveats).to.deep.equal([]);
     expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
     expect(result.permissionContext).to.match(/^0x[a-fA-F0-9]+$/u);
     expect(result.permissionContext.length).to.be.greaterThan(
       permissionContext.length,
     );
+  });
+
+  it("should use the parent delegation's delegate as from address", async () => {
+    const parentDelegate: Address =
+      '0x3000000000000000000000000000000000000003';
+    const permissionContext =
+      buildPermissionContextWithParentDelegate(parentDelegate);
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const result = await redelegatePermissionContext(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      to: newDelegate,
+    });
+
+    expect(result.delegation.delegator).to.equal(parentDelegate);
+    expect(result.delegation.delegator).to.not.equal(account.address);
   });
 
   it('should allow scope override even with parent', async () => {
@@ -220,7 +260,9 @@ describe('redelegatePermissionContext', () => {
     });
 
     expect(result.delegation.delegate).to.equal(newDelegate);
-    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
   });
 });
 
@@ -248,7 +290,9 @@ describe('redelegatePermissionContextOpen', () => {
     expect(result.delegation.delegate).to.equal(
       '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
     );
-    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
     expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
   });
 
@@ -293,9 +337,27 @@ describe('redelegatePermissionContextOpen', () => {
     expect(result.delegation.delegate).to.equal(
       '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
     );
-    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
     expect(result.delegation.caveats).to.deep.equal([]);
     expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
+  });
+
+  it("should use the parent delegation's delegate as from address", async () => {
+    const parentDelegate: Address =
+      '0x3000000000000000000000000000000000000003';
+    const permissionContext =
+      buildPermissionContextWithParentDelegate(parentDelegate);
+
+    const result = await redelegatePermissionContextOpen(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+    });
+
+    expect(result.delegation.delegator).to.equal(parentDelegate);
+    expect(result.delegation.delegator).to.not.equal(account.address);
   });
 
   it('should allow scope override on an open redelegation', async () => {
@@ -366,7 +428,9 @@ describe('redelegatePermissionContextActions', () => {
     });
 
     expect(result.delegation.delegate).to.equal(newDelegate);
-    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
   });
 
   it('should extend a wallet client with redelegatePermissionContextOpen', async () => {
@@ -388,7 +452,9 @@ describe('redelegatePermissionContextActions', () => {
     expect(result.delegation.delegate).to.equal(
       '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
     );
-    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.delegator.toLowerCase()).to.equal(
+      account.address.toLowerCase(),
+    );
   });
 
   it('should throw error if chain is not configured and chainId is not provided (specific)', async () => {

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 
 import {
   redelegatePermissionContext,
+  redelegatePermissionContextOpen,
   redelegatePermissionContextActions,
 } from '../../src/actions/redelegatePermissionContext';
 import { ScopeType } from '../../src/constants';
@@ -34,6 +35,30 @@ const mockEnvironment: SmartAccountsEnvironment = {
 
 const mockChainId = sepolia.id;
 
+const timestampCaveat = {
+  enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
+  terms:
+    '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+  args: '0x00' as Hex,
+};
+
+const buildRootPermissionContext = ({
+  maxAmount = 1000n,
+}: { maxAmount?: bigint } = {}) => {
+  const rootDelegation = createDelegation({
+    environment: mockEnvironment,
+    scope: {
+      type: ScopeType.Erc20TransferAmount,
+      tokenAddress: '0xabc0000000000000000000000000000000000000',
+      maxAmount,
+    },
+    to: account.address,
+    from: '0x1000000000000000000000000000000000000001',
+  });
+
+  return encodeDelegations([rootDelegation]);
+};
+
 describe('redelegatePermissionContext', () => {
   let client: ReturnType<typeof createWalletClient>;
 
@@ -46,26 +71,8 @@ describe('redelegatePermissionContext', () => {
   });
 
   it('should create a redelegation with a specific delegate', async () => {
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 1000n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
+    const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
-
-    const timestampCaveat = {
-      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms:
-        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
-      args: '0x00' as Hex,
-    };
 
     const result = await redelegatePermissionContext(client, {
       environment: mockEnvironment,
@@ -86,63 +93,9 @@ describe('redelegatePermissionContext', () => {
     );
   });
 
-  it('should create an open redelegation when no delegate is specified', async () => {
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 500n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
-
-    const timestampCaveat = {
-      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms:
-        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
-      args: '0x00' as Hex,
-    };
-
-    const result = await redelegatePermissionContext(client, {
-      environment: mockEnvironment,
-      permissionContext,
-      chainId: mockChainId,
-      // No `to` specified - creates an open delegation
-      caveats: [timestampCaveat],
-    });
-
-    expect(result.delegation.delegate).to.equal(
-      '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
-    );
-    expect(result.delegation.delegator).to.equal(account.address);
-    expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
-  });
-
   it('should add additional caveats to the redelegation', async () => {
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 1000n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
+    const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
-
-    const timestampCaveat = {
-      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms:
-        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
-      args: '0x00' as Hex,
-    };
 
     const result = await redelegatePermissionContext(client, {
       environment: mockEnvironment,
@@ -156,26 +109,8 @@ describe('redelegatePermissionContext', () => {
   });
 
   it('should inherit scope from parent when no scope is provided', async () => {
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 1000n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
+    const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
-
-    const timestampCaveat = {
-      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms:
-        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
-      args: '0x00' as Hex,
-    };
 
     const result = await redelegatePermissionContext(client, {
       environment: mockEnvironment,
@@ -183,27 +118,15 @@ describe('redelegatePermissionContext', () => {
       chainId: mockChainId,
       to: newDelegate,
       // No scope provided - should inherit from parent
-      caveats: [timestampCaveat], // Add a caveat so signature doesn't fail
+      caveats: [timestampCaveat],
     });
 
     expect(result.delegation.delegate).to.equal(newDelegate);
-    // Should have the additional caveat we added
     expect(result.delegation.caveats).to.deep.include(timestampCaveat);
   });
 
   it('should allow scope override even with parent', async () => {
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 1000n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
+    const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
     const result = await redelegatePermissionContext(client, {
@@ -243,18 +166,7 @@ describe('redelegatePermissionContext', () => {
       transport: http(),
     });
 
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 1000n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
+    const permissionContext = buildRootPermissionContext();
 
     await expect(
       redelegatePermissionContext(clientWithoutAccount, {
@@ -272,26 +184,8 @@ describe('redelegatePermissionContext', () => {
       transport: http('https://rpc.sepolia.org'),
     });
 
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 1000n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
+    const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
-
-    const timestampCaveat = {
-      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms:
-        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
-      args: '0x00' as Hex,
-    };
 
     const result = await redelegatePermissionContext(clientWithoutAccount, {
       account,
@@ -307,6 +201,109 @@ describe('redelegatePermissionContext', () => {
   });
 });
 
+describe('redelegatePermissionContextOpen', () => {
+  let client: ReturnType<typeof createWalletClient>;
+
+  beforeEach(() => {
+    client = createWalletClient({
+      account,
+      chain: sepolia,
+      transport: http('https://rpc.sepolia.org'),
+    });
+  });
+
+  it('should create an open redelegation (delegate = ANY_BENEFICIARY)', async () => {
+    const permissionContext = buildRootPermissionContext({ maxAmount: 500n });
+
+    const result = await redelegatePermissionContextOpen(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.delegate).to.equal(
+      '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
+    );
+    expect(result.delegation.delegator).to.equal(account.address);
+    expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
+  });
+
+  it('should add additional caveats to the open redelegation', async () => {
+    const permissionContext = buildRootPermissionContext();
+
+    const result = await redelegatePermissionContextOpen(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.caveats).to.deep.include(timestampCaveat);
+  });
+
+  it('should inherit scope from parent when no scope is provided', async () => {
+    const permissionContext = buildRootPermissionContext();
+
+    const result = await redelegatePermissionContextOpen(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      // No scope - inherits from parent. Add a caveat so the delegation isn't empty.
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.caveats).to.deep.include(timestampCaveat);
+  });
+
+  it('should allow scope override on an open redelegation', async () => {
+    const permissionContext = buildRootPermissionContext();
+
+    const result = await redelegatePermissionContextOpen(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      scope: {
+        type: ScopeType.NativeTokenTransferAmount,
+        maxAmount: 500n,
+      },
+    });
+
+    expect(result.delegation.caveats.length).to.be.greaterThan(0);
+  });
+
+  it('should throw error if permission context is empty', async () => {
+    const emptyContext = encodeDelegations([]);
+
+    await expect(
+      redelegatePermissionContextOpen(client, {
+        environment: mockEnvironment,
+        permissionContext: emptyContext,
+        chainId: mockChainId,
+      }),
+    ).rejects.toThrow(
+      'Permission context must contain at least one delegation',
+    );
+  });
+
+  it('should throw error if no account is provided', async () => {
+    const clientWithoutAccount = createWalletClient({
+      chain: sepolia,
+      transport: http(),
+    });
+
+    const permissionContext = buildRootPermissionContext();
+
+    await expect(
+      redelegatePermissionContextOpen(clientWithoutAccount, {
+        environment: mockEnvironment,
+        permissionContext,
+        chainId: mockChainId,
+      }),
+    ).rejects.toThrow('Account not found');
+  });
+});
+
 describe('redelegatePermissionContextActions', () => {
   it('should extend a wallet client with redelegatePermissionContext', async () => {
     const client = createWalletClient({
@@ -315,26 +312,8 @@ describe('redelegatePermissionContextActions', () => {
       transport: http('https://rpc.sepolia.org'),
     }).extend(redelegatePermissionContextActions());
 
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 1000n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
+    const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
-
-    const timestampCaveat = {
-      enforcer: mockEnvironment.caveatEnforcers.TimestampEnforcer as Address,
-      terms:
-        '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
-      args: '0x00' as Hex,
-    };
 
     const result = await client.redelegatePermissionContext({
       environment: mockEnvironment,
@@ -348,30 +327,57 @@ describe('redelegatePermissionContextActions', () => {
     expect(result.delegation.delegator).to.equal(account.address);
   });
 
-  it('should throw error if chain is not configured and chainId is not provided', async () => {
+  it('should extend a wallet client with redelegatePermissionContextOpen', async () => {
+    const client = createWalletClient({
+      account,
+      chain: sepolia,
+      transport: http('https://rpc.sepolia.org'),
+    }).extend(redelegatePermissionContextActions());
+
+    const permissionContext = buildRootPermissionContext();
+
+    const result = await client.redelegatePermissionContextOpen({
+      environment: mockEnvironment,
+      permissionContext,
+      caveats: [timestampCaveat],
+      // chainId should be inferred from client
+    });
+
+    expect(result.delegation.delegate).to.equal(
+      '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
+    );
+    expect(result.delegation.delegator).to.equal(account.address);
+  });
+
+  it('should throw error if chain is not configured and chainId is not provided (specific)', async () => {
     const clientWithoutChain = createWalletClient({
       account,
       transport: http('https://rpc.sepolia.org'),
     }).extend(redelegatePermissionContextActions());
 
-    const rootDelegation = createDelegation({
-      environment: mockEnvironment,
-      scope: {
-        type: ScopeType.Erc20TransferAmount,
-        tokenAddress: '0xabc0000000000000000000000000000000000000',
-        maxAmount: 1000n,
-      },
-      to: account.address,
-      from: '0x1000000000000000000000000000000000000001',
-    });
-
-    const permissionContext = encodeDelegations([rootDelegation]);
+    const permissionContext = buildRootPermissionContext();
 
     await expect(
       clientWithoutChain.redelegatePermissionContext({
         environment: mockEnvironment,
         permissionContext,
         to: '0x2000000000000000000000000000000000000002',
+      }),
+    ).rejects.toThrow('Chain ID is required');
+  });
+
+  it('should throw error if chain is not configured and chainId is not provided (open)', async () => {
+    const clientWithoutChain = createWalletClient({
+      account,
+      transport: http('https://rpc.sepolia.org'),
+    }).extend(redelegatePermissionContextActions());
+
+    const permissionContext = buildRootPermissionContext();
+
+    await expect(
+      clientWithoutChain.redelegatePermissionContextOpen({
+        environment: mockEnvironment,
+        permissionContext,
       }),
     ).rejects.toThrow('Chain ID is required');
   });

--- a/packages/smart-accounts-kit/test/caveatBuilder/resolveCaveats.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/resolveCaveats.test.ts
@@ -48,6 +48,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: caveatBuilder,
+        hasInheritance: false,
       });
 
       // 4 caveats: 2 from the scope, 2 from the builder
@@ -65,6 +66,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: caveatBuilder,
+        hasInheritance: false,
       });
 
       expect(result).to.be.an('array');
@@ -83,6 +85,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: caveatBuilder as any,
+        hasInheritance: false,
       });
 
       expect(result).to.be.an('array');
@@ -98,6 +101,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats,
+        hasInheritance: false,
       });
 
       expect(result).to.be.an('array');
@@ -125,6 +129,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: caveatConfigs,
+        hasInheritance: false,
       });
 
       expect(result).to.be.an('array');
@@ -135,6 +140,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: [],
+        hasInheritance: false,
       });
       expect(result.length).to.be.greaterThan(scopeOnlyResult.length);
     });
@@ -158,6 +164,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: mixedCaveats,
+        hasInheritance: false,
       });
 
       expect(result).to.be.an('array');
@@ -173,6 +180,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: [],
+        hasInheritance: false,
       });
 
       expect(result).to.be.an('array');
@@ -197,6 +205,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc721Scope,
         caveats: [caveatConfig],
+        hasInheritance: false,
       });
 
       expect(result).to.be.an('array');
@@ -208,12 +217,14 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: [mockCaveat1],
+        hasInheritance: false,
       });
 
       const resultWithoutCaveats = resolveCaveats({
         environment,
         scope: erc20Scope,
         caveats: [],
+        hasInheritance: false,
       });
 
       expect(resultWithCaveats.length).to.be.greaterThan(
@@ -236,8 +247,65 @@ describe('resolveCaveats', () => {
           environment,
           scope: erc20Scope,
           caveats: [invalidType as any],
+          hasInheritance: false,
         });
       }).to.throw('Invalid caveat');
+    });
+  });
+
+  describe('hasInheritance', () => {
+    it('should throw if scope is not provided and the delegation has no inheritance', () => {
+      expect(() =>
+        resolveCaveats({
+          environment,
+          caveats: [mockCaveat1],
+          hasInheritance: false,
+        }),
+      ).to.throw('Scope is required when the delegation has no inheritance');
+    });
+
+    it('should throw if neither scope nor caveats are provided and the delegation has no inheritance', () => {
+      expect(() =>
+        resolveCaveats({
+          environment,
+          hasInheritance: false,
+        }),
+      ).to.throw('Scope is required when the delegation has no inheritance');
+    });
+
+    it('should resolve caveats without a scope when the delegation has inheritance', () => {
+      const result = resolveCaveats({
+        environment,
+        caveats: [mockCaveat1, mockCaveat2],
+        hasInheritance: true,
+      });
+
+      // No scope caveats are added when the scope is inherited from the parent
+      expect(result).to.have.lengthOf(2);
+      expect(result).to.deep.include(mockCaveat1);
+      expect(result).to.deep.include(mockCaveat2);
+    });
+
+    it('should return an empty array when no scope, no caveats and the delegation has inheritance', () => {
+      const result = resolveCaveats({
+        environment,
+        hasInheritance: true,
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should still apply scope caveats when both scope and inheritance are provided', () => {
+      const result = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: [mockCaveat1],
+        hasInheritance: true,
+      });
+
+      // Scope caveats are still produced when an explicit scope is provided
+      expect(result.length).to.be.greaterThan(1);
+      expect(result).to.deep.include(mockCaveat1);
     });
   });
 });

--- a/packages/smart-accounts-kit/test/caveatBuilder/resolveCaveats.test.ts
+++ b/packages/smart-accounts-kit/test/caveatBuilder/resolveCaveats.test.ts
@@ -48,7 +48,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: caveatBuilder,
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       // 4 caveats: 2 from the scope, 2 from the builder
@@ -66,7 +66,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: caveatBuilder,
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       expect(result).to.be.an('array');
@@ -85,7 +85,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: caveatBuilder as any,
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       expect(result).to.be.an('array');
@@ -101,7 +101,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats,
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       expect(result).to.be.an('array');
@@ -129,7 +129,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: caveatConfigs,
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       expect(result).to.be.an('array');
@@ -140,7 +140,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: [],
-        hasInheritance: false,
+        isScopeOptional: false,
       });
       expect(result.length).to.be.greaterThan(scopeOnlyResult.length);
     });
@@ -164,7 +164,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: mixedCaveats,
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       expect(result).to.be.an('array');
@@ -180,7 +180,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: [],
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       expect(result).to.be.an('array');
@@ -205,7 +205,7 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc721Scope,
         caveats: [caveatConfig],
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       expect(result).to.be.an('array');
@@ -217,14 +217,14 @@ describe('resolveCaveats', () => {
         environment,
         scope: erc20Scope,
         caveats: [mockCaveat1],
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       const resultWithoutCaveats = resolveCaveats({
         environment,
         scope: erc20Scope,
         caveats: [],
-        hasInheritance: false,
+        isScopeOptional: false,
       });
 
       expect(resultWithCaveats.length).to.be.greaterThan(
@@ -247,37 +247,37 @@ describe('resolveCaveats', () => {
           environment,
           scope: erc20Scope,
           caveats: [invalidType as any],
-          hasInheritance: false,
+          isScopeOptional: false,
         });
       }).to.throw('Invalid caveat');
     });
   });
 
-  describe('hasInheritance', () => {
+  describe('isScopeOptional', () => {
     it('should throw if scope is not provided and the delegation has no inheritance', () => {
       expect(() =>
         resolveCaveats({
           environment,
           caveats: [mockCaveat1],
-          hasInheritance: false,
+          isScopeOptional: false,
         }),
-      ).to.throw('Scope is required when the delegation has no inheritance');
+      ).to.throw('Scope is required');
     });
 
-    it('should throw if neither scope nor caveats are provided and the delegation has no inheritance', () => {
+    it('should throw if neither scope nor caveats are provided and scope is optional', () => {
       expect(() =>
         resolveCaveats({
           environment,
-          hasInheritance: false,
+          isScopeOptional: false,
         }),
-      ).to.throw('Scope is required when the delegation has no inheritance');
+      ).to.throw('Scope is required');
     });
 
-    it('should resolve caveats without a scope when the delegation has inheritance', () => {
+    it('should resolve caveats without a scope when scope is optional', () => {
       const result = resolveCaveats({
         environment,
         caveats: [mockCaveat1, mockCaveat2],
-        hasInheritance: true,
+        isScopeOptional: true,
       });
 
       // No scope caveats are added when the scope is inherited from the parent
@@ -286,21 +286,21 @@ describe('resolveCaveats', () => {
       expect(result).to.deep.include(mockCaveat2);
     });
 
-    it('should return an empty array when no scope, no caveats and the delegation has inheritance', () => {
+    it('should return an empty array when no scope, no caveats and scope is optional', () => {
       const result = resolveCaveats({
         environment,
-        hasInheritance: true,
+        isScopeOptional: true,
       });
 
       expect(result).to.deep.equal([]);
     });
 
-    it('should still apply scope caveats when both scope and inheritance are provided', () => {
+    it('should still apply scope caveats when both scope and scope is optional', () => {
       const result = resolveCaveats({
         environment,
         scope: erc20Scope,
         caveats: [mockCaveat1],
-        hasInheritance: true,
+        isScopeOptional: true,
       });
 
       // Scope caveats are still produced when an explicit scope is provided

--- a/packages/smart-accounts-kit/test/delegation.test.ts
+++ b/packages/smart-accounts-kit/test/delegation.test.ts
@@ -918,7 +918,7 @@ describe('parentPermissionContext support', () => {
 
     const differentErc20Scope = {
       type: ScopeType.Erc20TransferAmount as const,
-      tokenAddress: '0xdffe000000000000000000000000000000000000',
+      tokenAddress: '0xdffe000000000000000000000000000000000000' as const,
       maxAmount: 5000n,
     };
 

--- a/packages/smart-accounts-kit/test/delegation.test.ts
+++ b/packages/smart-accounts-kit/test/delegation.test.ts
@@ -813,3 +813,168 @@ describe('signDelegation', () => {
     expect(signature).to.have.length(132);
   });
 });
+
+describe('parentPermissionContext support', () => {
+  it('should create a delegation using parentPermissionContext with Delegation array', () => {
+    const parentDelegation = createDelegation({
+      environment: smartAccountEnvironment,
+      scope: erc20Scope,
+      to: mockDelegate,
+      from: mockDelegator,
+    });
+
+    const permissionContext = [parentDelegation];
+
+    const result = createDelegation({
+      environment: smartAccountEnvironment,
+      to: randomAddress(),
+      from: mockDelegate,
+      parentPermissionContext: permissionContext,
+      caveats: [mockCaveat],
+    });
+
+    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+    expect(result.caveats).to.deep.equal([mockCaveat]);
+  });
+
+  it('should create a delegation using parentPermissionContext with encoded Hex', () => {
+    const parentDelegation = createDelegation({
+      environment: smartAccountEnvironment,
+      scope: erc20Scope,
+      to: mockDelegate,
+      from: mockDelegator,
+    });
+
+    const encodedContext = encodeDelegations([parentDelegation]);
+
+    const result = createDelegation({
+      environment: smartAccountEnvironment,
+      to: randomAddress(),
+      from: mockDelegate,
+      parentPermissionContext: encodedContext,
+      caveats: [mockCaveat],
+    });
+
+    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+    expect(result.caveats).to.deep.equal([mockCaveat]);
+  });
+
+  it('should create an open delegation using parentPermissionContext', () => {
+    const parentDelegation = createDelegation({
+      environment: smartAccountEnvironment,
+      scope: erc20Scope,
+      to: mockDelegate,
+      from: mockDelegator,
+    });
+
+    const permissionContext = [parentDelegation];
+
+    const result = createOpenDelegation({
+      environment: smartAccountEnvironment,
+      from: mockDelegate,
+      parentPermissionContext: permissionContext,
+      caveats: [mockCaveat],
+    });
+
+    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+    expect(result.delegate).to.equal(
+      '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
+    );
+    expect(result.caveats).to.deep.equal([mockCaveat]);
+  });
+
+  it('should inherit scope from parent when no scope is provided', () => {
+    const parentDelegation = createDelegation({
+      environment: smartAccountEnvironment,
+      scope: erc20Scope,
+      to: mockDelegate,
+      from: mockDelegator,
+    });
+
+    const permissionContext = [parentDelegation];
+
+    const result = createDelegation({
+      environment: smartAccountEnvironment,
+      to: randomAddress(),
+      from: mockDelegate,
+      parentPermissionContext: permissionContext,
+      // No scope provided - inherits from parent
+    });
+
+    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+    // When no scope is provided, caveats should be empty (scope is inherited through the chain)
+    expect(result.caveats).to.deep.equal([]);
+  });
+
+  it('should allow scope override even with parent', () => {
+    const parentDelegation = createDelegation({
+      environment: smartAccountEnvironment,
+      scope: erc20Scope,
+      to: mockDelegate,
+      from: mockDelegator,
+    });
+
+    const permissionContext = [parentDelegation];
+
+    const differentErc20Scope = {
+      type: ScopeType.Erc20TransferAmount as const,
+      tokenAddress: '0xdffe000000000000000000000000000000000000',
+      maxAmount: 5000n,
+    };
+
+    const result = createDelegation({
+      environment: smartAccountEnvironment,
+      to: randomAddress(),
+      from: mockDelegate,
+      parentPermissionContext: permissionContext,
+      scope: differentErc20Scope,
+    });
+
+    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+    // Should have new scope's caveats
+    expect(result.caveats.length).to.be.greaterThan(0);
+  });
+
+  it('should throw error if permission context is empty', () => {
+    const emptyContext: Delegation[] = [];
+
+    expect(() =>
+      createDelegation({
+        environment: smartAccountEnvironment,
+        to: randomAddress(),
+        from: mockDelegate,
+        parentPermissionContext: emptyContext,
+      }),
+    ).to.throw('Permission context must contain at least one delegation');
+  });
+
+  it('should extract leaf delegation from multi-delegation chain', () => {
+    const rootDelegation = createDelegation({
+      environment: smartAccountEnvironment,
+      scope: erc20Scope,
+      to: mockDelegate,
+      from: mockDelegator,
+    });
+
+    const childDelegation = createDelegation({
+      environment: smartAccountEnvironment,
+      to: randomAddress(),
+      from: mockDelegate,
+      parentDelegation: rootDelegation,
+      scope: erc20Scope,
+    });
+
+    // Chain ordered leaf to root
+    const permissionContext = [childDelegation, rootDelegation];
+
+    const result = createDelegation({
+      environment: smartAccountEnvironment,
+      to: randomAddress(),
+      from: randomAddress(),
+      parentPermissionContext: permissionContext,
+    });
+
+    // Should use childDelegation (leaf) as parent
+    expect(result.authority).to.equal(resolveAuthority(childDelegation));
+  });
+});

--- a/packages/smart-accounts-kit/test/delegation.test.ts
+++ b/packages/smart-accounts-kit/test/delegation.test.ts
@@ -225,6 +225,20 @@ describe('createDelegation', () => {
     });
   });
 
+  it('throws if parent delegation is root authority with differing case', () => {
+    const mixedCaseRootAuthority: Hex = `0x${ROOT_AUTHORITY.slice(2).toUpperCase()}`;
+
+    expect(() =>
+      createDelegation({
+        environment: smartAccountEnvironment,
+        scope: erc20Scope,
+        to: mockDelegate,
+        from: mockDelegator,
+        parentDelegation: mixedCaseRootAuthority,
+      }),
+    ).toThrow(`Invalid parent delegation - cannot be ${ROOT_AUTHORITY}`);
+  });
+
   it('should create a delegation with caveats', () => {
     const caveats: Caveat[] = [
       {
@@ -360,7 +374,22 @@ describe('createDelegation', () => {
         to: mockDelegate,
         from: mockDelegator,
       } as any);
-    }).toThrow('Scope is required when the delegation has no inheritance');
+    }).toThrow(
+      'Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope',
+    );
+  });
+
+  it('throws if scope is explicitly undefined and no inheritance is provided', () => {
+    expect(() => {
+      createDelegation({
+        environment: smartAccountEnvironment,
+        to: mockDelegate,
+        from: mockDelegator,
+        scope: undefined,
+      } as any);
+    }).toThrow(
+      'Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope',
+    );
   });
 
   describe('parentPermissionContext support', () => {
@@ -558,6 +587,19 @@ describe('createOpenDelegation', () => {
     });
   });
 
+  it('throws if parent delegation is root authority with differing case', () => {
+    const mixedCaseRootAuthority: Hex = `0x${ROOT_AUTHORITY.slice(2).toUpperCase()}`;
+
+    expect(() =>
+      createOpenDelegation({
+        environment: smartAccountEnvironment,
+        scope: erc20Scope,
+        from: mockDelegator,
+        parentDelegation: mixedCaseRootAuthority,
+      }),
+    ).toThrow(`Invalid parent delegation - cannot be ${ROOT_AUTHORITY}`);
+  });
+
   it('should create an open delegation with caveats', () => {
     const caveats: Caveat[] = [
       {
@@ -669,7 +711,21 @@ describe('createOpenDelegation', () => {
         environment: smartAccountEnvironment,
         from: mockDelegator,
       } as any);
-    }).toThrow('Scope is required when the delegation has no inheritance');
+    }).toThrow(
+      'Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope',
+    );
+  });
+
+  it('throws if scope is explicitly undefined and no inheritance is provided', () => {
+    expect(() => {
+      createOpenDelegation({
+        environment: smartAccountEnvironment,
+        from: mockDelegator,
+        scope: undefined,
+      } as any);
+    }).toThrow(
+      'Invalid arguments - must specify either parentDelegation, parentPermissionContext, or scope',
+    );
   });
 
   describe('parentPermissionContext support', () => {

--- a/packages/smart-accounts-kit/test/delegation.test.ts
+++ b/packages/smart-accounts-kit/test/delegation.test.ts
@@ -352,6 +352,160 @@ describe('createDelegation', () => {
       signature: '0x',
     });
   });
+
+  describe('parentPermissionContext support', () => {
+    it('should create a delegation using parentPermissionContext with Delegation array', () => {
+      const parentDelegation = createDelegation({
+        environment: smartAccountEnvironment,
+        scope: erc20Scope,
+        to: mockDelegate,
+        from: mockDelegator,
+      });
+
+      const permissionContext = [parentDelegation];
+
+      const result = createDelegation({
+        environment: smartAccountEnvironment,
+        to: randomAddress(),
+        from: mockDelegate,
+        parentPermissionContext: permissionContext,
+        caveats: [mockCaveat],
+      });
+
+      expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+      expect(result.caveats).to.deep.equal([mockCaveat]);
+    });
+
+    it('should create a delegation using parentPermissionContext with encoded Hex', () => {
+      const parentDelegation = createDelegation({
+        environment: smartAccountEnvironment,
+        scope: erc20Scope,
+        to: mockDelegate,
+        from: mockDelegator,
+      });
+
+      const encodedContext = encodeDelegations([parentDelegation]);
+
+      const result = createDelegation({
+        environment: smartAccountEnvironment,
+        to: randomAddress(),
+        from: mockDelegate,
+        parentPermissionContext: encodedContext,
+        caveats: [mockCaveat],
+      });
+
+      expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+      expect(result.caveats).to.deep.equal([mockCaveat]);
+    });
+
+    it('should inherit scope from parent when no scope is provided', () => {
+      const parentDelegation = createDelegation({
+        environment: smartAccountEnvironment,
+        scope: erc20Scope,
+        to: mockDelegate,
+        from: mockDelegator,
+      });
+
+      const permissionContext = [parentDelegation];
+
+      const result = createDelegation({
+        environment: smartAccountEnvironment,
+        to: randomAddress(),
+        from: mockDelegate,
+        parentPermissionContext: permissionContext,
+        // No scope provided - inherits from parent
+      });
+
+      expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+      // When no scope is provided, caveats should be empty (scope is inherited through the chain)
+      expect(result.caveats).to.deep.equal([]);
+    });
+
+    it('should allow scope override even with parent', () => {
+      const parentDelegation = createDelegation({
+        environment: smartAccountEnvironment,
+        scope: erc20Scope,
+        to: mockDelegate,
+        from: mockDelegator,
+      });
+
+      const permissionContext = [parentDelegation];
+
+      const differentErc20Scope = {
+        type: ScopeType.Erc20TransferAmount as const,
+        tokenAddress: '0xdffe000000000000000000000000000000000000' as const,
+        maxAmount: 5000n,
+      };
+
+      const result = createDelegation({
+        environment: smartAccountEnvironment,
+        to: randomAddress(),
+        from: mockDelegate,
+        parentPermissionContext: permissionContext,
+        scope: differentErc20Scope,
+      });
+
+      expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+      // Should have new scope's caveats
+      expect(result.caveats.length).to.be.greaterThan(0);
+    });
+
+    it('should throw error if permission context is empty', () => {
+      const emptyContext: Delegation[] = [];
+
+      expect(() =>
+        createDelegation({
+          environment: smartAccountEnvironment,
+          to: randomAddress(),
+          from: mockDelegate,
+          parentPermissionContext: emptyContext,
+        }),
+      ).to.throw('Permission context must contain at least one delegation');
+    });
+
+    it('should throw error if encoded permission context is empty', () => {
+      const emptyContext = encodeDelegations([]);
+
+      expect(() =>
+        createDelegation({
+          environment: smartAccountEnvironment,
+          to: randomAddress(),
+          from: mockDelegate,
+          parentPermissionContext: emptyContext,
+        }),
+      ).to.throw('Permission context must contain at least one delegation');
+    });
+
+    it('should extract leaf delegation from multi-delegation chain', () => {
+      const rootDelegation = createDelegation({
+        environment: smartAccountEnvironment,
+        scope: erc20Scope,
+        to: mockDelegate,
+        from: mockDelegator,
+      });
+
+      const childDelegation = createDelegation({
+        environment: smartAccountEnvironment,
+        to: randomAddress(),
+        from: mockDelegate,
+        parentDelegation: rootDelegation,
+        scope: erc20Scope,
+      });
+
+      // Chain ordered leaf to root
+      const permissionContext = [childDelegation, rootDelegation];
+
+      const result = createDelegation({
+        environment: smartAccountEnvironment,
+        to: randomAddress(),
+        from: randomAddress(),
+        parentPermissionContext: permissionContext,
+      });
+
+      // Should use childDelegation (leaf) as parent
+      expect(result.authority).to.equal(resolveAuthority(childDelegation));
+    });
+  });
 });
 
 describe('createOpenDelegation', () => {
@@ -496,6 +650,32 @@ describe('createOpenDelegation', () => {
       caveats: [...erc20ScopeCaveats],
       salt: '0x00',
       signature: '0x',
+    });
+  });
+
+  describe('parentPermissionContext support', () => {
+    it('should create an open delegation using parentPermissionContext', () => {
+      const parentDelegation = createDelegation({
+        environment: smartAccountEnvironment,
+        scope: erc20Scope,
+        to: mockDelegate,
+        from: mockDelegator,
+      });
+
+      const permissionContext = [parentDelegation];
+
+      const result = createOpenDelegation({
+        environment: smartAccountEnvironment,
+        from: mockDelegate,
+        parentPermissionContext: permissionContext,
+        caveats: [mockCaveat],
+      });
+
+      expect(result.authority).to.equal(resolveAuthority(parentDelegation));
+      expect(result.delegate).to.equal(
+        '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
+      );
+      expect(result.caveats).to.deep.equal([mockCaveat]);
     });
   });
 });
@@ -811,170 +991,5 @@ describe('signDelegation', () => {
     expect(signature).to.match(/^0x[a-fA-F0-9]+$/u);
     // ECDSA signature should be 65 bytes (130 hex chars) + 0x prefix = 132 total chars
     expect(signature).to.have.length(132);
-  });
-});
-
-describe('parentPermissionContext support', () => {
-  it('should create a delegation using parentPermissionContext with Delegation array', () => {
-    const parentDelegation = createDelegation({
-      environment: smartAccountEnvironment,
-      scope: erc20Scope,
-      to: mockDelegate,
-      from: mockDelegator,
-    });
-
-    const permissionContext = [parentDelegation];
-
-    const result = createDelegation({
-      environment: smartAccountEnvironment,
-      to: randomAddress(),
-      from: mockDelegate,
-      parentPermissionContext: permissionContext,
-      caveats: [mockCaveat],
-    });
-
-    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
-    expect(result.caveats).to.deep.equal([mockCaveat]);
-  });
-
-  it('should create a delegation using parentPermissionContext with encoded Hex', () => {
-    const parentDelegation = createDelegation({
-      environment: smartAccountEnvironment,
-      scope: erc20Scope,
-      to: mockDelegate,
-      from: mockDelegator,
-    });
-
-    const encodedContext = encodeDelegations([parentDelegation]);
-
-    const result = createDelegation({
-      environment: smartAccountEnvironment,
-      to: randomAddress(),
-      from: mockDelegate,
-      parentPermissionContext: encodedContext,
-      caveats: [mockCaveat],
-    });
-
-    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
-    expect(result.caveats).to.deep.equal([mockCaveat]);
-  });
-
-  it('should create an open delegation using parentPermissionContext', () => {
-    const parentDelegation = createDelegation({
-      environment: smartAccountEnvironment,
-      scope: erc20Scope,
-      to: mockDelegate,
-      from: mockDelegator,
-    });
-
-    const permissionContext = [parentDelegation];
-
-    const result = createOpenDelegation({
-      environment: smartAccountEnvironment,
-      from: mockDelegate,
-      parentPermissionContext: permissionContext,
-      caveats: [mockCaveat],
-    });
-
-    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
-    expect(result.delegate).to.equal(
-      '0x0000000000000000000000000000000000000a11', // ANY_BENEFICIARY
-    );
-    expect(result.caveats).to.deep.equal([mockCaveat]);
-  });
-
-  it('should inherit scope from parent when no scope is provided', () => {
-    const parentDelegation = createDelegation({
-      environment: smartAccountEnvironment,
-      scope: erc20Scope,
-      to: mockDelegate,
-      from: mockDelegator,
-    });
-
-    const permissionContext = [parentDelegation];
-
-    const result = createDelegation({
-      environment: smartAccountEnvironment,
-      to: randomAddress(),
-      from: mockDelegate,
-      parentPermissionContext: permissionContext,
-      // No scope provided - inherits from parent
-    });
-
-    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
-    // When no scope is provided, caveats should be empty (scope is inherited through the chain)
-    expect(result.caveats).to.deep.equal([]);
-  });
-
-  it('should allow scope override even with parent', () => {
-    const parentDelegation = createDelegation({
-      environment: smartAccountEnvironment,
-      scope: erc20Scope,
-      to: mockDelegate,
-      from: mockDelegator,
-    });
-
-    const permissionContext = [parentDelegation];
-
-    const differentErc20Scope = {
-      type: ScopeType.Erc20TransferAmount as const,
-      tokenAddress: '0xdffe000000000000000000000000000000000000' as const,
-      maxAmount: 5000n,
-    };
-
-    const result = createDelegation({
-      environment: smartAccountEnvironment,
-      to: randomAddress(),
-      from: mockDelegate,
-      parentPermissionContext: permissionContext,
-      scope: differentErc20Scope,
-    });
-
-    expect(result.authority).to.equal(resolveAuthority(parentDelegation));
-    // Should have new scope's caveats
-    expect(result.caveats.length).to.be.greaterThan(0);
-  });
-
-  it('should throw error if permission context is empty', () => {
-    const emptyContext: Delegation[] = [];
-
-    expect(() =>
-      createDelegation({
-        environment: smartAccountEnvironment,
-        to: randomAddress(),
-        from: mockDelegate,
-        parentPermissionContext: emptyContext,
-      }),
-    ).to.throw('Permission context must contain at least one delegation');
-  });
-
-  it('should extract leaf delegation from multi-delegation chain', () => {
-    const rootDelegation = createDelegation({
-      environment: smartAccountEnvironment,
-      scope: erc20Scope,
-      to: mockDelegate,
-      from: mockDelegator,
-    });
-
-    const childDelegation = createDelegation({
-      environment: smartAccountEnvironment,
-      to: randomAddress(),
-      from: mockDelegate,
-      parentDelegation: rootDelegation,
-      scope: erc20Scope,
-    });
-
-    // Chain ordered leaf to root
-    const permissionContext = [childDelegation, rootDelegation];
-
-    const result = createDelegation({
-      environment: smartAccountEnvironment,
-      to: randomAddress(),
-      from: randomAddress(),
-      parentPermissionContext: permissionContext,
-    });
-
-    // Should use childDelegation (leaf) as parent
-    expect(result.authority).to.equal(resolveAuthority(childDelegation));
   });
 });

--- a/packages/smart-accounts-kit/test/delegation.test.ts
+++ b/packages/smart-accounts-kit/test/delegation.test.ts
@@ -353,6 +353,16 @@ describe('createDelegation', () => {
     });
   });
 
+  it('throws if no scope no inheritance is provided', () => {
+    expect(() => {
+      createDelegation({
+        environment: smartAccountEnvironment,
+        to: mockDelegate,
+        from: mockDelegator,
+      } as any);
+    }).toThrow('Scope is required when the delegation has no inheritance');
+  });
+
   describe('parentPermissionContext support', () => {
     it('should create a delegation using parentPermissionContext with Delegation array', () => {
       const parentDelegation = createDelegation({
@@ -651,6 +661,15 @@ describe('createOpenDelegation', () => {
       salt: '0x00',
       signature: '0x',
     });
+  });
+
+  it('throws if no scope no inheritance is provided', () => {
+    expect(() => {
+      createOpenDelegation({
+        environment: smartAccountEnvironment,
+        from: mockDelegator,
+      } as any);
+    }).toThrow('Scope is required when the delegation has no inheritance');
   });
 
   describe('parentPermissionContext support', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

This PR implements support for creating redelegations from existing permission contexts (e.g., ERC-7715 responses), significantly improving the developer experience when working with delegation chains.

Previously, developers had to manually decode permission contexts, extract the leaf delegation, sign a new delegation, and re-encode the chain. This PR streamlines that workflow with new APIs and improved type safety.

## 🔄 What Changed?

### Core API Enhancements (`createDelegation` / `createOpenDelegation`)
- **Added `parentPermissionContext` parameter** to `createDelegation` and `createOpenDelegation`
  - Accepts a `PermissionContext` (either a `Delegation[]` or encoded `Hex`)
  - Automatically extracts the leaf delegation (first element in the chain) to use as the parent authority
  - Uses a discriminated union with `parentDelegation` and `scope` so the three options are mutually exclusive at the type level

- **Made `scope` optional** when a parent delegation/permission context exists
  - When redelegating, scope can be inherited from the parent
  - Scope constraints are still enforced through the parent's caveats in the chain
  - An explicit scope override is still supported when you want to add additional scope-derived caveats

- **`resolveCaveats` now takes `hasInheritance`**
  - Throws `Scope is required when the delegation has no inheritance` when scope is missing on a root delegation
  - When inheriting, falls back to a base caveat builder (no scope caveats appended)

### New Redelegation Actions
Two explicit, high-level convenience functions that handle the full redelegation workflow. They mirror the `createDelegation` / `createOpenDelegation` split so callers always get the kind of delegation they expect — no optional `to` flag deciding the shape of the result.

- **`redelegatePermissionContext`** — creates a redelegation to a **specific** delegate (`to` is required).
- **`redelegatePermissionContextOpen`** — creates an **open** redelegation (delegate is `ANY_BENEFICIARY`); does not accept `to`.

Both functions:

1. Decode the permission context
2. Extract the leaf delegation as the parent
3. Create a new delegation (specific or open) inheriting from it
4. Sign it via `signDelegation`
5. Prepend it to the chain and re-encode
6. Return both the signed `delegation` and the encoded `permissionContext`

Shared parameters:
- `account?` — defaults to `client.account`
- `environment` — provides `DelegationManager` and caveat enforcers
- `permissionContext` — the context to redelegate from
- `chainId` — chain id used for the EIP-712 signature
- `scope?` — optional override; inherits from parent when omitted
- `caveats?` — additional caveats to apply
- `salt?` — optional salt for uniqueness

`redelegatePermissionContext` additionally requires:
- `to` — the address of the new delegate

### Client Extension (`redelegatePermissionContextActions`)
- Follows the existing SDK pattern (e.g., `signDelegationActions`)
- Adds **both** `redelegatePermissionContext` and `redelegatePermissionContextOpen` to the wallet client when `.extend()`-ed
- Automatically infers `chainId` from `client.chain.id` for both actions (throws `Chain ID is required` if neither client chain nor `chainId` is provided)

### Type Safety
- The `BaseCreateDelegationOptions` type uses a discriminated union so exactly one of the following is allowed:
  - `scope` (root delegation, no parent)
  - `parentDelegation` (with optional `scope`)
  - `parentPermissionContext` (with optional `scope`)
- The two redelegation actions are independent functions with distinct parameter types (`RedelegatePermissionContextParameters` vs `RedelegatePermissionContextOpenParameters`), so the choice between specific and open is made at the call site rather than via an optional flag.

## 🚀 Why?

**Issue**: https://github.com/MetaMask/smart-accounts-kit/issues/196

Before this PR, redelegating from an ERC-7715 response required manual orchestration:

```typescript
const erc7715Response = {...};

const decodedContext = decodeDelegations(erc7715Response.context);
const leafDelegation = decodedContext[0];

const newDelegation = createDelegation({
  environment,
  scope: erc20Scope, // had to manually re-specify scope
  to: charlie.address,
  from: bob.address,
  parentDelegation: leafDelegation,
  caveats: [timestampCaveat],
});

const signature = await signDelegation(walletClient, {
  delegation: newDelegation,
  delegationManager: environment.DelegationManager,
  chainId: 11155111,
});

const signed = { ...newDelegation, signature };
const newContext = encodeDelegations([signed, ...decodedContext]);
```

Now, you can use the `parentPermissionContext` parameter on `createDelegation`:

```typescript
import {
  createDelegation,
  decodeDelegations,
  encodeDelegations,
  signDelegation,
} from '@metamask/smart-accounts-kit';

const erc7715Response = {...};

const redelegation = createDelegation({
  environment,
  from: bob.address,
  to: charlie.address,
  parentPermissionContext: erc7715Response.context,
  caveats: [timestampCaveat],
});

const signature = await signDelegation(walletClient, {
  delegation: redelegation,
  delegationManager: environment.DelegationManager,
  chainId: sepolia.id,
});

const newPermissionContext = encodeDelegations([
  { ...redelegation, signature },
  ...decodeDelegations(erc7715Response.context),
]);
```

Or, use the dedicated actions to redelegate directly:

```typescript
import { redelegatePermissionContextActions } from '@metamask/smart-accounts-kit/actions';
import { createWalletClient, http } from 'viem';
import { sepolia } from 'viem/chains';

const erc7715Response = {...};

const walletClient = createWalletClient({
  account: bob,
  chain: sepolia,
  transport: http(),
}).extend(redelegatePermissionContextActions());

const { delegation, permissionContext } =
  await walletClient.redelegatePermissionContext({
    environment,
    permissionContext: erc7715Response.context,
    to: charlie.address,
    caveats: [timestampCaveat],
  });

await sendUserOperationWithDelegation(client, {
  calls: [
    {
      to: contractAddress,
      data: callData,
      permissionContext,
      delegationManager: environment.DelegationManager,
    },
  ],
});
```
<!-- CURSOR_AGENT_PR_BODY_END -->