### PR TITLE
feat: add payee rule and LogicalOrWrapper enforcer

### DIFF
--- a/packages/delegation-core/src/caveats/index.ts
+++ b/packages/delegation-core/src/caveats/index.ts
@@ -101,3 +101,9 @@ export {
   createSpecificActionERC20TransferBatchTerms,
   decodeSpecificActionERC20TransferBatchTerms,
 } from './specificActionERC20TransferBatch';
+export {
+  createLogicalOrWrapperTerms,
+  decodeLogicalOrWrapperTerms,
+  createLogicalOrWrapperArgs,
+  decodeLogicalOrWrapperArgs,
+} from './logicalOrWrapper';

--- a/packages/delegation-core/src/caveats/logicalOrWrapper.ts
+++ b/packages/delegation-core/src/caveats/logicalOrWrapper.ts
@@ -58,6 +58,11 @@ export function createLogicalOrWrapperTerms(
   terms: LogicalOrWrapperTerms,
   encodingOptions: EncodingOptions<'bytes'>,
 ): Uint8Array;
+/**
+ * @param terms - The terms for the LogicalOrWrapper caveat.
+ * @param encodingOptions - The encoding options for the result.
+ * @returns Encoded terms.
+ */
 export function createLogicalOrWrapperTerms(
   terms: LogicalOrWrapperTerms,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
@@ -116,6 +121,11 @@ export function decodeLogicalOrWrapperTerms(
   terms: BytesLike,
   encodingOptions: EncodingOptions<'bytes'>,
 ): LogicalOrWrapperTerms<DecodedBytesLike<'bytes'>>;
+/**
+ * @param terms - The encoded terms as a hex string or Uint8Array.
+ * @param encodingOptions - Whether decoded values are returned as hex or bytes.
+ * @returns The decoded LogicalOrWrapperTerms object.
+ */
 export function decodeLogicalOrWrapperTerms(
   terms: BytesLike,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
@@ -158,6 +168,11 @@ export function createLogicalOrWrapperArgs(
   args: LogicalOrWrapperArgs,
   encodingOptions: EncodingOptions<'bytes'>,
 ): Uint8Array;
+/**
+ * @param args - The args containing the group index.
+ * @param encodingOptions - The encoding options for the result.
+ * @returns Encoded args.
+ */
 export function createLogicalOrWrapperArgs(
   args: LogicalOrWrapperArgs,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
@@ -176,8 +191,10 @@ export function createLogicalOrWrapperArgs(
  * @param args - The encoded args as a hex string or Uint8Array.
  * @returns The decoded LogicalOrWrapperArgs object.
  */
-export function decodeLogicalOrWrapperArgs(args: BytesLike): LogicalOrWrapperArgs {
+export function decodeLogicalOrWrapperArgs(
+  args: BytesLike,
+): LogicalOrWrapperArgs {
   const hexArgs = bytesLikeToHex(args);
-  const groupIndex = decodeSingle(GROUP_INDEX_ABI, hexArgs) as bigint;
+  const groupIndex = decodeSingle(GROUP_INDEX_ABI, hexArgs);
   return { groupIndex };
 }

--- a/packages/delegation-core/src/caveats/logicalOrWrapper.ts
+++ b/packages/delegation-core/src/caveats/logicalOrWrapper.ts
@@ -1,13 +1,11 @@
 /**
  * ## LogicalOrWrapperEnforcer
  *
- * Wraps multiple groups of caveats in a logical OR — redemption succeeds if any single group passes.
+ * Wraps multiple caveat groups in a logical OR: redemption evaluates exactly one group, which passes only if every caveat in that group passes.
  *
- * Terms are ABI-encoded as `((address,bytes,bytes)[])[]` — an array of `CaveatGroup` structs,
- * each containing an array of `Caveat(enforcer, terms, args)`.
+ * Terms are encoded as ABI-encoded `CaveatGroup[]`, i.e. `((address,bytes,bytes)[])[]`, matching Solidity `CaveatGroup` / `Caveat`.
  *
- * Args are ABI-encoded as `(uint256,bytes[])` — a `SelectedGroup` struct with the group index
- * and per-caveat arguments.
+ * Args are encoded as ABI-encoded `(uint256 groupIndex, bytes[] caveatArgs)` (`SelectedGroup`). On redemption, `groupIndex` must be less than the number of groups and `caveatArgs.length` must match the caveat count of the chosen group. Each child enforcer receives `Caveat.terms` from the encoded group and hook args from `caveatArgs[i]` (not `Caveat.args` in terms). If groups differ in restrictiveness, the redeemer can choose the weakest valid group.
  */
 
 import { decodeSingle, encodeSingle } from '@metamask/abi-utils';
@@ -28,7 +26,7 @@ import type { CaveatStruct, Hex } from '../types';
  * Terms for configuring a LogicalOrWrapper caveat.
  */
 export type LogicalOrWrapperTerms<TBytesLike extends BytesLike = BytesLike> = {
-  /** An array of caveat groups — redemption succeeds if any single group passes. */
+  /** An array of caveat groups — redemption evaluates exactly one group via args. */
   caveatGroups: CaveatStruct<TBytesLike>[][];
 };
 
@@ -36,14 +34,64 @@ export type LogicalOrWrapperTerms<TBytesLike extends BytesLike = BytesLike> = {
  * Args for a LogicalOrWrapper caveat at redemption time.
  */
 export type LogicalOrWrapperArgs<TBytesLike extends BytesLike = BytesLike> = {
-  /** The zero-based index of the caveat group to evaluate. */
+  /** Zero-based index into `terms.caveatGroups`; must be `< caveatGroups.length` on-chain. */
   groupIndex: bigint;
-  /** Per-caveat arguments for each caveat in the selected group. */
+  /** One redemption-time arg blob per caveat in the selected group; length must match that group on-chain. */
   caveatArgs: TBytesLike[];
 };
 
 const CAVEAT_GROUPS_ABI = '((address,bytes,bytes)[])[]';
 const SELECTED_GROUP_ABI = '(uint256,bytes[])';
+
+type EncodedCaveatRow = readonly [string, string, string];
+
+/**
+ * Ensures there is at least one group and each group has at least one caveat.
+ *
+ * @param groups - Caveat groups from caller input.
+ */
+function assertValidCaveatGroups(groups: CaveatStruct[][]): void {
+  if (!groups?.length) {
+    throw new Error(
+      'Invalid caveatGroups: must provide at least one caveat group',
+    );
+  }
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i];
+    if (!group?.length) {
+      throw new Error(
+        `Invalid caveatGroups: group at index ${i} must contain at least one caveat`,
+      );
+    }
+  }
+}
+
+/**
+ * Builds one ABI `(address,bytes,bytes)` caveat tuple from structured input.
+ *
+ * @param caveat - Caveat fields to normalize.
+ * @returns Tuple accepted by `@metamask/abi-utils` encoders.
+ */
+function normalizeCaveatTuple(caveat: CaveatStruct): EncodedCaveatRow {
+  return [
+    normalizeAddress(
+      caveat.enforcer,
+      'Invalid enforcer: must be a valid address',
+    ),
+    normalizeHex(caveat.terms, 'Invalid terms: must be a valid hex string'),
+    normalizeHex(caveat.args, 'Invalid args: must be a valid hex string'),
+  ];
+}
+
+/**
+ * Encodes one `CaveatGroup` as ABI `tuple(Caveat[] caveats)`.
+ *
+ * @param group - Caveats belonging to this OR-branch.
+ * @returns Single-element tuple wrapping the inner caveat array (Solidity layout).
+ */
+function encodeCaveatGroupTuple(group: CaveatStruct[]): [EncodedCaveatRow[]] {
+  return [group.map(normalizeCaveatTuple)];
+}
 
 /**
  * Creates terms for a LogicalOrWrapper caveat.
@@ -62,55 +110,26 @@ export function createLogicalOrWrapperTerms(
   encodingOptions: EncodingOptions<'bytes'>,
 ): Uint8Array;
 /**
+ * Creates terms for a LogicalOrWrapper caveat.
+ *
  * @param terms - The terms for the LogicalOrWrapper caveat.
  * @param encodingOptions - The encoding options for the result.
  * @returns Encoded terms.
+ * @throws Error if caveatGroups is empty or contains invalid data.
  */
 export function createLogicalOrWrapperTerms(
   terms: LogicalOrWrapperTerms,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
-  const { caveatGroups } = terms;
+  assertValidCaveatGroups(terms.caveatGroups);
 
-  if (!caveatGroups || caveatGroups.length === 0) {
-    throw new Error(
-      'Invalid caveatGroups: must provide at least one caveat group',
-    );
-  }
-
-  for (let i = 0; i < caveatGroups.length; i++) {
-    const group = caveatGroups[i];
-    if (!group || group.length === 0) {
-      throw new Error(
-        `Invalid caveatGroups: group at index ${i} must contain at least one caveat`,
-      );
-    }
-  }
-
-  const encodableGroups = caveatGroups.map((group) => [
-    group.map((caveat) => {
-      const enforcer = normalizeAddress(
-        caveat.enforcer,
-        'Invalid enforcer: must be a valid address',
-      );
-      const termsHex = normalizeHex(
-        caveat.terms,
-        'Invalid terms: must be a valid hex string',
-      );
-      const argsHex = normalizeHex(
-        caveat.args,
-        'Invalid args: must be a valid hex string',
-      );
-      return [enforcer, termsHex, argsHex];
-    }),
-  ]);
-
+  const encodableGroups = terms.caveatGroups.map(encodeCaveatGroupTuple);
   const hexValue = encodeSingle(CAVEAT_GROUPS_ABI, encodableGroups);
   return prepareResult(hexValue, encodingOptions);
 }
 
 /**
- * Decodes terms for a LogicalOrWrapper caveat from encoded data.
+ * Decodes terms for a LogicalOrWrapper caveat from encoded hex data.
  *
  * @param terms - The encoded terms as a hex string or Uint8Array.
  * @param encodingOptions - Whether decoded values are returned as hex or bytes.
@@ -136,10 +155,10 @@ export function decodeLogicalOrWrapperTerms(
   | LogicalOrWrapperTerms<DecodedBytesLike<'hex'>>
   | LogicalOrWrapperTerms<DecodedBytesLike<'bytes'>> {
   const hexTerms = bytesLikeToHex(terms);
-
-  const decoded = decodeSingle(CAVEAT_GROUPS_ABI, hexTerms) as [
-    [string, Uint8Array, Uint8Array][],
-  ][];
+  const decoded = decodeSingle(
+    CAVEAT_GROUPS_ABI,
+    hexTerms,
+  ) as unknown as readonly [readonly [string, Uint8Array, Uint8Array][]][];
 
   const caveatGroups = decoded.map(([caveats]) =>
     caveats.map(([enforcer, caveatTerms, args]) => ({
@@ -155,11 +174,12 @@ export function decodeLogicalOrWrapperTerms(
 }
 
 /**
- * Creates args for a LogicalOrWrapper caveat specifying which group to evaluate.
+ * Creates args for a LogicalOrWrapper caveat that selects which group to evaluate.
  *
- * @param args - The args containing the group index and per-caveat arguments.
+ * @param args - The group index and per-caveat arguments for redemption.
  * @param encodingOptions - The encoding options for the result.
  * @returns Encoded args.
+ * @throws Error if groupIndex is negative or caveatArgs entries are invalid hex.
  */
 export function createLogicalOrWrapperArgs(
   args: LogicalOrWrapperArgs,
@@ -170,9 +190,12 @@ export function createLogicalOrWrapperArgs(
   encodingOptions: EncodingOptions<'bytes'>,
 ): Uint8Array;
 /**
- * @param args - The args containing the group index and per-caveat arguments.
+ * Creates args for a LogicalOrWrapper caveat that selects which group to evaluate.
+ *
+ * @param args - The group index and per-caveat arguments for redemption.
  * @param encodingOptions - The encoding options for the result.
  * @returns Encoded args.
+ * @throws Error if groupIndex is negative or caveatArgs entries are invalid hex.
  */
 export function createLogicalOrWrapperArgs(
   args: LogicalOrWrapperArgs,
@@ -194,7 +217,7 @@ export function createLogicalOrWrapperArgs(
 }
 
 /**
- * Decodes args for a LogicalOrWrapper caveat.
+ * Decodes args for a LogicalOrWrapper caveat from encoded hex data.
  *
  * @param args - The encoded args as a hex string or Uint8Array.
  * @param encodingOptions - Whether decoded values are returned as hex or bytes.

--- a/packages/delegation-core/src/caveats/logicalOrWrapper.ts
+++ b/packages/delegation-core/src/caveats/logicalOrWrapper.ts
@@ -1,0 +1,183 @@
+/**
+ * ## LogicalOrWrapperEnforcer
+ *
+ * Wraps multiple groups of caveats in a logical OR — redemption succeeds if any single group passes.
+ *
+ * Terms are ABI-encoded as `(address,bytes,bytes)[][]`, an array of caveat groups where each
+ * caveat is `(enforcer, terms, args)`.
+ *
+ * Args are ABI-encoded as `uint256`, the index of the caveat group to evaluate.
+ */
+
+import { decodeSingle, encodeSingle } from '@metamask/abi-utils';
+import { bytesToHex, type BytesLike } from '@metamask/utils';
+
+import { normalizeAddress, normalizeHex } from '../internalUtils';
+import {
+  bytesLikeToHex,
+  defaultOptions,
+  prepareResult,
+  type DecodedBytesLike,
+  type EncodingOptions,
+  type ResultValue,
+} from '../returns';
+import type { CaveatStruct, Hex } from '../types';
+
+/**
+ * Terms for configuring a LogicalOrWrapper caveat.
+ */
+export type LogicalOrWrapperTerms<TBytesLike extends BytesLike = BytesLike> = {
+  /** An array of caveat groups — redemption succeeds if any single group passes. */
+  caveatGroups: CaveatStruct<TBytesLike>[][];
+};
+
+/**
+ * Args for a LogicalOrWrapper caveat at redemption time.
+ */
+export type LogicalOrWrapperArgs = {
+  /** The zero-based index of the caveat group to evaluate. */
+  groupIndex: bigint;
+};
+
+const CAVEAT_GROUPS_ABI = '(address,bytes,bytes)[][]';
+const GROUP_INDEX_ABI = 'uint256';
+
+/**
+ * Creates terms for a LogicalOrWrapper caveat.
+ *
+ * @param terms - The terms for the LogicalOrWrapper caveat.
+ * @param encodingOptions - The encoding options for the result.
+ * @returns Encoded terms.
+ * @throws Error if caveatGroups is empty or contains invalid data.
+ */
+export function createLogicalOrWrapperTerms(
+  terms: LogicalOrWrapperTerms,
+  encodingOptions?: EncodingOptions<'hex'>,
+): Hex;
+export function createLogicalOrWrapperTerms(
+  terms: LogicalOrWrapperTerms,
+  encodingOptions: EncodingOptions<'bytes'>,
+): Uint8Array;
+export function createLogicalOrWrapperTerms(
+  terms: LogicalOrWrapperTerms,
+  encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
+): Hex | Uint8Array {
+  const { caveatGroups } = terms;
+
+  if (!caveatGroups || caveatGroups.length === 0) {
+    throw new Error(
+      'Invalid caveatGroups: must provide at least one caveat group',
+    );
+  }
+
+  for (let i = 0; i < caveatGroups.length; i++) {
+    const group = caveatGroups[i];
+    if (!group || group.length === 0) {
+      throw new Error(
+        `Invalid caveatGroups: group at index ${i} must contain at least one caveat`,
+      );
+    }
+  }
+
+  const encodableGroups = caveatGroups.map((group) =>
+    group.map((caveat) => {
+      const enforcer = normalizeAddress(
+        caveat.enforcer,
+        'Invalid enforcer: must be a valid address',
+      );
+      const termsHex = normalizeHex(
+        caveat.terms,
+        'Invalid terms: must be a valid hex string',
+      );
+      const argsHex = normalizeHex(
+        caveat.args,
+        'Invalid args: must be a valid hex string',
+      );
+      return [enforcer, termsHex, argsHex];
+    }),
+  );
+
+  const hexValue = encodeSingle(CAVEAT_GROUPS_ABI, encodableGroups);
+  return prepareResult(hexValue, encodingOptions);
+}
+
+/**
+ * Decodes terms for a LogicalOrWrapper caveat from encoded data.
+ *
+ * @param terms - The encoded terms as a hex string or Uint8Array.
+ * @param encodingOptions - Whether decoded values are returned as hex or bytes.
+ * @returns The decoded LogicalOrWrapperTerms object.
+ */
+export function decodeLogicalOrWrapperTerms(
+  terms: BytesLike,
+  encodingOptions?: EncodingOptions<'hex'>,
+): LogicalOrWrapperTerms<DecodedBytesLike<'hex'>>;
+export function decodeLogicalOrWrapperTerms(
+  terms: BytesLike,
+  encodingOptions: EncodingOptions<'bytes'>,
+): LogicalOrWrapperTerms<DecodedBytesLike<'bytes'>>;
+export function decodeLogicalOrWrapperTerms(
+  terms: BytesLike,
+  encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
+):
+  | LogicalOrWrapperTerms<DecodedBytesLike<'hex'>>
+  | LogicalOrWrapperTerms<DecodedBytesLike<'bytes'>> {
+  const hexTerms = bytesLikeToHex(terms);
+
+  const decoded = decodeSingle(CAVEAT_GROUPS_ABI, hexTerms) as [
+    string,
+    Uint8Array,
+    Uint8Array,
+  ][][];
+
+  const caveatGroups = decoded.map((group) =>
+    group.map(([enforcer, caveatTerms, args]) => ({
+      enforcer: prepareResult(enforcer, encodingOptions),
+      terms: prepareResult(bytesToHex(caveatTerms), encodingOptions),
+      args: prepareResult(bytesToHex(args), encodingOptions),
+    })),
+  );
+
+  return { caveatGroups } as
+    | LogicalOrWrapperTerms<DecodedBytesLike<'hex'>>
+    | LogicalOrWrapperTerms<DecodedBytesLike<'bytes'>>;
+}
+
+/**
+ * Creates args for a LogicalOrWrapper caveat specifying which group to evaluate.
+ *
+ * @param args - The args containing the group index.
+ * @param encodingOptions - The encoding options for the result.
+ * @returns Encoded args.
+ */
+export function createLogicalOrWrapperArgs(
+  args: LogicalOrWrapperArgs,
+  encodingOptions?: EncodingOptions<'hex'>,
+): Hex;
+export function createLogicalOrWrapperArgs(
+  args: LogicalOrWrapperArgs,
+  encodingOptions: EncodingOptions<'bytes'>,
+): Uint8Array;
+export function createLogicalOrWrapperArgs(
+  args: LogicalOrWrapperArgs,
+  encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
+): Hex | Uint8Array {
+  if (args.groupIndex < 0n) {
+    throw new Error('Invalid groupIndex: must be a non-negative number');
+  }
+
+  const hexValue = encodeSingle(GROUP_INDEX_ABI, args.groupIndex);
+  return prepareResult(hexValue, encodingOptions);
+}
+
+/**
+ * Decodes args for a LogicalOrWrapper caveat.
+ *
+ * @param args - The encoded args as a hex string or Uint8Array.
+ * @returns The decoded LogicalOrWrapperArgs object.
+ */
+export function decodeLogicalOrWrapperArgs(args: BytesLike): LogicalOrWrapperArgs {
+  const hexArgs = bytesLikeToHex(args);
+  const groupIndex = decodeSingle(GROUP_INDEX_ABI, hexArgs) as bigint;
+  return { groupIndex };
+}

--- a/packages/delegation-core/src/caveats/logicalOrWrapper.ts
+++ b/packages/delegation-core/src/caveats/logicalOrWrapper.ts
@@ -3,10 +3,11 @@
  *
  * Wraps multiple groups of caveats in a logical OR — redemption succeeds if any single group passes.
  *
- * Terms are ABI-encoded as `(address,bytes,bytes)[][]`, an array of caveat groups where each
- * caveat is `(enforcer, terms, args)`.
+ * Terms are ABI-encoded as `((address,bytes,bytes)[])[]` — an array of `CaveatGroup` structs,
+ * each containing an array of `Caveat(enforcer, terms, args)`.
  *
- * Args are ABI-encoded as `uint256`, the index of the caveat group to evaluate.
+ * Args are ABI-encoded as `(uint256,bytes[])` — a `SelectedGroup` struct with the group index
+ * and per-caveat arguments.
  */
 
 import { decodeSingle, encodeSingle } from '@metamask/abi-utils';
@@ -34,13 +35,15 @@ export type LogicalOrWrapperTerms<TBytesLike extends BytesLike = BytesLike> = {
 /**
  * Args for a LogicalOrWrapper caveat at redemption time.
  */
-export type LogicalOrWrapperArgs = {
+export type LogicalOrWrapperArgs<TBytesLike extends BytesLike = BytesLike> = {
   /** The zero-based index of the caveat group to evaluate. */
   groupIndex: bigint;
+  /** Per-caveat arguments for each caveat in the selected group. */
+  caveatArgs: TBytesLike[];
 };
 
-const CAVEAT_GROUPS_ABI = '(address,bytes,bytes)[][]';
-const GROUP_INDEX_ABI = 'uint256';
+const CAVEAT_GROUPS_ABI = '((address,bytes,bytes)[])[]';
+const SELECTED_GROUP_ABI = '(uint256,bytes[])';
 
 /**
  * Creates terms for a LogicalOrWrapper caveat.
@@ -84,7 +87,7 @@ export function createLogicalOrWrapperTerms(
     }
   }
 
-  const encodableGroups = caveatGroups.map((group) =>
+  const encodableGroups = caveatGroups.map((group) => [
     group.map((caveat) => {
       const enforcer = normalizeAddress(
         caveat.enforcer,
@@ -100,7 +103,7 @@ export function createLogicalOrWrapperTerms(
       );
       return [enforcer, termsHex, argsHex];
     }),
-  );
+  ]);
 
   const hexValue = encodeSingle(CAVEAT_GROUPS_ABI, encodableGroups);
   return prepareResult(hexValue, encodingOptions);
@@ -135,13 +138,11 @@ export function decodeLogicalOrWrapperTerms(
   const hexTerms = bytesLikeToHex(terms);
 
   const decoded = decodeSingle(CAVEAT_GROUPS_ABI, hexTerms) as [
-    string,
-    Uint8Array,
-    Uint8Array,
-  ][][];
+    [string, Uint8Array, Uint8Array][],
+  ][];
 
-  const caveatGroups = decoded.map((group) =>
-    group.map(([enforcer, caveatTerms, args]) => ({
+  const caveatGroups = decoded.map(([caveats]) =>
+    caveats.map(([enforcer, caveatTerms, args]) => ({
       enforcer: prepareResult(enforcer, encodingOptions),
       terms: prepareResult(bytesToHex(caveatTerms), encodingOptions),
       args: prepareResult(bytesToHex(args), encodingOptions),
@@ -156,7 +157,7 @@ export function decodeLogicalOrWrapperTerms(
 /**
  * Creates args for a LogicalOrWrapper caveat specifying which group to evaluate.
  *
- * @param args - The args containing the group index.
+ * @param args - The args containing the group index and per-caveat arguments.
  * @param encodingOptions - The encoding options for the result.
  * @returns Encoded args.
  */
@@ -169,7 +170,7 @@ export function createLogicalOrWrapperArgs(
   encodingOptions: EncodingOptions<'bytes'>,
 ): Uint8Array;
 /**
- * @param args - The args containing the group index.
+ * @param args - The args containing the group index and per-caveat arguments.
  * @param encodingOptions - The encoding options for the result.
  * @returns Encoded args.
  */
@@ -181,7 +182,14 @@ export function createLogicalOrWrapperArgs(
     throw new Error('Invalid groupIndex: must be a non-negative number');
   }
 
-  const hexValue = encodeSingle(GROUP_INDEX_ABI, args.groupIndex);
+  const caveatArgsHex = args.caveatArgs.map((arg) =>
+    normalizeHex(arg, 'Invalid caveatArgs: must be valid hex strings'),
+  );
+
+  const hexValue = encodeSingle(SELECTED_GROUP_ABI, [
+    args.groupIndex,
+    caveatArgsHex,
+  ]);
   return prepareResult(hexValue, encodingOptions);
 }
 
@@ -189,12 +197,39 @@ export function createLogicalOrWrapperArgs(
  * Decodes args for a LogicalOrWrapper caveat.
  *
  * @param args - The encoded args as a hex string or Uint8Array.
+ * @param encodingOptions - Whether decoded values are returned as hex or bytes.
  * @returns The decoded LogicalOrWrapperArgs object.
  */
 export function decodeLogicalOrWrapperArgs(
   args: BytesLike,
-): LogicalOrWrapperArgs {
+  encodingOptions?: EncodingOptions<'hex'>,
+): LogicalOrWrapperArgs<DecodedBytesLike<'hex'>>;
+export function decodeLogicalOrWrapperArgs(
+  args: BytesLike,
+  encodingOptions: EncodingOptions<'bytes'>,
+): LogicalOrWrapperArgs<DecodedBytesLike<'bytes'>>;
+/**
+ * @param args - The encoded args as a hex string or Uint8Array.
+ * @param encodingOptions - Whether decoded values are returned as hex or bytes.
+ * @returns The decoded LogicalOrWrapperArgs object.
+ */
+export function decodeLogicalOrWrapperArgs(
+  args: BytesLike,
+  encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
+):
+  | LogicalOrWrapperArgs<DecodedBytesLike<'hex'>>
+  | LogicalOrWrapperArgs<DecodedBytesLike<'bytes'>> {
   const hexArgs = bytesLikeToHex(args);
-  const groupIndex = decodeSingle(GROUP_INDEX_ABI, hexArgs);
-  return { groupIndex };
+  const [groupIndex, caveatArgsRaw] = decodeSingle(
+    SELECTED_GROUP_ABI,
+    hexArgs,
+  ) as [bigint, Uint8Array[]];
+
+  const caveatArgs = caveatArgsRaw.map((arg) =>
+    prepareResult(bytesToHex(arg), encodingOptions),
+  );
+
+  return { groupIndex, caveatArgs } as
+    | LogicalOrWrapperArgs<DecodedBytesLike<'hex'>>
+    | LogicalOrWrapperArgs<DecodedBytesLike<'bytes'>>;
 }

--- a/packages/delegation-core/src/index.ts
+++ b/packages/delegation-core/src/index.ts
@@ -69,6 +69,10 @@ export {
   decodeRedeemerTerms,
   createSpecificActionERC20TransferBatchTerms,
   decodeSpecificActionERC20TransferBatchTerms,
+  createLogicalOrWrapperTerms,
+  decodeLogicalOrWrapperTerms,
+  createLogicalOrWrapperArgs,
+  decodeLogicalOrWrapperArgs,
 } from './caveats';
 
 export {

--- a/packages/delegation-core/test/caveats/logicalOrWrapper.test.ts
+++ b/packages/delegation-core/test/caveats/logicalOrWrapper.test.ts
@@ -27,12 +27,14 @@ describe('LogicalOrWrapper', () => {
     it('creates valid terms for caveat groups', () => {
       const result = createLogicalOrWrapperTerms({ caveatGroups });
       const expected = bytesToHex(
-        encodeSingle('(address,bytes,bytes)[][]', [
+        encodeSingle('((address,bytes,bytes)[])[]', [
           [
-            [enforcerA, '0x1234', '0x00'],
-            [enforcerB, '0x5678', '0x00'],
+            [
+              [enforcerA, '0x1234', '0x00'],
+              [enforcerB, '0x5678', '0x00'],
+            ],
           ],
-          [[enforcerC, '0xabcd', '0x00']],
+          [[[enforcerC, '0xabcd', '0x00']]],
         ]),
       );
 
@@ -95,29 +97,39 @@ describe('LogicalOrWrapper', () => {
   });
 
   describe('createLogicalOrWrapperArgs', () => {
-    it('encodes group index', () => {
-      const result = createLogicalOrWrapperArgs({ groupIndex: 0n });
-      const expected = bytesToHex(encodeSingle('uint256', 0n));
+    it('encodes group index and caveat args', () => {
+      const result = createLogicalOrWrapperArgs({
+        groupIndex: 0n,
+        caveatArgs: ['0xaa' as Hex, '0xbb' as Hex],
+      });
+      const expected = bytesToHex(
+        encodeSingle('(uint256,bytes[])', [0n, ['0xaa', '0xbb']]),
+      );
 
       expect(result).toStrictEqual(expected);
     });
 
     it('encodes non-zero group index', () => {
-      const result = createLogicalOrWrapperArgs({ groupIndex: 1n });
-      const expected = bytesToHex(encodeSingle('uint256', 1n));
+      const result = createLogicalOrWrapperArgs({
+        groupIndex: 1n,
+        caveatArgs: ['0x00' as Hex],
+      });
+      const expected = bytesToHex(
+        encodeSingle('(uint256,bytes[])', [1n, ['0x00']]),
+      );
 
       expect(result).toStrictEqual(expected);
     });
 
     it('throws for negative group index', () => {
-      expect(() => createLogicalOrWrapperArgs({ groupIndex: -1n })).toThrow(
-        'Invalid groupIndex: must be a non-negative number',
-      );
+      expect(() =>
+        createLogicalOrWrapperArgs({ groupIndex: -1n, caveatArgs: [] }),
+      ).toThrow('Invalid groupIndex: must be a non-negative number');
     });
 
     it('returns Uint8Array when bytes encoding is specified', () => {
       const result = createLogicalOrWrapperArgs(
-        { groupIndex: 0n },
+        { groupIndex: 0n, caveatArgs: ['0x00' as Hex] },
         { out: 'bytes' },
       );
 
@@ -127,17 +139,29 @@ describe('LogicalOrWrapper', () => {
 
   describe('decodeLogicalOrWrapperArgs', () => {
     it('round-trips through encode and decode', () => {
-      const original = { groupIndex: 1n };
+      const original = {
+        groupIndex: 1n,
+        caveatArgs: ['0xaa' as Hex, '0xbb' as Hex],
+      };
       expect(
         decodeLogicalOrWrapperArgs(createLogicalOrWrapperArgs(original)),
       ).toStrictEqual(original);
     });
 
-    it('decodes zero index', () => {
-      const encoded = createLogicalOrWrapperArgs({ groupIndex: 0n });
-      expect(decodeLogicalOrWrapperArgs(encoded)).toStrictEqual({
+    it('decodes zero index with empty caveat args', () => {
+      const original = { groupIndex: 0n, caveatArgs: [] as Hex[] };
+      const encoded = createLogicalOrWrapperArgs(original);
+      expect(decodeLogicalOrWrapperArgs(encoded)).toStrictEqual(original);
+    });
+
+    it('returns bytes when bytes encoding is specified', () => {
+      const encoded = createLogicalOrWrapperArgs({
         groupIndex: 0n,
+        caveatArgs: ['0xaa' as Hex],
       });
+      const decoded = decodeLogicalOrWrapperArgs(encoded, { out: 'bytes' });
+
+      expect(decoded.caveatArgs[0]).toBeInstanceOf(Uint8Array);
     });
   });
 });

--- a/packages/delegation-core/test/caveats/logicalOrWrapper.test.ts
+++ b/packages/delegation-core/test/caveats/logicalOrWrapper.test.ts
@@ -20,9 +20,7 @@ describe('LogicalOrWrapper', () => {
       { enforcer: enforcerA, terms: '0x1234' as Hex, args: '0x00' as Hex },
       { enforcer: enforcerB, terms: '0x5678' as Hex, args: '0x00' as Hex },
     ],
-    [
-      { enforcer: enforcerC, terms: '0xabcd' as Hex, args: '0x00' as Hex },
-    ],
+    [{ enforcer: enforcerC, terms: '0xabcd' as Hex, args: '0x00' as Hex }],
   ];
 
   describe('createLogicalOrWrapperTerms', () => {
@@ -42,15 +40,13 @@ describe('LogicalOrWrapper', () => {
     });
 
     it('throws for empty caveatGroups array', () => {
-      expect(() =>
-        createLogicalOrWrapperTerms({ caveatGroups: [] }),
-      ).toThrow('Invalid caveatGroups: must provide at least one caveat group');
+      expect(() => createLogicalOrWrapperTerms({ caveatGroups: [] })).toThrow(
+        'Invalid caveatGroups: must provide at least one caveat group',
+      );
     });
 
     it('throws for empty group within caveatGroups', () => {
-      expect(() =>
-        createLogicalOrWrapperTerms({ caveatGroups: [[]] }),
-      ).toThrow(
+      expect(() => createLogicalOrWrapperTerms({ caveatGroups: [[]] })).toThrow(
         'Invalid caveatGroups: group at index 0 must contain at least one caveat',
       );
     });
@@ -58,9 +54,7 @@ describe('LogicalOrWrapper', () => {
     it('throws for invalid enforcer address', () => {
       expect(() =>
         createLogicalOrWrapperTerms({
-          caveatGroups: [
-            [{ enforcer: '0x1234', terms: '0x00', args: '0x00' }],
-          ],
+          caveatGroups: [[{ enforcer: '0x1234', terms: '0x00', args: '0x00' }]],
         }),
       ).toThrow('Invalid enforcer: must be a valid address');
     });
@@ -79,9 +73,7 @@ describe('LogicalOrWrapper', () => {
     it('round-trips through encode and decode', () => {
       const original = { caveatGroups };
       expect(
-        decodeLogicalOrWrapperTerms(
-          createLogicalOrWrapperTerms(original),
-        ),
+        decodeLogicalOrWrapperTerms(createLogicalOrWrapperTerms(original)),
       ).toStrictEqual(original);
     });
 
@@ -95,9 +87,10 @@ describe('LogicalOrWrapper', () => {
       const encoded = createLogicalOrWrapperTerms({ caveatGroups });
       const decoded = decodeLogicalOrWrapperTerms(encoded, { out: 'bytes' });
 
-      expect(decoded.caveatGroups[0]![0]!.enforcer).toBeInstanceOf(Uint8Array);
-      expect(decoded.caveatGroups[0]![0]!.terms).toBeInstanceOf(Uint8Array);
-      expect(decoded.caveatGroups[0]![0]!.args).toBeInstanceOf(Uint8Array);
+      const firstCaveat = decoded.caveatGroups[0]?.[0];
+      expect(firstCaveat?.enforcer).toBeInstanceOf(Uint8Array);
+      expect(firstCaveat?.terms).toBeInstanceOf(Uint8Array);
+      expect(firstCaveat?.args).toBeInstanceOf(Uint8Array);
     });
   });
 
@@ -117,9 +110,9 @@ describe('LogicalOrWrapper', () => {
     });
 
     it('throws for negative group index', () => {
-      expect(() =>
-        createLogicalOrWrapperArgs({ groupIndex: -1n }),
-      ).toThrow('Invalid groupIndex: must be a non-negative number');
+      expect(() => createLogicalOrWrapperArgs({ groupIndex: -1n })).toThrow(
+        'Invalid groupIndex: must be a non-negative number',
+      );
     });
 
     it('returns Uint8Array when bytes encoding is specified', () => {

--- a/packages/delegation-core/test/caveats/logicalOrWrapper.test.ts
+++ b/packages/delegation-core/test/caveats/logicalOrWrapper.test.ts
@@ -1,0 +1,150 @@
+import { encodeSingle } from '@metamask/abi-utils';
+import { bytesToHex } from '@metamask/utils';
+import { describe, it, expect } from 'vitest';
+
+import {
+  createLogicalOrWrapperTerms,
+  decodeLogicalOrWrapperTerms,
+  createLogicalOrWrapperArgs,
+  decodeLogicalOrWrapperArgs,
+} from '../../src/caveats/logicalOrWrapper';
+import type { Hex } from '../../src/types';
+
+describe('LogicalOrWrapper', () => {
+  const enforcerA: Hex = '0x0000000000000000000000000000000000000001';
+  const enforcerB: Hex = '0x0000000000000000000000000000000000000002';
+  const enforcerC: Hex = '0x0000000000000000000000000000000000000003';
+
+  const caveatGroups = [
+    [
+      { enforcer: enforcerA, terms: '0x1234' as Hex, args: '0x00' as Hex },
+      { enforcer: enforcerB, terms: '0x5678' as Hex, args: '0x00' as Hex },
+    ],
+    [
+      { enforcer: enforcerC, terms: '0xabcd' as Hex, args: '0x00' as Hex },
+    ],
+  ];
+
+  describe('createLogicalOrWrapperTerms', () => {
+    it('creates valid terms for caveat groups', () => {
+      const result = createLogicalOrWrapperTerms({ caveatGroups });
+      const expected = bytesToHex(
+        encodeSingle('(address,bytes,bytes)[][]', [
+          [
+            [enforcerA, '0x1234', '0x00'],
+            [enforcerB, '0x5678', '0x00'],
+          ],
+          [[enforcerC, '0xabcd', '0x00']],
+        ]),
+      );
+
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('throws for empty caveatGroups array', () => {
+      expect(() =>
+        createLogicalOrWrapperTerms({ caveatGroups: [] }),
+      ).toThrow('Invalid caveatGroups: must provide at least one caveat group');
+    });
+
+    it('throws for empty group within caveatGroups', () => {
+      expect(() =>
+        createLogicalOrWrapperTerms({ caveatGroups: [[]] }),
+      ).toThrow(
+        'Invalid caveatGroups: group at index 0 must contain at least one caveat',
+      );
+    });
+
+    it('throws for invalid enforcer address', () => {
+      expect(() =>
+        createLogicalOrWrapperTerms({
+          caveatGroups: [
+            [{ enforcer: '0x1234', terms: '0x00', args: '0x00' }],
+          ],
+        }),
+      ).toThrow('Invalid enforcer: must be a valid address');
+    });
+
+    it('returns Uint8Array when bytes encoding is specified', () => {
+      const result = createLogicalOrWrapperTerms(
+        { caveatGroups },
+        { out: 'bytes' },
+      );
+
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('decodeLogicalOrWrapperTerms', () => {
+    it('round-trips through encode and decode', () => {
+      const original = { caveatGroups };
+      expect(
+        decodeLogicalOrWrapperTerms(
+          createLogicalOrWrapperTerms(original),
+        ),
+      ).toStrictEqual(original);
+    });
+
+    it('accepts Uint8Array terms from the encoder', () => {
+      const original = { caveatGroups };
+      const bytes = createLogicalOrWrapperTerms(original, { out: 'bytes' });
+      expect(decodeLogicalOrWrapperTerms(bytes)).toStrictEqual(original);
+    });
+
+    it('returns bytes when bytes encoding is specified', () => {
+      const encoded = createLogicalOrWrapperTerms({ caveatGroups });
+      const decoded = decodeLogicalOrWrapperTerms(encoded, { out: 'bytes' });
+
+      expect(decoded.caveatGroups[0]![0]!.enforcer).toBeInstanceOf(Uint8Array);
+      expect(decoded.caveatGroups[0]![0]!.terms).toBeInstanceOf(Uint8Array);
+      expect(decoded.caveatGroups[0]![0]!.args).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('createLogicalOrWrapperArgs', () => {
+    it('encodes group index', () => {
+      const result = createLogicalOrWrapperArgs({ groupIndex: 0n });
+      const expected = bytesToHex(encodeSingle('uint256', 0n));
+
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('encodes non-zero group index', () => {
+      const result = createLogicalOrWrapperArgs({ groupIndex: 1n });
+      const expected = bytesToHex(encodeSingle('uint256', 1n));
+
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('throws for negative group index', () => {
+      expect(() =>
+        createLogicalOrWrapperArgs({ groupIndex: -1n }),
+      ).toThrow('Invalid groupIndex: must be a non-negative number');
+    });
+
+    it('returns Uint8Array when bytes encoding is specified', () => {
+      const result = createLogicalOrWrapperArgs(
+        { groupIndex: 0n },
+        { out: 'bytes' },
+      );
+
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('decodeLogicalOrWrapperArgs', () => {
+    it('round-trips through encode and decode', () => {
+      const original = { groupIndex: 1n };
+      expect(
+        decodeLogicalOrWrapperArgs(createLogicalOrWrapperArgs(original)),
+      ).toStrictEqual(original);
+    });
+
+    it('decodes zero index', () => {
+      const encoded = createLogicalOrWrapperArgs({ groupIndex: 0n });
+      expect(decodeLogicalOrWrapperArgs(encoded)).toStrictEqual({
+        groupIndex: 0n,
+      });
+    });
+  });
+});

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- feat: add payee rule
+- Optional `payee` on `PermissionRequestParameter` maps to a `payee` execution rule; granted permission responses checksum-normalize payee addresses in `rules`.
+
 ## [1.3.0]
 
 ### Added

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- feat: add payee rule
-- Optional `payee` on `PermissionRequestParameter` maps to a `payee` execution rule; granted permission responses checksum-normalize payee addresses in `rules`.
+- Add optional `payee` execution rule to `PermissionRequestParameter` for allowance-type permissions ([#219](https://github.com/MetaMask/smart-accounts-kit/pull/219))
 
 ## [1.3.0]
 

--- a/packages/smart-accounts-kit/src/actions/erc7715GetSupportedExecutionPermissionsAction.ts
+++ b/packages/smart-accounts-kit/src/actions/erc7715GetSupportedExecutionPermissionsAction.ts
@@ -22,7 +22,7 @@ export type { GetSupportedExecutionPermissionsResult } from './erc7715Types';
  * // {
  * //   "native-token-allowance": {
  * //     "chainIds": [1, 137],
- * //     "ruleTypes": ["expiry", "redeemer"]
+ * //     "ruleTypes": ["expiry", "redeemer", "payee"]
  * //   },
  * //   "erc20-token-allowance": {
  * //     "chainIds": [1],
@@ -31,7 +31,8 @@ export type { GetSupportedExecutionPermissionsResult } from './erc7715Types';
  * // }
  * //
  * // Which strings appear in `ruleTypes` is defined by the wallet; when supported,
- * // `"redeemer"` indicates the wallet accepts a redeemer execution rule.
+ * // `"redeemer"` indicates the wallet accepts a redeemer execution rule and
+ * // `"payee"` indicates the wallet accepts a payee execution rule.
  * ```
  */
 export async function erc7715GetSupportedExecutionPermissionsAction(

--- a/packages/smart-accounts-kit/src/actions/erc7715Mapping.ts
+++ b/packages/smart-accounts-kit/src/actions/erc7715Mapping.ts
@@ -42,7 +42,7 @@ import type {
 export function permissionRequestToRpc(
   parameters: PermissionRequestParameter,
 ): PermissionRequest<RpcPermissionTypes> {
-  const { chainId, from, expiry, redeemer } = parameters;
+  const { chainId, from, expiry, redeemer, payee } = parameters;
 
   const converter = getPermissionRequestToRpcConverter(
     parameters.permission.type,
@@ -73,6 +73,24 @@ export function permissionRequestToRpc(
     rules.push({
       type: 'redeemer',
       data: { addresses },
+    });
+  }
+  if (isDefined(payee)) {
+    if (payee.length === 0) {
+      throw new Error(
+        'Invalid payees: must specify at least one payee address',
+      );
+    }
+    const payeeAddresses: Hex[] = [];
+    for (const addr of payee) {
+      if (!isAddress(addr)) {
+        throw new Error('Invalid payees: must be a valid address');
+      }
+      payeeAddresses.push(getAddress(addr));
+    }
+    rules.push({
+      type: 'payee',
+      data: { addresses: payeeAddresses },
     });
   }
 
@@ -412,10 +430,10 @@ export function permissionResponsesFromRpc(
 }
 
 /**
- * Checksums addresses in `redeemer` rules; other rules are returned unchanged.
+ * Checksums addresses in `redeemer` and `payee` rules; other rules are returned unchanged.
  *
  * @param rules - Rules from the wallet RPC response.
- * @returns The same list with normalized redeemer addresses, or null/undefined if that was the input.
+ * @returns The same list with normalized addresses, or null/undefined if that was the input.
  */
 function normalizeRulesFromRpc(
   rules: Rule[] | null | undefined,
@@ -424,7 +442,7 @@ function normalizeRulesFromRpc(
     return rules;
   }
   return rules.map((rule) => {
-    if (rule.type !== 'redeemer') {
+    if (rule.type !== 'redeemer' && rule.type !== 'payee') {
       return rule;
     }
     const rawAddresses = (rule.data as { addresses?: unknown } | undefined)
@@ -433,7 +451,7 @@ function normalizeRulesFromRpc(
       return rule;
     }
     return {
-      type: 'redeemer',
+      type: rule.type,
       data: {
         addresses: rawAddresses.map((addr) => getAddress(addr as Hex)),
       },

--- a/packages/smart-accounts-kit/src/actions/erc7715Types.ts
+++ b/packages/smart-accounts-kit/src/actions/erc7715Types.ts
@@ -145,6 +145,10 @@ export type PermissionRequestParameter = {
    * When set, adds a `redeemer` execution rule: only these addresses may redeem the permission.
    */
   redeemer?: readonly Address[] | undefined | null;
+  /**
+   * When set, adds a `payee` execution rule: only these addresses may receive funds from the permission.
+   */
+  payee?: readonly Address[] | undefined | null;
 };
 
 /**

--- a/packages/smart-accounts-kit/src/actions/erc7715Types.ts
+++ b/packages/smart-accounts-kit/src/actions/erc7715Types.ts
@@ -147,6 +147,7 @@ export type PermissionRequestParameter = {
   redeemer?: readonly Address[] | undefined | null;
   /**
    * When set, adds a `payee` execution rule: only these addresses may receive funds from the permission.
+   * Only supported on allowance-type permissions (allowance, stream, periodic).
    */
   payee?: readonly Address[] | undefined | null;
 };

--- a/packages/smart-accounts-kit/test/actions/erc7715GetGrantedExecutionPermissionsAction.test.ts
+++ b/packages/smart-accounts-kit/test/actions/erc7715GetGrantedExecutionPermissionsAction.test.ts
@@ -110,6 +110,37 @@ describe('erc7715GetGrantedExecutionPermissionsAction', () => {
       ]);
     });
 
+    it('checksum-normalizes payee addresses in rules', async () => {
+      const responseWithPayee: RpcGetGrantedExecutionPermissionsResult = [
+        {
+          ...mockPermission,
+          rules: [
+            {
+              type: 'payee',
+              data: {
+                addresses: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
+              },
+            },
+          ],
+        },
+      ];
+      stubRequest.resolves(responseWithPayee);
+
+      const result =
+        await erc7715GetGrantedExecutionPermissionsAction(mockClient);
+
+      expect(result[0]?.rules).to.deep.equal([
+        {
+          type: 'payee',
+          data: {
+            addresses: [
+              getAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'),
+            ],
+          },
+        },
+      ]);
+    });
+
     it('should set retryCount to 0', async () => {
       stubRequest.resolves(mockResponse);
 

--- a/packages/smart-accounts-kit/test/actions/erc7715Mapping.test.ts
+++ b/packages/smart-accounts-kit/test/actions/erc7715Mapping.test.ts
@@ -268,6 +268,45 @@ describe('erc7715Mapping', () => {
         },
       ]);
     });
+
+    it('checksum-normalizes payee rule addresses', () => {
+      const rpcPermissions = [
+        {
+          ...basePermissionFields,
+          rules: [
+            {
+              type: 'payee',
+              data: {
+                addresses: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
+              },
+            },
+          ],
+          permission: {
+            type: 'native-token-stream',
+            isAdjustmentAllowed: true,
+            data: {
+              amountPerSecond: '0x64',
+              startTime: 1700000000,
+            },
+          },
+        },
+      ];
+
+      const result = permissionResponsesFromRpc(
+        rpcPermissions as RpcGetGrantedExecutionPermissionsResult,
+      );
+
+      expect(result[0]?.rules).toStrictEqual([
+        {
+          type: 'payee',
+          data: {
+            addresses: [
+              getAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'),
+            ],
+          },
+        },
+      ]);
+    });
   });
 
   describe('rpcSupportedPermissionsToDeveloper', () => {
@@ -438,6 +477,106 @@ describe('erc7715Mapping', () => {
 
       expect(() => permissionRequestToRpc(permissionRequest)).toThrow(
         'Invalid redeemers: must be a valid address',
+      );
+    });
+
+    it('adds payee rule with checksummed addresses', () => {
+      const permissionRequest = {
+        chainId: 1,
+        permission: {
+          type: 'native-token-stream',
+          data: { amountPerSecond: 0x1n },
+          isAdjustmentAllowed: false,
+        },
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        payee: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
+      } as const;
+
+      const result = permissionRequestToRpc(permissionRequest);
+
+      expect(result.rules).toStrictEqual([
+        {
+          type: 'payee',
+          data: {
+            addresses: [
+              getAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'),
+            ],
+          },
+        },
+      ]);
+    });
+
+    it('adds expiry, redeemer, then payee when all are set', () => {
+      const permissionRequest = {
+        chainId: 1,
+        permission: {
+          type: 'native-token-stream',
+          data: { amountPerSecond: 0x1n },
+          isAdjustmentAllowed: false,
+        },
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        expiry: 1234567890,
+        redeemer: ['0x1111111111111111111111111111111111111111'],
+        payee: ['0x2222222222222222222222222222222222222222'],
+      } as const;
+
+      const result = permissionRequestToRpc(permissionRequest);
+
+      expect(result.rules).toStrictEqual([
+        {
+          type: 'expiry',
+          data: { timestamp: 1234567890 },
+        },
+        {
+          type: 'redeemer',
+          data: {
+            addresses: [
+              getAddress('0x1111111111111111111111111111111111111111'),
+            ],
+          },
+        },
+        {
+          type: 'payee',
+          data: {
+            addresses: [
+              getAddress('0x2222222222222222222222222222222222222222'),
+            ],
+          },
+        },
+      ]);
+    });
+
+    it('throws when payee is empty', () => {
+      const permissionRequest = {
+        chainId: 1,
+        permission: {
+          type: 'native-token-stream',
+          data: { amountPerSecond: 0x1n },
+          isAdjustmentAllowed: false,
+        },
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        payee: [],
+      } as const;
+
+      expect(() => permissionRequestToRpc(permissionRequest)).toThrow(
+        'Invalid payees: must specify at least one payee address',
+      );
+    });
+
+    it('throws when payee contains invalid address', () => {
+      const permissionRequest = {
+        chainId: 1,
+        permission: {
+          type: 'native-token-stream',
+          data: { amountPerSecond: 0x1n },
+          isAdjustmentAllowed: false,
+        },
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        payee: ['0x1234'],
+      } as const;
+
+      expect(() => permissionRequestToRpc(permissionRequest)).toThrow(
+        'Invalid payees: must be a valid address',
       );
     });
 

--- a/packages/smart-accounts-kit/test/actions/erc7715RequestExecutionPermissionsAction.test.ts
+++ b/packages/smart-accounts-kit/test/actions/erc7715RequestExecutionPermissionsAction.test.ts
@@ -175,6 +175,45 @@ describe('erc7715RequestExecutionPermissionsAction', () => {
       ]);
     });
 
+    it('includes payee rule in wallet RPC params when payee is set', async () => {
+      const payeeAddr = '0x2222222222222222222222222222222222222222' as Address;
+      const permissionRequest = {
+        chainId: 31337,
+        from: bob.address,
+        expiry: 1234567890,
+        payee: [payeeAddr],
+        permission: {
+          type: 'native-token-stream' as const,
+          data: {
+            amountPerSecond: 0x1n,
+            maxAmount: 2n,
+            startTime: 2,
+            justification: 'Test justification',
+          },
+          isAdjustmentAllowed: false,
+        },
+        to: alice.address,
+      };
+      const parameters: RequestExecutionPermissionsParameters = [
+        permissionRequest,
+      ];
+
+      stubRequest.resolves(mockRpcResponse);
+
+      await erc7715RequestExecutionPermissionsAction(mockClient, parameters);
+
+      expect(stubRequest.firstCall.args[0].params[0].rules).to.deep.equal([
+        {
+          type: 'expiry',
+          data: { timestamp: 1234567890 },
+        },
+        {
+          type: 'payee',
+          data: { addresses: [getAddress(payeeAddr)] },
+        },
+      ]);
+    });
+
     it('should set retryCount to 0', async () => {
       const permissionRequest = {
         chainId: 31337,


### PR DESCRIPTION
## 📝 Description

Add optional `payee` execution rule to `PermissionRequestParameter` for allowance-type permissions, and add `LogicalOrWrapperEnforcer` encoding/decoding support to `delegation-core`.

## 🔄 What Changed?

- Added optional `payee` field on `PermissionRequestParameter` that maps to a `payee` execution rule (allowance, stream, periodic permissions only)
- Added `LogicalOrWrapperEnforcer` caveat to `delegation-core` with `createLogicalOrWrapperTerms`, `decodeLogicalOrWrapperTerms`, `createLogicalOrWrapperArgs`, and `decodeLogicalOrWrapperArgs`
- Checksum-normalize payee addresses in granted permission responses

## 🚀 Why?

- Payee rule allows restricting which addresses may receive funds from an allowance-type permission
- LogicalOrWrapper enables combining multiple caveat groups with OR logic — redemption succeeds if any single group passes

## 🧪 How to Test?

- [x] Automated tests added/updated
- [x] All existing tests pass

## ⚠️ Breaking Changes

- [x] No breaking changes

## 📋 Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Tests added/updated
- [x] Changelog updated (if needed)
- [x] All CI checks pass

## CHANGELOG entry

~~~
### Added
- Add optional `payee` execution rule to `PermissionRequestParameter` for allowance-type permissions ([#219](https://github.com/MetaMask/smart-accounts-kit/pull/219))
~~~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new execution rule (`payee`) that affects how permission requests are serialized/validated and how returned rules are normalized, plus introduces a new caveat encoding format (`LogicalOrWrapper`) where incorrect ABI packing could break interoperability.
> 
> **Overview**
> Adds support for a new `LogicalOrWrapperEnforcer` caveat in `delegation-core`, including ABI encode/decode helpers for both *terms* (OR over caveat groups) and *redemption args* (selected group + per-caveat args), and exports these helpers from the package.
> 
> Extends ERC-7715 permission requests in `smart-accounts-kit` with an optional `payee` field that is validated, checksummed, and mapped into a `payee` rule for wallet RPC requests; granted permission responses now checksum-normalize addresses for both `redeemer` and `payee` rules. Tests and the changelog/docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cbf55e6f8e1bba18b2935f6ddaa59df617b14b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->