### PR TITLE
Revert "Release/28.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [28.0.0]
-
 ## [27.0.0]
 
 ## [26.0.0]
@@ -51,8 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0]
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@28.0.0...HEAD
-[28.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@27.0.0...delegator-sdk-monorepo@28.0.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@27.0.0...HEAD
 [27.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@26.0.0...delegator-sdk-monorepo@27.0.0
 [26.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@25.0.0...delegator-sdk-monorepo@26.0.0
 [25.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@24.0.0...delegator-sdk-monorepo@25.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delegator-sdk-monorepo",
-  "version": "28.0.0",
+  "version": "27.0.0",
   "license": "(MIT-0 OR Apache-2.0)",
   "private": true,
   "repository": {

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.0]
-
-### Added
-
-- ERC-7715 `payee` rule to `PermissionRequestParameter` ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
-- Encoding and decoding utils for `LogicalOrWrapper` enforcer args and terms ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
-
-### Changed
-
-- Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
-
 ## [1.1.0]
 
 ### Added
@@ -101,8 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add @metamask/delegation-core package, providing utility types, delegation hashing, and terms encoding for a limited set of caveat enforcers.
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.2.0...HEAD
-[1.2.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.1.0...@metamask/delegation-core@1.2.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.1.0...HEAD
 [1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.0.0...@metamask/delegation-core@1.1.0
 [1.0.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@0.4.0...@metamask/delegation-core@1.0.0
 [0.4.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@0.3.0...@metamask/delegation-core@0.4.0

--- a/packages/delegation-core/package.json
+++ b/packages/delegation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-core",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "Low level core functionality for interacting with the Delegation Framework",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0]
-
-### Added
-
-- `LogicalOrWrapperEnforcer` address added to contract addresses ([#220](https://github.com/metamask/smart-accounts-kit/pull/220))
-
 ## [1.2.0]
 
 ### Added
@@ -71,8 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add deployments for Sei mainnet ([#84](https://github.com/metamask/smart-accounts-kit/pull/84))
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.3.0...HEAD
-[1.3.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.2.0...@metamask/delegation-deployments@1.3.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.2.0...HEAD
 [1.2.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.1.0...@metamask/delegation-deployments@1.2.0
 [1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.0.0...@metamask/delegation-deployments@1.1.0
 [1.0.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@0.17.0...@metamask/delegation-deployments@1.0.0

--- a/packages/delegation-deployments/package.json
+++ b/packages/delegation-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-deployments",
-  "version": "1.3.0",
+  "version": "1.2.0",
   "description": "A history of deployments of the Delegation Framework",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.0]
-
-### Uncategorized
-
-- Release/27.0.0 ([#216](https://github.com/metamask/smart-accounts-kit/pull/216))
-- fix: Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
-- Add new erc-7715 simple allowance types: ([#214](https://github.com/metamask/smart-accounts-kit/pull/214))
-- Add new erc-7715 `payee` rule ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
-
 ### Added
 
 - Add optional `payee` execution rule to `PermissionRequestParameter` for allowance-type permissions ([#219](https://github.com/MetaMask/smart-accounts-kit/pull/219))
@@ -134,8 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Promote readable permissions actions (`requestExecutionPermissions`, `sendTransactionWithDelegation`, and `sendUserOperationWithDelegation`) from experimental ([#91](https://github.com/MetaMask/smart-accounts-kit/pull/91))
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.4.0...HEAD
-[1.4.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.3.0...@metamask/smart-accounts-kit@1.4.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.3.0...HEAD
 [1.3.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.2.0...@metamask/smart-accounts-kit@1.3.0
 [1.2.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.1.0...@metamask/smart-accounts-kit@1.2.0
 [1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.0.0...@metamask/smart-accounts-kit@1.1.0

--- a/packages/smart-accounts-kit/package.json
+++ b/packages/smart-accounts-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/smart-accounts-kit",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "type": "module",
   "description": "Toolkit for managing and interacting with MetaMask Smart Accounts, built on Viem",
   "license": "(MIT-0 OR Apache-2.0)",
@@ -126,8 +126,8 @@
   "dependencies": {
     "@metamask/7715-permission-types": "^0.6.0",
     "@metamask/delegation-abis": "^1.0.0",
-    "@metamask/delegation-core": "^1.2.0",
-    "@metamask/delegation-deployments": "^1.3.0",
+    "@metamask/delegation-core": "^1.1.0",
+    "@metamask/delegation-deployments": "^1.2.0",
     "openapi-fetch": "^0.13.5",
     "ox": "0.8.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,7 +675,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/delegation-core@npm:^1.2.0, @metamask/delegation-core@workspace:packages/delegation-core":
+"@metamask/delegation-core@npm:^1.1.0, @metamask/delegation-core@workspace:packages/delegation-core":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-core@workspace:packages/delegation-core"
   dependencies:
@@ -692,7 +692,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/delegation-deployments@npm:^1.3.0, @metamask/delegation-deployments@workspace:packages/delegation-deployments":
+"@metamask/delegation-deployments@npm:^1.2.0, @metamask/delegation-deployments@workspace:packages/delegation-deployments":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-deployments@workspace:packages/delegation-deployments"
   dependencies:
@@ -779,8 +779,8 @@ __metadata:
     "@metamask/7715-permission-types": "npm:^0.6.0"
     "@metamask/auto-changelog": "npm:^5.0.2"
     "@metamask/delegation-abis": "npm:^1.0.0"
-    "@metamask/delegation-core": "npm:^1.2.0"
-    "@metamask/delegation-deployments": "npm:^1.3.0"
+    "@metamask/delegation-core": "npm:^1.1.0"
+    "@metamask/delegation-deployments": "npm:^1.2.0"
     "@metamask/eslint-config": "npm:14.1.0"
     "@metamask/eslint-config-nodejs": "npm:14.0.0"
     "@metamask/eslint-config-typescript": "npm:14.0.0"


### PR DESCRIPTION
Reverts MetaMask/smart-accounts-kit#222
Since the following update should be a breaking change

- Balance change type enforcers now use BalanceChangeType enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))