### PR TITLE
Release/28.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [28.0.0]
+
 ## [27.0.0]
 
 ## [26.0.0]
@@ -49,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0]
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@27.0.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@28.0.0...HEAD
+[28.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@27.0.0...delegator-sdk-monorepo@28.0.0
 [27.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@26.0.0...delegator-sdk-monorepo@27.0.0
 [26.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@25.0.0...delegator-sdk-monorepo@26.0.0
 [25.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@24.0.0...delegator-sdk-monorepo@25.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delegator-sdk-monorepo",
-  "version": "27.0.0",
+  "version": "28.0.0",
   "license": "(MIT-0 OR Apache-2.0)",
   "private": true,
   "repository": {

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ### Uncategorized
 
 - Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
@@ -97,7 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add @metamask/delegation-core package, providing utility types, delegation hashing, and terms encoding for a limited set of caveat enforcers.
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.1.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.0.0...HEAD
+[2.0.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.1.0...@metamask/delegation-core@2.0.0
 [1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.0.0...@metamask/delegation-core@1.1.0
 [1.0.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@0.4.0...@metamask/delegation-core@1.0.0
 [0.4.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@0.3.0...@metamask/delegation-core@0.4.0

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
+- Release/28.0.0 ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
+- feat: add payee rule and LogicalOrWrapper enforcer ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
+- fix: Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
+
 ## [1.1.0]
 
 ### Added

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 
-### Uncategorized
+### Added
 
-- Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
-- Release/28.0.0 ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
-- feat: add payee rule and LogicalOrWrapper enforcer ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
-- fix: Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
+- ERC-7715 `payee` rule to `PermissionRequestParameter` ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
+- Encoding and decoding utils for `LogicalOrWrapper` enforcer args and terms ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
+
+### Changed
+
+- **Breaking** Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
 
 ## [1.1.0]
 

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- ERC-7715 `payee` rule to `PermissionRequestParameter` ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
 - Encoding and decoding utils for `LogicalOrWrapper` enforcer args and terms ([#219](https://github.com/metamask/smart-accounts-kit/pull/219))
 
 ### Changed

--- a/packages/delegation-core/package.json
+++ b/packages/delegation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-core",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Low level core functionality for interacting with the Delegation Framework",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -9,12 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0]
 
-### Uncategorized
+### Added
 
-- Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
-- Release/28.0.0 ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
-- Fix contract validations ([#221](https://github.com/metamask/smart-accounts-kit/pull/221))
-- feat: add LogicalOrWrapperEnforcer address to contractAddresses ([#220](https://github.com/metamask/smart-accounts-kit/pull/220))
+- `LogicalOrWrapperEnforcer` address added to contract addresses ([#220](https://github.com/metamask/smart-accounts-kit/pull/220))
 
 ## [1.2.0]
 

--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
+- Release/28.0.0 ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
+- Fix contract validations ([#221](https://github.com/metamask/smart-accounts-kit/pull/221))
+- feat: add LogicalOrWrapperEnforcer address to contractAddresses ([#220](https://github.com/metamask/smart-accounts-kit/pull/220))
+
 ## [1.2.0]
 
 ### Added

--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0]
+
 ### Uncategorized
 
 - Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
@@ -72,7 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add deployments for Sei mainnet ([#84](https://github.com/metamask/smart-accounts-kit/pull/84))
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.2.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.3.0...HEAD
+[1.3.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.2.0...@metamask/delegation-deployments@1.3.0
 [1.2.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.1.0...@metamask/delegation-deployments@1.2.0
 [1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.0.0...@metamask/delegation-deployments@1.1.0
 [1.0.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@0.17.0...@metamask/delegation-deployments@1.0.0

--- a/packages/delegation-deployments/package.json
+++ b/packages/delegation-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-deployments",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A history of deployments of the Delegation Framework",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -14,9 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add optional `payee` execution rule to `PermissionRequestParameter` for allowance-type permissions ([#219](https://github.com/MetaMask/smart-accounts-kit/pull/219))
 - Add new erc-7715 simple allowance types: ([#214](https://github.com/metamask/smart-accounts-kit/pull/214))
 
-### Changed
-
-
 ## [1.3.0]
 
 ### Added

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- fix: Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
 
 ## [1.3.0]
 

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
+- Release/28.0.0 ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
+- Release/27.0.0 ([#216](https://github.com/metamask/smart-accounts-kit/pull/216))
+- fix: Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
+- Add new erc-7715 simple allowance types: ([#214](https://github.com/metamask/smart-accounts-kit/pull/214))
+
 ### Added
 
 - Add optional `payee` execution rule to `PermissionRequestParameter` for allowance-type permissions ([#219](https://github.com/MetaMask/smart-accounts-kit/pull/219))

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -9,17 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.0]
 
-### Uncategorized
-
-- Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
-- Release/28.0.0 ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
-- Release/27.0.0 ([#216](https://github.com/metamask/smart-accounts-kit/pull/216))
-- fix: Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
-- Add new erc-7715 simple allowance types: ([#214](https://github.com/metamask/smart-accounts-kit/pull/214))
-
 ### Added
 
 - Add optional `payee` execution rule to `PermissionRequestParameter` for allowance-type permissions ([#219](https://github.com/MetaMask/smart-accounts-kit/pull/219))
+- Add new erc-7715 simple allowance types: ([#214](https://github.com/metamask/smart-accounts-kit/pull/214))
+
+### Changed
+
+- fix: Balance change type enforcers now use `BalanceChangeType` enum instead of number type ([#205](https://github.com/metamask/smart-accounts-kit/pull/205))
 
 ## [1.3.0]
 

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0]
+
 ### Uncategorized
 
 - Revert "Release/28.0.0 (#222)" ([#222](https://github.com/metamask/smart-accounts-kit/pull/222))
@@ -133,7 +135,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Promote readable permissions actions (`requestExecutionPermissions`, `sendTransactionWithDelegation`, and `sendUserOperationWithDelegation`) from experimental ([#91](https://github.com/MetaMask/smart-accounts-kit/pull/91))
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.3.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.4.0...HEAD
+[1.4.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.3.0...@metamask/smart-accounts-kit@1.4.0
 [1.3.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.2.0...@metamask/smart-accounts-kit@1.3.0
 [1.2.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.1.0...@metamask/smart-accounts-kit@1.2.0
 [1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/smart-accounts-kit@1.0.0...@metamask/smart-accounts-kit@1.1.0

--- a/packages/smart-accounts-kit/package.json
+++ b/packages/smart-accounts-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/smart-accounts-kit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "description": "Toolkit for managing and interacting with MetaMask Smart Accounts, built on Viem",
   "license": "(MIT-0 OR Apache-2.0)",
@@ -126,8 +126,8 @@
   "dependencies": {
     "@metamask/7715-permission-types": "^0.6.0",
     "@metamask/delegation-abis": "^1.0.0",
-    "@metamask/delegation-core": "^1.1.0",
-    "@metamask/delegation-deployments": "^1.2.0",
+    "@metamask/delegation-core": "^2.0.0",
+    "@metamask/delegation-deployments": "^1.3.0",
     "openapi-fetch": "^0.13.5",
     "ox": "0.8.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,7 +675,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/delegation-core@npm:^1.1.0, @metamask/delegation-core@workspace:packages/delegation-core":
+"@metamask/delegation-core@npm:^2.0.0, @metamask/delegation-core@workspace:packages/delegation-core":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-core@workspace:packages/delegation-core"
   dependencies:
@@ -692,7 +692,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/delegation-deployments@npm:^1.2.0, @metamask/delegation-deployments@workspace:packages/delegation-deployments":
+"@metamask/delegation-deployments@npm:^1.3.0, @metamask/delegation-deployments@workspace:packages/delegation-deployments":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-deployments@workspace:packages/delegation-deployments"
   dependencies:
@@ -779,8 +779,8 @@ __metadata:
     "@metamask/7715-permission-types": "npm:^0.6.0"
     "@metamask/auto-changelog": "npm:^5.0.2"
     "@metamask/delegation-abis": "npm:^1.0.0"
-    "@metamask/delegation-core": "npm:^1.1.0"
-    "@metamask/delegation-deployments": "npm:^1.2.0"
+    "@metamask/delegation-core": "npm:^2.0.0"
+    "@metamask/delegation-deployments": "npm:^1.3.0"
     "@metamask/eslint-config": "npm:14.1.0"
     "@metamask/eslint-config-nodejs": "npm:14.0.0"
     "@metamask/eslint-config-typescript": "npm:14.0.0"


### PR DESCRIPTION
## 📝 Description

Provide a brief description of the changes in this PR

## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily release metadata, but it bumps `@metamask/delegation-core` to `2.0.0` (breaking) and updates downstream dependency ranges, which can affect consumers at publish time.
> 
> **Overview**
> Cuts a new release by bumping the monorepo version to `28.0.0` and updating root/package changelog links accordingly.
> 
> Publishes new package versions for `@metamask/delegation-core` (`2.0.0`) and `@metamask/delegation-deployments` (`1.3.0`), updates `@metamask/smart-accounts-kit` to `1.4.0`, and bumps its dependency constraints to the new delegation package versions (with matching `yarn.lock` updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f4bb28cec9b6d8457e5c396cf980f6564864ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->