### PR TITLE
feat: @metamask/delegation-core encoders and decoders now accept `periodDuration` as bigint

### DIFF
--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `MultiTokenPeriod`, `Erc20TokenPeriodTransfer`, and `NativeTokenPeriodTransfer` encoders now accept `periodDuration` parameter as `bigint. ([#227](https://github.com/MetaMask/smart-accounts-kit/pull/227))
+
 ## [2.0.0]
 
 ### Added

--- a/packages/delegation-core/src/caveats/erc20TokenPeriodTransfer.ts
+++ b/packages/delegation-core/src/caveats/erc20TokenPeriodTransfer.ts
@@ -30,13 +30,14 @@ import type { Hex } from '../types';
  */
 export type ERC20TokenPeriodTransferTerms<
   TBytesLike extends BytesLike = BytesLike,
+  TDuration extends number | bigint = number,
 > = {
   /** The address of the ERC20 token. */
   tokenAddress: TBytesLike;
   /** The maximum amount that can be transferred within each period. */
   periodAmount: bigint;
   /** The duration of each period in seconds. */
-  periodDuration: number;
+  periodDuration: TDuration;
   /** Unix timestamp when the first period begins. */
   startDate: number;
 };
@@ -52,11 +53,11 @@ export type ERC20TokenPeriodTransferTerms<
  * @throws Error if any of the numeric parameters are invalid.
  */
 export function createERC20TokenPeriodTransferTerms(
-  terms: ERC20TokenPeriodTransferTerms,
+  terms: ERC20TokenPeriodTransferTerms<BytesLike, number | bigint>,
   encodingOptions?: EncodingOptions<'hex'>,
 ): Hex;
 export function createERC20TokenPeriodTransferTerms(
-  terms: ERC20TokenPeriodTransferTerms,
+  terms: ERC20TokenPeriodTransferTerms<BytesLike, number | bigint>,
   encodingOptions: EncodingOptions<'bytes'>,
 ): Uint8Array;
 /**
@@ -69,7 +70,7 @@ export function createERC20TokenPeriodTransferTerms(
  * @throws Error if any of the numeric parameters are invalid.
  */
 export function createERC20TokenPeriodTransferTerms(
-  terms: ERC20TokenPeriodTransferTerms,
+  terms: ERC20TokenPeriodTransferTerms<BytesLike, number | bigint>,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
   const { tokenAddress, periodAmount, periodDuration, startDate } = terms;

--- a/packages/delegation-core/src/caveats/multiTokenPeriod.ts
+++ b/packages/delegation-core/src/caveats/multiTokenPeriod.ts
@@ -31,18 +31,24 @@ import type { Hex } from '../types';
 /**
  * Configuration for a single token in MultiTokenPeriod terms.
  */
-export type TokenPeriodConfig<TBytesLike extends BytesLike = BytesLike> = {
+export type TokenPeriodConfig<
+  TBytesLike extends BytesLike = BytesLike,
+  TDuration extends number | bigint = number,
+> = {
   token: TBytesLike;
   periodAmount: bigint;
-  periodDuration: number;
+  periodDuration: TDuration;
   startDate: number;
 };
 
 /**
  * Terms for configuring a MultiTokenPeriod caveat.
  */
-export type MultiTokenPeriodTerms<TBytesLike extends BytesLike = BytesLike> = {
-  tokenConfigs: TokenPeriodConfig<TBytesLike>[];
+export type MultiTokenPeriodTerms<
+  TBytesLike extends BytesLike = BytesLike,
+  TDuration extends number | bigint = number,
+> = {
+  tokenConfigs: TokenPeriodConfig<TBytesLike, TDuration>[];
 };
 
 /**
@@ -54,11 +60,11 @@ export type MultiTokenPeriodTerms<TBytesLike extends BytesLike = BytesLike> = {
  * @throws Error if the tokenConfigs array is empty or contains invalid parameters.
  */
 export function createMultiTokenPeriodTerms(
-  terms: MultiTokenPeriodTerms,
+  terms: MultiTokenPeriodTerms<BytesLike, number | bigint>,
   encodingOptions?: EncodingOptions<'hex'>,
 ): Hex;
 export function createMultiTokenPeriodTerms(
-  terms: MultiTokenPeriodTerms,
+  terms: MultiTokenPeriodTerms<BytesLike, number | bigint>,
   encodingOptions: EncodingOptions<'bytes'>,
 ): Uint8Array;
 /**
@@ -70,7 +76,7 @@ export function createMultiTokenPeriodTerms(
  * @throws Error if the tokenConfigs array is empty or contains invalid parameters.
  */
 export function createMultiTokenPeriodTerms(
-  terms: MultiTokenPeriodTerms,
+  terms: MultiTokenPeriodTerms<BytesLike, number | bigint>,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
   const { tokenConfigs } = terms;

--- a/packages/delegation-core/src/caveats/nativeTokenPeriodTransfer.ts
+++ b/packages/delegation-core/src/caveats/nativeTokenPeriodTransfer.ts
@@ -26,11 +26,13 @@ import type { Hex } from '../types';
 /**
  * Terms for configuring a periodic transfer allowance of native tokens.
  */
-export type NativeTokenPeriodTransferTerms = {
+export type NativeTokenPeriodTransferTerms<
+  TDuration extends number | bigint = number,
+> = {
   /** The maximum amount that can be transferred within each period (in wei). */
   periodAmount: bigint;
   /** The duration of each period in seconds. */
-  periodDuration: number;
+  periodDuration: TDuration;
   /** Unix timestamp when the first period begins. */
   startDate: number;
 };
@@ -46,11 +48,11 @@ export type NativeTokenPeriodTransferTerms = {
  * @throws Error if any of the numeric parameters are invalid.
  */
 export function createNativeTokenPeriodTransferTerms(
-  terms: NativeTokenPeriodTransferTerms,
+  terms: NativeTokenPeriodTransferTerms<number | bigint>,
   encodingOptions?: EncodingOptions<'hex'>,
 ): Hex;
 export function createNativeTokenPeriodTransferTerms(
-  terms: NativeTokenPeriodTransferTerms,
+  terms: NativeTokenPeriodTransferTerms<number | bigint>,
   encodingOptions: EncodingOptions<'bytes'>,
 ): Uint8Array;
 /**
@@ -63,7 +65,7 @@ export function createNativeTokenPeriodTransferTerms(
  * @throws Error if any of the numeric parameters are invalid.
  */
 export function createNativeTokenPeriodTransferTerms(
-  terms: NativeTokenPeriodTransferTerms,
+  terms: NativeTokenPeriodTransferTerms<number | bigint>,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
   const { periodAmount, periodDuration, startDate } = terms;

--- a/packages/delegation-core/test/caveats/decoders.test.ts
+++ b/packages/delegation-core/test/caveats/decoders.test.ts
@@ -319,6 +319,20 @@ describe('Terms Decoders', () => {
       const decoded = decodeNativeTokenPeriodTransferTerms(encoded);
       expect(decoded).toEqual(original);
     });
+
+    it('decodes bigint periodDuration input as number', () => {
+      const encoded = createNativeTokenPeriodTransferTerms({
+        periodAmount: 1000000000000000000n,
+        periodDuration: 86400n,
+        startDate: 1640995200,
+      });
+      const decoded = decodeNativeTokenPeriodTransferTerms(encoded);
+      expect(decoded).toEqual({
+        periodAmount: 1000000000000000000n,
+        periodDuration: 86400,
+        startDate: 1640995200,
+      });
+    });
   });
 
   describe('decodeNativeTokenStreamingTerms', () => {
@@ -383,6 +397,24 @@ describe('Terms Decoders', () => {
       const encoded = createERC20TokenPeriodTransferTerms(original);
       const decoded = decodeERC20TokenPeriodTransferTerms(encoded);
       expect(decoded).toEqual(original);
+    });
+
+    it('decodes bigint periodDuration input as number', () => {
+      const encoded = createERC20TokenPeriodTransferTerms({
+        tokenAddress:
+          '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        periodAmount: 1000000000000000000n,
+        periodDuration: 86400n,
+        startDate: 1640995200,
+      });
+      const decoded = decodeERC20TokenPeriodTransferTerms(encoded);
+      expect(decoded).toEqual({
+        tokenAddress:
+          '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        periodAmount: 1000000000000000000n,
+        periodDuration: 86400,
+        startDate: 1640995200,
+      });
     });
 
     it('throws when encoded terms are not exactly 116 bytes', () => {
@@ -524,6 +556,46 @@ describe('Terms Decoders', () => {
       const encoded = createMultiTokenPeriodTerms(original);
       const decoded = decodeMultiTokenPeriodTerms(encoded);
       expect(decoded).toEqual(original);
+    });
+
+    it('decodes bigint periodDuration input as number', () => {
+      const encoded = createMultiTokenPeriodTerms({
+        tokenConfigs: [
+          {
+            token:
+              '0x1234567890123456789012345678901234567890' as `0x${string}`,
+            periodAmount: 1000000000000000000n,
+            periodDuration: 86400n,
+            startDate: 1640995200,
+          },
+          {
+            token:
+              '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+            periodAmount: 2000000000000000000n,
+            periodDuration: 172800n,
+            startDate: 1640995200,
+          },
+        ],
+      });
+      const decoded = decodeMultiTokenPeriodTerms(encoded);
+      expect(decoded).toEqual({
+        tokenConfigs: [
+          {
+            token:
+              '0x1234567890123456789012345678901234567890' as `0x${string}`,
+            periodAmount: 1000000000000000000n,
+            periodDuration: 86400,
+            startDate: 1640995200,
+          },
+          {
+            token:
+              '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+            periodAmount: 2000000000000000000n,
+            periodDuration: 172800,
+            startDate: 1640995200,
+          },
+        ],
+      });
     });
   });
 

--- a/packages/delegation-core/test/caveats/erc20TokenPeriodTransfer.test.ts
+++ b/packages/delegation-core/test/caveats/erc20TokenPeriodTransfer.test.ts
@@ -1,0 +1,254 @@
+import { isStrictHexString } from '@metamask/utils';
+import { describe, it, expect } from 'vitest';
+
+import {
+  createERC20TokenPeriodTransferTerms,
+  decodeERC20TokenPeriodTransferTerms,
+} from '../../src/caveats/erc20TokenPeriodTransfer';
+
+describe('ERC20TokenPeriodTransfer', () => {
+  describe('createERC20TokenPeriodTransferTerms', () => {
+    const tokenAddress = '0x0000000000000000000000000000000000000011';
+    const EXPECTED_BYTE_LENGTH = 116; // 20-byte address + 3 x 32-byte values
+
+    it('creates valid terms for standard parameters', () => {
+      const periodAmount = 1000000000000000000n; // 1 token at 18 decimals
+      const periodDuration = 3600; // 1 hour in seconds
+      const startDate = 1640995200; // 2022-01-01 00:00:00 UTC
+      const result = createERC20TokenPeriodTransferTerms({
+        tokenAddress,
+        periodAmount,
+        periodDuration,
+        startDate,
+      });
+
+      const expectedPeriodAmount =
+        '0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+      const expectedPeriodDuration =
+        '0000000000000000000000000000000000000000000000000000000000000e10';
+      const expectedStartDate =
+        '0000000000000000000000000000000000000000000000000000000061cf9980';
+
+      expect(result).toStrictEqual(
+        `${tokenAddress}${expectedPeriodAmount}${expectedPeriodDuration}${expectedStartDate}`,
+      );
+      expect(result).toHaveLength(234);
+    });
+
+    it('creates valid terms when periodDuration is bigint', () => {
+      const result = createERC20TokenPeriodTransferTerms({
+        tokenAddress,
+        periodAmount: 1n,
+        periodDuration: 1n,
+        startDate: 1,
+      });
+
+      expect(result).toStrictEqual(
+        '0x0000000000000000000000000000000000000011' +
+          '0000000000000000000000000000000000000000000000000000000000000001' +
+          '0000000000000000000000000000000000000000000000000000000000000001' +
+          '0000000000000000000000000000000000000000000000000000000000000001',
+      );
+    });
+
+    it('creates valid terms when tokenAddress is bytes', () => {
+      const tokenAddressBytes = Uint8Array.from([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17,
+      ]);
+      const result = createERC20TokenPeriodTransferTerms({
+        tokenAddress: tokenAddressBytes,
+        periodAmount: 10n,
+        periodDuration: 60,
+        startDate: 10,
+      });
+
+      expect(result).toStrictEqual(
+        '0x0000000000000000000000000000000000000011' +
+          '000000000000000000000000000000000000000000000000000000000000000a' +
+          '000000000000000000000000000000000000000000000000000000000000003c' +
+          '000000000000000000000000000000000000000000000000000000000000000a',
+      );
+    });
+
+    it('throws an error for invalid token address', () => {
+      expect(() =>
+        createERC20TokenPeriodTransferTerms({
+          tokenAddress: '0x1234',
+          periodAmount: 1n,
+          periodDuration: 1,
+          startDate: 1,
+        }),
+      ).toThrow('Invalid tokenAddress: must be a valid address');
+    });
+
+    it('throws an error for invalid token address bytes length', () => {
+      expect(() =>
+        createERC20TokenPeriodTransferTerms({
+          tokenAddress: new Uint8Array(19),
+          periodAmount: 1n,
+          periodDuration: 1,
+          startDate: 1,
+        }),
+      ).toThrow('Invalid tokenAddress: must be a valid address');
+    });
+
+    it('throws an error for zero period amount', () => {
+      expect(() =>
+        createERC20TokenPeriodTransferTerms({
+          tokenAddress,
+          periodAmount: 0n,
+          periodDuration: 3600,
+          startDate: 1640995200,
+        }),
+      ).toThrow('Invalid periodAmount: must be a positive number');
+    });
+
+    it('throws an error for zero period duration', () => {
+      expect(() =>
+        createERC20TokenPeriodTransferTerms({
+          tokenAddress,
+          periodAmount: 1000000000000000000n,
+          periodDuration: 0,
+          startDate: 1640995200,
+        }),
+      ).toThrow('Invalid periodDuration: must be a positive number');
+    });
+
+    it('throws an error for negative period duration bigint', () => {
+      expect(() =>
+        createERC20TokenPeriodTransferTerms({
+          tokenAddress,
+          periodAmount: 1000000000000000000n,
+          periodDuration: -1n,
+          startDate: 1640995200,
+        }),
+      ).toThrow('Invalid periodDuration: must be a positive number');
+    });
+
+    it('throws an error for zero start date', () => {
+      expect(() =>
+        createERC20TokenPeriodTransferTerms({
+          tokenAddress,
+          periodAmount: 1000000000000000000n,
+          periodDuration: 3600,
+          startDate: 0,
+        }),
+      ).toThrow('Invalid startDate: must be a positive number');
+    });
+
+    it('creates valid terms for maximum safe values', () => {
+      const result = createERC20TokenPeriodTransferTerms({
+        tokenAddress,
+        periodAmount:
+          115792089237316195423570985008687907853269984665640564039457584007913129639935n, // max uint256
+        periodDuration: Number.MAX_SAFE_INTEGER,
+        startDate: Number.MAX_SAFE_INTEGER,
+      });
+
+      expect(result).toHaveLength(234);
+      expect(isStrictHexString(result)).toBe(true);
+    });
+
+    describe('bytes return type', () => {
+      it('returns Uint8Array when bytes encoding is specified', () => {
+        const result = createERC20TokenPeriodTransferTerms(
+          {
+            tokenAddress,
+            periodAmount: 1000000000000000000n,
+            periodDuration: 3600,
+            startDate: 1640995200,
+          },
+          { out: 'bytes' },
+        );
+
+        expect(result).toBeInstanceOf(Uint8Array);
+        expect(result).toHaveLength(EXPECTED_BYTE_LENGTH);
+      });
+    });
+  });
+
+  describe('decodeERC20TokenPeriodTransferTerms', () => {
+    const tokenAddress =
+      '0x0000000000000000000000000000000000000011' as `0x${string}`;
+
+    it('decodes standard parameters', () => {
+      const original = {
+        tokenAddress,
+        periodAmount: 1000000000000000000n,
+        periodDuration: 3600,
+        startDate: 1640995200,
+      };
+
+      expect(
+        decodeERC20TokenPeriodTransferTerms(
+          createERC20TokenPeriodTransferTerms(original),
+        ),
+      ).toStrictEqual(original);
+    });
+
+    it('decodes bigint periodDuration input as number', () => {
+      const original = {
+        tokenAddress,
+        periodAmount: 1n,
+        periodDuration: 1n,
+        startDate: 1,
+      };
+
+      expect(
+        decodeERC20TokenPeriodTransferTerms(
+          createERC20TokenPeriodTransferTerms(original),
+        ),
+      ).toStrictEqual({
+        tokenAddress,
+        periodAmount: 1n,
+        periodDuration: 1,
+        startDate: 1,
+      });
+    });
+
+    it('accepts Uint8Array terms from the encoder', () => {
+      const original = {
+        tokenAddress,
+        periodAmount: 1n,
+        periodDuration: 1,
+        startDate: 1,
+      };
+      const bytes = createERC20TokenPeriodTransferTerms(original, {
+        out: 'bytes',
+      });
+
+      expect(decodeERC20TokenPeriodTransferTerms(bytes)).toStrictEqual(
+        original,
+      );
+    });
+
+    it('decodes tokenAddress as Uint8Array when bytes output is requested', () => {
+      const original = {
+        tokenAddress,
+        periodAmount: 1n,
+        periodDuration: 1,
+        startDate: 1,
+      };
+      const decoded = decodeERC20TokenPeriodTransferTerms(
+        createERC20TokenPeriodTransferTerms(original),
+        { out: 'bytes' },
+      );
+
+      expect(decoded.tokenAddress).toBeInstanceOf(Uint8Array);
+      expect(Array.from(decoded.tokenAddress)).toStrictEqual([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17,
+      ]);
+      expect(decoded.periodAmount).toBe(1n);
+      expect(decoded.periodDuration).toBe(1);
+      expect(decoded.startDate).toBe(1);
+    });
+
+    it('throws when encoded terms are not exactly 116 bytes', () => {
+      expect(() =>
+        decodeERC20TokenPeriodTransferTerms(`0x${'00'.repeat(115)}`),
+      ).toThrow(
+        'Invalid ERC20TokenPeriodTransfer terms: must be exactly 116 bytes',
+      );
+    });
+  });
+});

--- a/packages/delegation-core/test/caveats/multiTokenPeriod.test.ts
+++ b/packages/delegation-core/test/caveats/multiTokenPeriod.test.ts
@@ -29,6 +29,26 @@ describe('MultiTokenPeriod', () => {
       );
     });
 
+    it('accepts bigint periodDuration', () => {
+      const result = createMultiTokenPeriodTerms({
+        tokenConfigs: [
+          {
+            token,
+            periodAmount: 100n,
+            periodDuration: 60n,
+            startDate: 10,
+          },
+        ],
+      });
+
+      expect(result).toStrictEqual(
+        '0x0000000000000000000000000000000000000011' +
+          '0000000000000000000000000000000000000000000000000000000000000064' +
+          '000000000000000000000000000000000000000000000000000000000000003c' +
+          '000000000000000000000000000000000000000000000000000000000000000a',
+      );
+    });
+
     it('throws for empty token configs', () => {
       expect(() => createMultiTokenPeriodTerms({ tokenConfigs: [] })).toThrow(
         'MultiTokenPeriodBuilder: tokenConfigs array cannot be empty',

--- a/packages/delegation-core/test/caveats/nativeTokenPeriodTransfer.test.ts
+++ b/packages/delegation-core/test/caveats/nativeTokenPeriodTransfer.test.ts
@@ -47,6 +47,21 @@ describe('NativeTokenPeriodTransfer', () => {
       );
     });
 
+    it('creates valid terms when periodDuration is bigint', () => {
+      const periodAmount = 1n;
+      const periodDuration = 1n;
+      const startDate = 1;
+      const result = createNativeTokenPeriodTransferTerms({
+        periodAmount,
+        periodDuration,
+        startDate,
+      });
+
+      expect(result).toStrictEqual(
+        '0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001',
+      );
+    });
+
     it('creates valid terms for large values', () => {
       const periodAmount = 100000000000000000000n; // 100 ETH in wei
       const periodDuration = 86400; // 1 day in seconds
@@ -341,6 +356,23 @@ describe('NativeTokenPeriodTransfer', () => {
           createNativeTokenPeriodTransferTerms(original),
         ),
       ).toStrictEqual(original);
+    });
+
+    it('decodes bigint periodDuration input as number', () => {
+      const original = {
+        periodAmount: 1n,
+        periodDuration: 1n,
+        startDate: 1,
+      };
+      expect(
+        decodeNativeTokenPeriodTransferTerms(
+          createNativeTokenPeriodTransferTerms(original),
+        ),
+      ).toStrictEqual({
+        periodAmount: 1n,
+        periodDuration: 1,
+        startDate: 1,
+      });
     });
 
     it('decodes maximum uint256 and max safe integers', () => {


### PR DESCRIPTION
## 📝 Description

`MultiTokenPeriod`, `NativeTokenPeriodTransfer` and `Erc20TokenPeriodTransfer` enforcers encode `periodDuration` as UINT256. Because `number` is the natural type for duration represented as seconds, it was chosen as the `periodDuration` type for the typescript interface.

There's a case where the enforcer is used to encode a single allowance, where the period duration is simply set as `UINT256_MAX` - meaning there's no real possibility of a second duration (unless you wait ~3.6 times 10^69 years).

By making the config type generic with default value, the return type of `decodeXXX` is unchanged, and a caller can specify `periodDuration` as `bigint`.

## 🧪 How to Test?

This is a typing only change, as the encoders already work with `periodDuration` values specified as `bigint`. New unit tests invoke the `encodeXXX` functions with `periodDuration` as `bigint`.

## ⚠️ Breaking Changes

Non breaking.

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk typing/API-surface tweak: encoding already uses uint256 and runtime behavior is unchanged; primary impact is TypeScript types and added test coverage.
> 
> **Overview**
> **Adds `bigint` support for `periodDuration` inputs** in the `MultiTokenPeriod`, `ERC20TokenPeriodTransfer`, and `NativeTokenPeriodTransfer` terms/encoder APIs by making the term types generic and widening the encoder overloads to `number | bigint`.
> 
> **Keeps decode output unchanged** (still decoding `periodDuration` to a `number`), and adds unit tests to ensure encoding accepts bigint durations and decoding normalizes them back to numbers. The `CHANGELOG.md` is updated to document the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7f12b7bc49c7c99d7512e7736f770446dccadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->