### PR TITLE
Shuffle redelegation actions

### DIFF
--- a/packages/smart-accounts-kit/src/actions/index.ts
+++ b/packages/smart-accounts-kit/src/actions/index.ts
@@ -16,6 +16,12 @@ import type {
   MetaMaskExtensionClient,
   RequestExecutionPermissionsParameters,
 } from './erc7715RequestExecutionPermissionsAction';
+import {
+  redelegatePermissionContextAction,
+  redelegatePermissionContextOpenAction,
+  type RedelegatePermissionContextOpenParameters,
+  type RedelegatePermissionContextParameters,
+} from './redelegatePermissionContext';
 
 export {
   // Individual action functions
@@ -52,9 +58,8 @@ export {
 
 // Redelegation actions
 export {
-  redelegatePermissionContext,
-  redelegatePermissionContextOpen,
-  redelegatePermissionContextActions,
+  redelegatePermissionContextAction,
+  redelegatePermissionContextOpenAction,
   type RedelegatePermissionContextParameters,
   type RedelegatePermissionContextOpenParameters,
   type RedelegatePermissionContextReturnType,
@@ -116,7 +121,7 @@ export const erc7715ProviderActions = () => (client: Client) => ({
 });
 
 /**
- * Type for a viem Client extended with ERC-7715 provider actions.
+ * Type for a viem Client extended with ERC-7710 provider actions.
  * Use this to type variables that will be assigned an extended client later.
  *
  * @example
@@ -138,6 +143,12 @@ export const erc7710WalletActions = () => (client: WalletClient) => ({
   sendTransactionWithDelegation: async (
     args: SendTransactionWithDelegationParameters,
   ) => sendTransactionWithDelegationAction(client, args),
+  redelegatePermissionContext: async (
+    parameters: RedelegatePermissionContextParameters,
+  ) => redelegatePermissionContextAction(client, parameters),
+  redelegatePermissionContextOpen: async (
+    parameters: RedelegatePermissionContextOpenParameters,
+  ) => redelegatePermissionContextOpenAction(client, parameters),
 });
 
 export const erc7710BundlerActions = () => (client: Client) => ({

--- a/packages/smart-accounts-kit/src/actions/index.ts
+++ b/packages/smart-accounts-kit/src/actions/index.ts
@@ -99,6 +99,26 @@ export {
 
 export type { DelegatedCall } from './erc7710RedeemDelegationAction';
 
+/**
+ * Extends a viem client with ERC-7715 provider actions.
+ *
+ * @returns A function that decorates a client with ERC-7715 provider actions.
+ *
+ * @example
+ * ```typescript
+ * const providerClient = createClient({
+ *   chain: sepolia,
+ *   transport: custom(window.ethereum),
+ * }).extend(erc7715ProviderActions());
+ *
+ * await providerClient.requestExecutionPermissions({
+ *   requests: [permissionRequest],
+ * });
+ *
+ * const supported = await providerClient.getSupportedExecutionPermissions();
+ * const granted = await providerClient.getGrantedExecutionPermissions();
+ * ```
+ */
 export const erc7715ProviderActions = () => (client: Client) => ({
   requestExecutionPermissions: async (
     parameters: RequestExecutionPermissionsParameters,
@@ -121,15 +141,15 @@ export const erc7715ProviderActions = () => (client: Client) => ({
 });
 
 /**
- * Type for a viem Client extended with ERC-7710 provider actions.
- * Use this to type variables that will be assigned an extended client later.
+ * Type for a viem Client extended with ERC-7715 provider actions.
+ * Use this to type variables for deferred initialization.
  *
  * @example
  * ```typescript
  * let client: Erc7715Client | null = null;
  *
  * function setupClient() {
- *   client = createWalletClient({
+ *   client = createClient({
  *     chain: sepolia,
  *     transport: custom(window.ethereum),
  *   }).extend(erc7715ProviderActions());
@@ -139,6 +159,58 @@ export const erc7715ProviderActions = () => (client: Client) => ({
 export type Erc7715Client = Client &
   ReturnType<ReturnType<typeof erc7715ProviderActions>>;
 
+/**
+ * Type for a viem WalletClient extended with ERC-7710 wallet actions.
+ * Use this to type variables for deferred initialization.
+ *
+ * @example
+ * ```typescript
+ * let walletClient: Erc7710WalletClient | null = null;
+ *
+ * function setupClient() {
+ *   walletClient = createWalletClient({
+ *     account,
+ *     chain: sepolia,
+ *     transport: custom(window.ethereum),
+ *   }).extend(erc7710WalletActions());
+ * }
+ * ```
+ */
+export type Erc7710WalletClient = WalletClient &
+  ReturnType<ReturnType<typeof erc7710WalletActions>>;
+
+/**
+ * Extends a viem wallet client with ERC-7710 wallet actions.
+ *
+ * @returns A function that decorates a wallet client with ERC-7710 wallet actions.
+ *
+ * @example
+ * ```typescript
+ * const walletClient = createWalletClient({
+ *   account,
+ *   chain: sepolia,
+ *   transport: custom(window.ethereum),
+ * }).extend(erc7710WalletActions());
+ *
+ * await walletClient.sendTransactionWithDelegation({
+ *   account,
+ *   chain: sepolia,
+ *   to: recipient,
+ *   value: 0n,
+ *   data: callData,
+ *   permissionContext,
+ *   delegationManager: environment.DelegationManager,
+ * });
+ *
+ * await walletClient.redelegatePermissionContext({
+ *   environment,
+ *   permissionContext,
+ *   to: anotherDelegate,
+ *   // optional when client.chain is configured
+ *   chainId: sepolia.id,
+ * });
+ * ```
+ */
 export const erc7710WalletActions = () => (client: WalletClient) => ({
   sendTransactionWithDelegation: async (
     args: SendTransactionWithDelegationParameters,
@@ -151,6 +223,33 @@ export const erc7710WalletActions = () => (client: WalletClient) => ({
   ) => redelegatePermissionContextOpenAction(client, parameters),
 });
 
+/**
+ * Extends a viem bundler client with ERC-7710 bundler actions.
+ *
+ * @returns A function that decorates a bundler client with ERC-7710 bundler actions.
+ *
+ * @example
+ * ```typescript
+ * const bundlerClient = createBundlerClient({
+ *   account: smartAccount,
+ *   chain: sepolia,
+ *   transport: http(bundlerUrl),
+ * }).extend(erc7710BundlerActions());
+ *
+ * const userOpHash = await bundlerClient.sendUserOperationWithDelegation({
+ *   publicClient,
+ *   calls: [
+ *     {
+ *       to: recipient,
+ *       data: callData,
+ *       value: 0n,
+ *       permissionContext,
+ *       delegationManager: environment.DelegationManager,
+ *     },
+ *   ],
+ * });
+ * ```
+ */
 export const erc7710BundlerActions = () => (client: Client) => ({
   sendUserOperationWithDelegation: async (
     args: SendUserOperationWithDelegationParameters,

--- a/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
+++ b/packages/smart-accounts-kit/src/actions/redelegatePermissionContext.ts
@@ -34,8 +34,8 @@ type BaseRedelegatePermissionContextParameters = {
   environment: SmartAccountsEnvironment;
   /** The permission context to redelegate from (i.e., from ERC-7715 response) */
   permissionContext: PermissionContext;
-  /** The chain ID for the signature */
-  chainId: number;
+  /** The chain ID for the signature (falls back to `client.chain.id`) */
+  chainId?: number;
   /** Optional scope - if not provided, inherits from parent */
   scope?: ScopeConfig;
   /** Additional caveats to apply to the redelegation */
@@ -181,7 +181,8 @@ function resolveRedelegationArgs<
  * 4. Prepends it to the delegation chain
  * 5. Returns the encoded permission context
  *
- * Use {@link redelegatePermissionContextOpen} to create an open redelegation
+ * Use {@link redelegatePermissionContextOpenAction} to create an open
+ * redelegation
  * (delegate set to `ANY_BENEFICIARY`).
  *
  * @param client - Wallet client with signing capability.
@@ -190,7 +191,7 @@ function resolveRedelegationArgs<
  *
  * @example
  * ```ts
- * const result = await redelegatePermissionContext(walletClient, {
+ * const result = await redelegatePermissionContextAction(walletClient, {
  *   environment,
  *   permissionContext: erc7715Response.context,
  *   chainId: 11155111,
@@ -208,14 +209,15 @@ function resolveRedelegationArgs<
  * });
  * ```
  */
-export async function redelegatePermissionContext<
+export async function redelegatePermissionContextAction<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
 >(
   client: SigningClient<TChain, TAccount>,
   parameters: RedelegatePermissionContextParameters,
 ): Promise<RedelegatePermissionContextReturnType> {
-  const { environment, chainId, scope, caveats, salt, to } = parameters;
+  const { environment, scope, caveats, salt, to } = parameters;
+  const chainId = resolveChainId(client, parameters.chainId);
 
   const { account, delegations, parentDelegation, from } =
     resolveRedelegationArgs(client, parameters);
@@ -250,7 +252,7 @@ export async function redelegatePermissionContext<
  * existing permission context and returns both the signed delegation and the
  * updated permission context.
  *
- * Use {@link redelegatePermissionContext} when you want to delegate to a
+ * Use {@link redelegatePermissionContextAction} when you want to delegate to a
  * specific address.
  *
  * @param client - Wallet client with signing capability.
@@ -259,7 +261,7 @@ export async function redelegatePermissionContext<
  *
  * @example
  * ```ts
- * const result = await redelegatePermissionContextOpen(walletClient, {
+ * const result = await redelegatePermissionContextOpenAction(walletClient, {
  *   environment,
  *   permissionContext: erc7715Response.context,
  *   chainId: 11155111,
@@ -267,14 +269,15 @@ export async function redelegatePermissionContext<
  * });
  * ```
  */
-export async function redelegatePermissionContextOpen<
+export async function redelegatePermissionContextOpenAction<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
 >(
   client: SigningClient<TChain, TAccount>,
   parameters: RedelegatePermissionContextOpenParameters,
 ): Promise<RedelegatePermissionContextReturnType> {
-  const { environment, chainId, scope, caveats, salt } = parameters;
+  const { environment, scope, caveats, salt } = parameters;
+  const chainId = resolveChainId(client, parameters.chainId);
 
   const { account, delegations, parentDelegation, from } =
     resolveRedelegationArgs(client, parameters);
@@ -324,62 +327,4 @@ function resolveChainId(
     );
   }
   return client.chain.id;
-}
-
-/**
- * Creates redelegation actions that can be used to extend a wallet client.
- *
- * Adds two actions:
- * - `redelegatePermissionContext` for redelegating to a specific delegate.
- * - `redelegatePermissionContextOpen` for creating an open redelegation.
- *
- * @returns A function that can be used with the wallet client `extend` method.
- *
- * @example
- * ```ts
- * const walletClient = createWalletClient({
- *   chain: sepolia,
- *   transport: http(),
- * }).extend(redelegatePermissionContextActions());
- *
- * // Specific redelegation
- * const specific = await walletClient.redelegatePermissionContext({
- *   environment,
- *   permissionContext: erc7715Response.context,
- *   to: charlie.address,
- * });
- *
- * // Open redelegation
- * const open = await walletClient.redelegatePermissionContextOpen({
- *   environment,
- *   permissionContext: erc7715Response.context,
- * });
- * ```
- */
-export function redelegatePermissionContextActions() {
-  return <
-    TChain extends Chain | undefined,
-    TAccount extends Account | undefined,
-  >(
-    client: SigningClient<TChain, TAccount>,
-  ) => ({
-    redelegatePermissionContext: async (
-      parameters: Omit<RedelegatePermissionContextParameters, 'chainId'> & {
-        chainId?: number;
-      },
-    ) =>
-      redelegatePermissionContext(client, {
-        ...parameters,
-        chainId: resolveChainId(client, parameters.chainId),
-      }),
-    redelegatePermissionContextOpen: async (
-      parameters: Omit<RedelegatePermissionContextOpenParameters, 'chainId'> & {
-        chainId?: number;
-      },
-    ) =>
-      redelegatePermissionContextOpen(client, {
-        ...parameters,
-        chainId: resolveChainId(client, parameters.chainId),
-      }),
-  });
 }

--- a/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
+++ b/packages/smart-accounts-kit/test/actions/redelegatePermissionContext.test.ts
@@ -3,10 +3,10 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { sepolia } from 'viem/chains';
 import { describe, it, expect, beforeEach } from 'vitest';
 
+import { erc7710WalletActions } from '../../src/actions';
 import {
-  redelegatePermissionContext,
-  redelegatePermissionContextOpen,
-  redelegatePermissionContextActions,
+  redelegatePermissionContextAction,
+  redelegatePermissionContextOpenAction,
 } from '../../src/actions/redelegatePermissionContext';
 import { ScopeType } from '../../src/constants';
 import {
@@ -127,7 +127,7 @@ const buildPermissionContextWithRootAuthorityLeafDelegate = (
   return encodeDelegations([rootAuthorityLeafDelegation]);
 };
 
-describe('redelegatePermissionContext', () => {
+describe('redelegatePermissionContextAction', () => {
   let client: ReturnType<typeof createWalletClient>;
 
   beforeEach(() => {
@@ -142,7 +142,7 @@ describe('redelegatePermissionContext', () => {
     const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(client, {
+    const result = await redelegatePermissionContextAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -167,7 +167,7 @@ describe('redelegatePermissionContext', () => {
     const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(client, {
+    const result = await redelegatePermissionContextAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -182,7 +182,7 @@ describe('redelegatePermissionContext', () => {
     const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(client, {
+    const result = await redelegatePermissionContextAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -199,7 +199,7 @@ describe('redelegatePermissionContext', () => {
     const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(client, {
+    const result = await redelegatePermissionContextAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -227,7 +227,7 @@ describe('redelegatePermissionContext', () => {
       buildPermissionContextWithParentDelegate(parentDelegate);
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(client, {
+    const result = await redelegatePermissionContextAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -242,7 +242,7 @@ describe('redelegatePermissionContext', () => {
     const permissionContext = buildPermissionContextWithOpenLeafDelegation();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(client, {
+    const result = await redelegatePermissionContextAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -260,7 +260,7 @@ describe('redelegatePermissionContext', () => {
       buildPermissionContextWithRootAuthorityLeafDelegate(leafDelegate);
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(client, {
+    const result = await redelegatePermissionContextAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -275,7 +275,7 @@ describe('redelegatePermissionContext', () => {
     const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(client, {
+    const result = await redelegatePermissionContextAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -295,7 +295,7 @@ describe('redelegatePermissionContext', () => {
     const emptyContext = encodeDelegations([]);
 
     await expect(
-      redelegatePermissionContext(client, {
+      redelegatePermissionContextAction(client, {
         environment: mockEnvironment,
         permissionContext: emptyContext,
         chainId: mockChainId,
@@ -315,13 +315,44 @@ describe('redelegatePermissionContext', () => {
     const permissionContext = buildRootPermissionContext();
 
     await expect(
-      redelegatePermissionContext(clientWithoutAccount, {
+      redelegatePermissionContextAction(clientWithoutAccount, {
         environment: mockEnvironment,
         permissionContext,
         chainId: mockChainId,
         to: '0x2000000000000000000000000000000000000002',
       }),
     ).rejects.toThrow('Account not found');
+  });
+
+  it('should infer chainId from client when not provided', async () => {
+    const permissionContext = buildRootPermissionContext();
+    const newDelegate: Address = '0x2000000000000000000000000000000000000002';
+
+    const result = await redelegatePermissionContextAction(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      to: newDelegate,
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.delegate).to.equal(newDelegate);
+    expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
+  });
+
+  it('should throw error if chain is not configured and chainId is not provided', async () => {
+    const clientWithoutChain = createWalletClient({
+      account,
+      transport: http('https://rpc.sepolia.org'),
+    });
+    const permissionContext = buildRootPermissionContext();
+
+    await expect(
+      redelegatePermissionContextAction(clientWithoutChain, {
+        environment: mockEnvironment,
+        permissionContext,
+        to: '0x2000000000000000000000000000000000000002',
+      }),
+    ).rejects.toThrow('Chain ID is required');
   });
 
   it('should work with explicit account parameter', async () => {
@@ -333,14 +364,17 @@ describe('redelegatePermissionContext', () => {
     const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
 
-    const result = await redelegatePermissionContext(clientWithoutAccount, {
-      account,
-      environment: mockEnvironment,
-      permissionContext,
-      chainId: mockChainId,
-      to: newDelegate,
-      caveats: [timestampCaveat],
-    });
+    const result = await redelegatePermissionContextAction(
+      clientWithoutAccount,
+      {
+        account,
+        environment: mockEnvironment,
+        permissionContext,
+        chainId: mockChainId,
+        to: newDelegate,
+        caveats: [timestampCaveat],
+      },
+    );
 
     expect(result.delegation.delegate).to.equal(newDelegate);
     expect(result.delegation.delegator.toLowerCase()).to.equal(
@@ -349,7 +383,7 @@ describe('redelegatePermissionContext', () => {
   });
 });
 
-describe('redelegatePermissionContextOpen', () => {
+describe('redelegatePermissionContextOpenAction', () => {
   let client: ReturnType<typeof createWalletClient>;
 
   beforeEach(() => {
@@ -363,7 +397,7 @@ describe('redelegatePermissionContextOpen', () => {
   it('should create an open redelegation (delegate = ANY_BENEFICIARY)', async () => {
     const permissionContext = buildRootPermissionContext({ maxAmount: 500n });
 
-    const result = await redelegatePermissionContextOpen(client, {
+    const result = await redelegatePermissionContextOpenAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -382,7 +416,7 @@ describe('redelegatePermissionContextOpen', () => {
   it('should add additional caveats to the open redelegation', async () => {
     const permissionContext = buildRootPermissionContext();
 
-    const result = await redelegatePermissionContextOpen(client, {
+    const result = await redelegatePermissionContextOpenAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -395,7 +429,7 @@ describe('redelegatePermissionContextOpen', () => {
   it('should inherit scope from parent when no scope is provided', async () => {
     const permissionContext = buildRootPermissionContext();
 
-    const result = await redelegatePermissionContextOpen(client, {
+    const result = await redelegatePermissionContextOpenAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -409,7 +443,7 @@ describe('redelegatePermissionContextOpen', () => {
   it('should sign successfully when inheriting from parent without scope or caveats', async () => {
     const permissionContext = buildRootPermissionContext();
 
-    const result = await redelegatePermissionContextOpen(client, {
+    const result = await redelegatePermissionContextOpenAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -433,7 +467,7 @@ describe('redelegatePermissionContextOpen', () => {
     const permissionContext =
       buildPermissionContextWithParentDelegate(parentDelegate);
 
-    const result = await redelegatePermissionContextOpen(client, {
+    const result = await redelegatePermissionContextOpenAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -446,7 +480,7 @@ describe('redelegatePermissionContextOpen', () => {
   it('should use the account address as from when the leaf delegation is open', async () => {
     const permissionContext = buildPermissionContextWithOpenLeafDelegation();
 
-    const result = await redelegatePermissionContextOpen(client, {
+    const result = await redelegatePermissionContextOpenAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -462,7 +496,7 @@ describe('redelegatePermissionContextOpen', () => {
     const permissionContext =
       buildPermissionContextWithRootAuthorityLeafDelegate(leafDelegate);
 
-    const result = await redelegatePermissionContextOpen(client, {
+    const result = await redelegatePermissionContextOpenAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -475,7 +509,7 @@ describe('redelegatePermissionContextOpen', () => {
   it('should allow scope override on an open redelegation', async () => {
     const permissionContext = buildRootPermissionContext();
 
-    const result = await redelegatePermissionContextOpen(client, {
+    const result = await redelegatePermissionContextOpenAction(client, {
       environment: mockEnvironment,
       permissionContext,
       chainId: mockChainId,
@@ -492,7 +526,7 @@ describe('redelegatePermissionContextOpen', () => {
     const emptyContext = encodeDelegations([]);
 
     await expect(
-      redelegatePermissionContextOpen(client, {
+      redelegatePermissionContextOpenAction(client, {
         environment: mockEnvironment,
         permissionContext: emptyContext,
         chainId: mockChainId,
@@ -511,22 +545,52 @@ describe('redelegatePermissionContextOpen', () => {
     const permissionContext = buildRootPermissionContext();
 
     await expect(
-      redelegatePermissionContextOpen(clientWithoutAccount, {
+      redelegatePermissionContextOpenAction(clientWithoutAccount, {
         environment: mockEnvironment,
         permissionContext,
         chainId: mockChainId,
       }),
     ).rejects.toThrow('Account not found');
   });
+
+  it('should infer chainId from client when not provided', async () => {
+    const permissionContext = buildRootPermissionContext();
+
+    const result = await redelegatePermissionContextOpenAction(client, {
+      environment: mockEnvironment,
+      permissionContext,
+      caveats: [timestampCaveat],
+    });
+
+    expect(result.delegation.delegate).to.equal(
+      '0x0000000000000000000000000000000000000a11',
+    );
+    expect(result.delegation.signature).to.match(/^0x[a-fA-F0-9]+$/u);
+  });
+
+  it('should throw error if chain is not configured and chainId is not provided', async () => {
+    const clientWithoutChain = createWalletClient({
+      account,
+      transport: http('https://rpc.sepolia.org'),
+    });
+    const permissionContext = buildRootPermissionContext();
+
+    await expect(
+      redelegatePermissionContextOpenAction(clientWithoutChain, {
+        environment: mockEnvironment,
+        permissionContext,
+      }),
+    ).rejects.toThrow('Chain ID is required');
+  });
 });
 
-describe('redelegatePermissionContextActions', () => {
+describe('erc7710WalletActions (redelegation actions)', () => {
   it('should extend a wallet client with redelegatePermissionContext', async () => {
     const client = createWalletClient({
       account,
       chain: sepolia,
       transport: http('https://rpc.sepolia.org'),
-    }).extend(redelegatePermissionContextActions());
+    }).extend(erc7710WalletActions());
 
     const permissionContext = buildRootPermissionContext();
     const newDelegate: Address = '0x2000000000000000000000000000000000000002';
@@ -536,7 +600,6 @@ describe('redelegatePermissionContextActions', () => {
       permissionContext,
       to: newDelegate,
       caveats: [timestampCaveat],
-      // chainId should be inferred from client
     });
 
     expect(result.delegation.delegate).to.equal(newDelegate);
@@ -550,7 +613,7 @@ describe('redelegatePermissionContextActions', () => {
       account,
       chain: sepolia,
       transport: http('https://rpc.sepolia.org'),
-    }).extend(redelegatePermissionContextActions());
+    }).extend(erc7710WalletActions());
 
     const permissionContext = buildRootPermissionContext();
 
@@ -558,7 +621,6 @@ describe('redelegatePermissionContextActions', () => {
       environment: mockEnvironment,
       permissionContext,
       caveats: [timestampCaveat],
-      // chainId should be inferred from client
     });
 
     expect(result.delegation.delegate).to.equal(
@@ -569,11 +631,48 @@ describe('redelegatePermissionContextActions', () => {
     );
   });
 
+  it('should work when client has no configured chain if chainId is provided (specific)', async () => {
+    const clientWithoutChain = createWalletClient({
+      account,
+      transport: http('https://rpc.sepolia.org'),
+    }).extend(erc7710WalletActions());
+
+    const permissionContext = buildRootPermissionContext();
+
+    const result = await clientWithoutChain.redelegatePermissionContext({
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+      to: '0x2000000000000000000000000000000000000002',
+    });
+    expect(result.delegation.delegate).to.equal(
+      '0x2000000000000000000000000000000000000002',
+    );
+  });
+
+  it('should work when client has no configured chain if chainId is provided (open)', async () => {
+    const clientWithoutChain = createWalletClient({
+      account,
+      transport: http('https://rpc.sepolia.org'),
+    }).extend(erc7710WalletActions());
+
+    const permissionContext = buildRootPermissionContext();
+
+    const result = await clientWithoutChain.redelegatePermissionContextOpen({
+      environment: mockEnvironment,
+      permissionContext,
+      chainId: mockChainId,
+    });
+    expect(result.delegation.delegate).to.equal(
+      '0x0000000000000000000000000000000000000a11',
+    );
+  });
+
   it('should throw error if chain is not configured and chainId is not provided (specific)', async () => {
     const clientWithoutChain = createWalletClient({
       account,
       transport: http('https://rpc.sepolia.org'),
-    }).extend(redelegatePermissionContextActions());
+    }).extend(erc7710WalletActions());
 
     const permissionContext = buildRootPermissionContext();
 
@@ -590,7 +689,7 @@ describe('redelegatePermissionContextActions', () => {
     const clientWithoutChain = createWalletClient({
       account,
       transport: http('https://rpc.sepolia.org'),
-    }).extend(redelegatePermissionContextActions());
+    }).extend(erc7710WalletActions());
 
     const permissionContext = buildRootPermissionContext();
 


### PR DESCRIPTION
## 📝 Description

To improve consistency with the existing ERC-7710 developer experience, this PR moves the redelegation actions to the `ERC7710WalletActions`

## 🔄 What Changed?

- add `Action` suffix to action names
- remove `redelegatePermissionContextActions` function
- add individual redelegation actions to `erc7710WalletActions`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to breaking API changes (renamed exports and removal of `redelegatePermissionContextActions`) and updated chainId resolution behavior that could affect downstream integrations.
> 
> **Overview**
> **Reshapes the redelegation API for consistency with ERC-7710 client extensions.** The standalone redelegation functions are renamed to `redelegatePermissionContextAction` / `redelegatePermissionContextOpenAction`, and the previous `redelegatePermissionContextActions` extender is removed.
> 
> **Adds redelegation methods to `erc7710WalletActions`.** Wallet clients extended via `erc7710WalletActions()` now expose `redelegatePermissionContext` and `redelegatePermissionContextOpen`.
> 
> **Makes `chainId` optional for redelegation.** Both redelegation actions now resolve `chainId` from `client.chain.id` when omitted (and throw if neither is available), with tests updated/expanded to cover inference and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aa9f001b8c3c9dfde9057c86c0751312b910fd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->