### PR TITLE
Bump yarn from 4.10.1 to 4.14.1

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -18,6 +18,8 @@ plugins:
 
 npmMinimalAgeGate: 4320
 
+approvedGitRepositories: []
+
 packageExtensions:
   "eslint-plugin-n@*":
     peerDependencies:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript-eslint": "^8.0.0",
     "viem": "2.31.4"
   },
-  "packageManager": "yarn@4.10.1",
+  "packageManager": "yarn@4.14.1",
   "engines": {
     "node": "^18.18 || >=20"
   },

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -179,7 +179,7 @@ module.exports = defineConfig({
       if (isChildWorkspace) {
         workspace.unset('packageManager');
       } else {
-        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.10.1');
+        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.14.1');
       }
 
       // All packages must specify a minimum Node.js version of 18.18.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@adraffy/ens-normalize@npm:^1.11.0":


### PR DESCRIPTION
## 📝 Description

Upgrades yarn from 4.10.1 to 4.14.1 to take advantage of `approvedGitRepositories`.

## 🔄 What Changed?

- Upgrades yarn from 4.10.1 to 4.14.1
- Updates the expected package manager version in constraints
- Adds `approvedGitRepositories` to `.yarnrc.yml` with empty array

## 🚀 Why?

By enforcing no-git-dependencies, we close a security vulnerability where transient depenencies can be added to a package, resulting in unverified code being downloaded.

Any dependencies that are required via git may be added by including the glob in `approvedGitRepositories` in `.yarnrc.yml`.

## 🧪 How to Test?

```
❯ yarn add typanion@git@github.com/arcanis/typanion.git
➤ YN0000: · Yarn 4.14.1
➤ YN0000: ┌ Resolution step
➤ YN0080: │ typanion@git@github.com/arcanis/typanion.git: Request to 'ssh://git@github.com/arcanis/typanion.git' has been blocked because it doesn't match any of the patterns in 'approvedGitRepositories'
➤ YN0000: └ Completed
➤ YN0000: · Failed with errors in 0s 40ms
```

## ⚠️ Breaking Changes

List any breaking changes:

- [X] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates the Yarn toolchain and lockfile metadata; primary risk is CI/dev environment mismatch if Yarn 4.14.1 isn’t used consistently.
> 
> **Overview**
> Upgrades the repo’s Yarn version requirement from `4.10.1` to `4.14.1` (including updating Yarn constraints and regenerating `yarn.lock` metadata).
> 
> Adds `approvedGitRepositories: []` to `.yarnrc.yml` to block git-based dependencies by default unless explicitly allowlisted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455c637b3c3875bdc8639849bc2739683821621c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->