### PR TITLE
Add workflow to post gatorbot issues

### DIFF
--- a/.github/workflows/new-issue-slack-notification.yml
+++ b/.github/workflows/new-issue-slack-notification.yml
@@ -1,0 +1,60 @@
+name: Notify Slack On New Issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  notify-slack:
+    name: Send issue notification to Slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post new issue to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.GATOR_BOT_SLACK_WEBHOOK_URL }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "GATOR_BOT_SLACK_WEBHOOK_URL is not set."
+            exit 1
+          fi
+
+          payload=$(jq -n \
+            --arg title "$ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
+            --arg author "$ISSUE_AUTHOR" \
+            '{
+              "text": "New GitHub issue created",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*New GitHub issue created*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Title:*\n\($title)"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Raised by:*\n\($author)"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Link:*\n<\($url)|View issue>"
+                    }
+                  ]
+                }
+              ]
+            }')
+
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --data "$payload" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## 📝 Description

New issues raised on the smart accounts kit are posted to slack via the gator bot.

Presently this posts _all_ issues created. If this becomes noisy, we can consider filtering out issues created by team members.

## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone GitHub Actions workflow that posts issue metadata to Slack via a secret webhook, with no runtime code changes. Main risk is misconfiguration/noise if the webhook secret is missing or points to the wrong channel.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `new-issue-slack-notification.yml`, that triggers on `issues: opened` and posts a formatted Slack message containing the issue title, author, and link.
> 
> The job uses the `GATOR_BOT_SLACK_WEBHOOK_URL` secret, fails fast when it’s unset, builds the payload with `jq`, and sends it via `curl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63e8fe9d3a8f2f741474147933e2b61e0c6ef29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->