### PR TITLE
Release/30.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [30.0.0]
+
 ## [29.0.0]
 
 ## [28.0.0]
@@ -53,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0]
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@29.0.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@30.0.0...HEAD
+[30.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@29.0.0...delegator-sdk-monorepo@30.0.0
 [29.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@28.0.0...delegator-sdk-monorepo@29.0.0
 [28.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@27.0.0...delegator-sdk-monorepo@28.0.0
 [27.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@26.0.0...delegator-sdk-monorepo@27.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delegator-sdk-monorepo",
-  "version": "29.0.0",
+  "version": "30.0.0",
   "license": "(MIT-0 OR Apache-2.0)",
   "private": true,
   "repository": {

--- a/packages/7715-permission-types/CHANGELOG.md
+++ b/packages/7715-permission-types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0]
+
 ### Added
 
 - New permission type `token-approval-revocation` ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226))
@@ -49,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Type definitions for EIP-7715 Execution Permissions, and definitions for permission types supported by MetaMask
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.6.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.7.0...HEAD
+[0.7.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.6.0...@metamask/7715-permission-types@0.7.0
 [0.6.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.5.0...@metamask/7715-permission-types@0.6.0
 [0.5.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.4.0...@metamask/7715-permission-types@0.5.0
 [0.4.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.3.0...@metamask/7715-permission-types@0.4.0

--- a/packages/7715-permission-types/package.json
+++ b/packages/7715-permission-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/7715-permission-types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Permission types for the ERC-7715",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/delegation-abis/CHANGELOG.md
+++ b/packages/delegation-abis/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0]
+
 ### Added
 
 - Abis for `ApprovalRevocationEnforcer` ([#226](https://github.com/metamask/smart-accounts-kit/pull/226))
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve @metamask/delegation-abis tree-shakability ([#131](https://github.com/metamask/smart-accounts-kit/pull/131))
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-abis@1.0.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-abis@1.1.0...HEAD
+[1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-abis@1.0.0...@metamask/delegation-abis@1.1.0
 [1.0.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-abis@0.12.0-beta.0...@metamask/delegation-abis@1.0.0
 [0.12.0-beta.0]: https://github.com/metamask/smart-accounts-kit/releases/tag/@metamask/delegation-abis@0.12.0-beta.0

--- a/packages/delegation-abis/package.json
+++ b/packages/delegation-abis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-abis",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ABIs mapped to versions of the Delegation Framework contracts",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0]
+
 ### Added
 
 - Encoding and decoding utils for `ApprovalRevocationEnforcer` enforcer args and terms ([#226](https://github.com/metamask/smart-accounts-kit/pull/226))
@@ -110,7 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add @metamask/delegation-core package, providing utility types, delegation hashing, and terms encoding for a limited set of caveat enforcers.
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.1.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.2.0...HEAD
+[2.2.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.1.0...@metamask/delegation-core@2.2.0
 [2.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.0.0...@metamask/delegation-core@2.1.0
 [2.0.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.1.0...@metamask/delegation-core@2.0.0
 [1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.0.0...@metamask/delegation-core@1.1.0

--- a/packages/delegation-core/package.json
+++ b/packages/delegation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Low level core functionality for interacting with the Delegation Framework",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0]
+
 ### Added
 
 - Add chain deployment for Intuition mainnet and testnet ([#206](https://github.com/MetaMask/smart-accounts-kit/pull/206))
@@ -76,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add deployments for Sei mainnet ([#84](https://github.com/metamask/smart-accounts-kit/pull/84))
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.3.0...HEAD
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.4.0...HEAD
+[1.4.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.3.0...@metamask/delegation-deployments@1.4.0
 [1.3.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.2.0...@metamask/delegation-deployments@1.3.0
 [1.2.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.1.0...@metamask/delegation-deployments@1.2.0
 [1.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-deployments@1.0.0...@metamask/delegation-deployments@1.1.0

--- a/packages/delegation-deployments/package.json
+++ b/packages/delegation-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-deployments",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A history of deployments of the Delegation Framework",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- TEMP remove changelog
-
 ### Added
 
 - ERC-7715 `token-approval-revocation` permission type ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226))

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,17 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ERC-7715 `token-approval-revocation` permission type ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226))
+- `CaveatBuilder` for `ApprovalRevocationEnforcer`, deployment address added to `SmartAccountsEnvironment` ([#226](https://github.com/metamask/smart-accounts-kit/pull/226))
+
 ### Changed
 
 - Bumped @metamask/delegation-abis from `^1.0.0` to `^1.1.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
 - Bumped @metamask/delegation-core from `^0.1.0` to `^@.2.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
 - Bumped @metamask/delegation-deployments from `^1.3.0` to `^1.4.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
 - Bumped @metamask/7715-permission-types from `^0.6.0` to `^0.7.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
-
-### Added
-
-- ERC-7715 `token-approval-revocation` permission type ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226))
-- `CaveatBuilder` for `ApprovalRevocationEnforcer`, deployment address added to `SmartAccountsEnvironment` ([#226](https://github.com/metamask/smart-accounts-kit/pull/226))
 
 ### Deprecated
 

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped @metamask/delegation-abis from `^1.0.0` to `^1.1.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
+- Bumped @metamask/delegation-core from `^0.1.0` to `^@.2.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
+- Bumped @metamask/delegation-deployments from `^1.3.0` to `^1.4.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
+- Bumped @metamask/7715-permission-types from `^0.6.0` to `^0.7.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
+
 ### Added
 
 - ERC-7715 `token-approval-revocation` permission type ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226))

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- TEMP remove changelog
+
 ### Added
 
 - ERC-7715 `token-approval-revocation` permission type ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226))

--- a/packages/smart-accounts-kit/package.json
+++ b/packages/smart-accounts-kit/package.json
@@ -124,10 +124,10 @@
     }
   },
   "dependencies": {
-    "@metamask/7715-permission-types": "^0.6.0",
-    "@metamask/delegation-abis": "^1.0.0",
-    "@metamask/delegation-core": "^2.1.0",
-    "@metamask/delegation-deployments": "^1.3.0",
+    "@metamask/7715-permission-types": "^0.7.0",
+    "@metamask/delegation-abis": "^1.1.0",
+    "@metamask/delegation-core": "^2.2.0",
+    "@metamask/delegation-deployments": "^1.4.0",
     "openapi-fetch": "^0.13.5",
     "ox": "0.8.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,7 +572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/7715-permission-types@npm:^0.6.0, @metamask/7715-permission-types@workspace:packages/7715-permission-types":
+"@metamask/7715-permission-types@npm:^0.7.0, @metamask/7715-permission-types@workspace:packages/7715-permission-types":
   version: 0.0.0-use.local
   resolution: "@metamask/7715-permission-types@workspace:packages/7715-permission-types"
   dependencies:
@@ -664,7 +664,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-abis@npm:^1.0.0, @metamask/delegation-abis@workspace:packages/delegation-abis":
+"@metamask/delegation-abis@npm:^1.1.0, @metamask/delegation-abis@workspace:packages/delegation-abis":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-abis@workspace:packages/delegation-abis"
   dependencies:
@@ -675,7 +675,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/delegation-core@npm:^2.1.0, @metamask/delegation-core@workspace:packages/delegation-core":
+"@metamask/delegation-core@npm:^2.2.0, @metamask/delegation-core@workspace:packages/delegation-core":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-core@workspace:packages/delegation-core"
   dependencies:
@@ -692,7 +692,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/delegation-deployments@npm:^1.3.0, @metamask/delegation-deployments@workspace:packages/delegation-deployments":
+"@metamask/delegation-deployments@npm:^1.4.0, @metamask/delegation-deployments@workspace:packages/delegation-deployments":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-deployments@workspace:packages/delegation-deployments"
   dependencies:
@@ -776,11 +776,11 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.4.0"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.1"
-    "@metamask/7715-permission-types": "npm:^0.6.0"
+    "@metamask/7715-permission-types": "npm:^0.7.0"
     "@metamask/auto-changelog": "npm:^5.0.2"
-    "@metamask/delegation-abis": "npm:^1.0.0"
-    "@metamask/delegation-core": "npm:^2.1.0"
-    "@metamask/delegation-deployments": "npm:^1.3.0"
+    "@metamask/delegation-abis": "npm:^1.1.0"
+    "@metamask/delegation-core": "npm:^2.2.0"
+    "@metamask/delegation-deployments": "npm:^1.4.0"
     "@metamask/eslint-config": "npm:14.1.0"
     "@metamask/eslint-config-nodejs": "npm:14.0.0"
     "@metamask/eslint-config-typescript": "npm:14.0.0"


### PR DESCRIPTION
## 📝 Description

Releases:
- @metamask/delegation-abis@1.1.0
- @metamask/delegation-core@@.2.0
- @metamask/delegation-deployments@1.4.0
- @metamask/7715-permission-types@0.7.0

## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates package versions/changelogs and bumps internal dependency ranges/lockfile, with no functional code changes in this diff.
> 
> **Overview**
> Cuts the `30.0.0` release by bumping the monorepo version and updating top-level and package changelog compare links.
> 
> Bumps package versions for `@metamask/7715-permission-types` (`0.6.0`→`0.7.0`), `@metamask/delegation-abis` (`1.0.0`→`1.1.0`), `@metamask/delegation-core` (`2.1.0`→`2.2.0`), and `@metamask/delegation-deployments` (`1.3.0`→`1.4.0`), and updates `@metamask/smart-accounts-kit` to depend on those new versions (with corresponding `yarn.lock` updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0da1bcf989e0960871d1ce23fcfcaa76dc50c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->