### PR TITLE
Revert "Update Release 31.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [31.0.0]
-
 ## [30.0.0]
 
 ## [29.0.0]
@@ -57,8 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0]
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@31.0.0...HEAD
-[31.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@30.0.0...delegator-sdk-monorepo@31.0.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@30.0.0...HEAD
 [30.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@29.0.0...delegator-sdk-monorepo@30.0.0
 [29.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@28.0.0...delegator-sdk-monorepo@29.0.0
 [28.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@27.0.0...delegator-sdk-monorepo@28.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delegator-sdk-monorepo",
-  "version": "31.0.0",
+  "version": "30.0.0",
   "license": "(MIT-0 OR Apache-2.0)",
   "private": true,
   "repository": {

--- a/packages/7715-permission-types/CHANGELOG.md
+++ b/packages/7715-permission-types/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.0]
-
 ### Fixed
 
 - Rename `permit2ApproveZero` to `permit2Approve` in `TokenApprovalRevocationPermission` ERC-7715 permission data ([#237](https://github.com/MetaMask/smart-accounts-kit/pull/237))
@@ -57,8 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Type definitions for EIP-7715 Execution Permissions, and definitions for permission types supported by MetaMask
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.8.0...HEAD
-[0.8.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.7.0...@metamask/7715-permission-types@0.8.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.7.0...HEAD
 [0.7.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.6.0...@metamask/7715-permission-types@0.7.0
 [0.6.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.5.0...@metamask/7715-permission-types@0.6.0
 [0.5.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.4.0...@metamask/7715-permission-types@0.5.0

--- a/packages/7715-permission-types/package.json
+++ b/packages/7715-permission-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/7715-permission-types",
-  "version": "0.8.0",
+  "version": "0.7.0",
   "description": "Permission types for the ERC-7715",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.3.0]
-
 ### Fixed
 
 - Rename `permit2ApproveZero` to `permit2Approve` in `approvalRevocationEnforcer` terms builders and decoders ([#237](https://github.com/MetaMask/smart-accounts-kit/pull/237))
@@ -118,8 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add @metamask/delegation-core package, providing utility types, delegation hashing, and terms encoding for a limited set of caveat enforcers.
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.3.0...HEAD
-[2.3.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.2.0...@metamask/delegation-core@2.3.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.2.0...HEAD
 [2.2.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.1.0...@metamask/delegation-core@2.2.0
 [2.1.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@2.0.0...@metamask/delegation-core@2.1.0
 [2.0.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/delegation-core@1.1.0...@metamask/delegation-core@2.0.0

--- a/packages/delegation-core/package.json
+++ b/packages/delegation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-core",
-  "version": "2.3.0",
+  "version": "2.2.0",
   "description": "Low level core functionality for interacting with the Delegation Framework",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped @metamask/delegation-abis from `^1.0.0` to `^1.1.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
-- Bumped @metamask/delegation-core from `^2.1.0` to `^2.3.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234), [#238](https://github.com/MetaMask/smart-accounts-kit/pull/238))
+- Bumped @metamask/delegation-core from `^0.1.0` to `^@.2.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
 - Bumped @metamask/delegation-deployments from `^1.3.0` to `^1.4.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
-- Bumped @metamask/7715-permission-types from `^0.6.0` to `^0.8.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234), [#238](https://github.com/MetaMask/smart-accounts-kit/pull/238))
+- Bumped @metamask/7715-permission-types from `^0.6.0` to `^0.7.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
 
 ### Deprecated
 

--- a/packages/smart-accounts-kit/package.json
+++ b/packages/smart-accounts-kit/package.json
@@ -124,9 +124,9 @@
     }
   },
   "dependencies": {
-    "@metamask/7715-permission-types": "^0.8.0",
+    "@metamask/7715-permission-types": "^0.7.0",
     "@metamask/delegation-abis": "^1.1.0",
-    "@metamask/delegation-core": "^2.3.0",
+    "@metamask/delegation-core": "^2.2.0",
     "@metamask/delegation-deployments": "^1.4.0",
     "openapi-fetch": "^0.13.5",
     "ox": "0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,7 +572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/7715-permission-types@npm:^0.8.0, @metamask/7715-permission-types@workspace:packages/7715-permission-types":
+"@metamask/7715-permission-types@npm:^0.7.0, @metamask/7715-permission-types@workspace:packages/7715-permission-types":
   version: 0.0.0-use.local
   resolution: "@metamask/7715-permission-types@workspace:packages/7715-permission-types"
   dependencies:
@@ -675,7 +675,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/delegation-core@npm:^2.3.0, @metamask/delegation-core@workspace:packages/delegation-core":
+"@metamask/delegation-core@npm:^2.2.0, @metamask/delegation-core@workspace:packages/delegation-core":
   version: 0.0.0-use.local
   resolution: "@metamask/delegation-core@workspace:packages/delegation-core"
   dependencies:
@@ -776,10 +776,10 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.4.0"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.1"
-    "@metamask/7715-permission-types": "npm:^0.8.0"
+    "@metamask/7715-permission-types": "npm:^0.7.0"
     "@metamask/auto-changelog": "npm:^5.0.2"
     "@metamask/delegation-abis": "npm:^1.1.0"
-    "@metamask/delegation-core": "npm:^2.3.0"
+    "@metamask/delegation-core": "npm:^2.2.0"
     "@metamask/delegation-deployments": "npm:^1.4.0"
     "@metamask/eslint-config": "npm:14.1.0"
     "@metamask/eslint-config-nodejs": "npm:14.0.0"


### PR DESCRIPTION
Reverts MetaMask/smart-accounts-kit#238

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily reverts package version/dependency bumps and changelog compare links; no runtime logic changes, but could affect published package versioning and downstream dependency resolution.
> 
> **Overview**
> Reverts the prior `31.0.0` release bookkeeping by rolling back the monorepo version to `30.0.0` and removing `31.0.0` entries/compare links from changelogs.
> 
> Downgrades `@metamask/7715-permission-types` (`0.8.0`→`0.7.0`) and `@metamask/delegation-core` (`2.3.0`→`2.2.0`) in `@metamask/smart-accounts-kit`, with corresponding `yarn.lock` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6518c2c2d195074b6b1209e755ea7706ff2e28a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->