### PR TITLE
fix: drop viem from x402 address validation

### DIFF
--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `@metamask/utils` for x402 address checksum validation instead of `viem`. ([#246](https://github.com/MetaMask/smart-accounts-kit/pull/246))
 - Bumped @metamask/delegation-abis from `^1.0.0` to `^1.1.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
 - Bumped @metamask/delegation-core from `^2.1.0` to `^2.2.1` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234), [#240](https://github.com/MetaMask/smart-accounts-kit/pull/240))
 - Bumped @metamask/delegation-deployments from `^1.3.0` to `^1.4.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use `@metamask/utils` for x402 address checksum validation instead of `viem`. ([#246](https://github.com/MetaMask/smart-accounts-kit/pull/246))
 - Bumped @metamask/delegation-abis from `^1.0.0` to `^1.1.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))
 - Bumped @metamask/delegation-core from `^2.1.0` to `^2.2.1` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234), [#240](https://github.com/MetaMask/smart-accounts-kit/pull/240))
 - Bumped @metamask/delegation-deployments from `^1.3.0` to `^1.4.0` ([#234](https://github.com/MetaMask/smart-accounts-kit/pull/234))

--- a/packages/x402/CHANGELOG.md
+++ b/packages/x402/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `@metamask/utils` for Ethereum address checksum validation and drop `viem` as a package dependency. ([#246](https://github.com/MetaMask/smart-accounts-kit/pull/246))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -55,10 +55,12 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
+  "dependencies": {
+    "@noble/hashes": "^1.8.0"
+  },
   "peerDependencies": {
     "@x402/core": "^2.12.0",
-    "@x402/evm": "^2.12.0",
-    "viem": "^2.31.4"
+    "@x402/evm": "^2.12.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^5.0.2",
@@ -68,7 +70,6 @@
     "prettier": "^3.5.3",
     "tsup": "^8.5.0",
     "typescript": "5.5.4",
-    "viem": "2.31.4",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -56,7 +56,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@noble/hashes": "^1.8.0"
+    "@metamask/utils": "^11.4.0"
   },
   "peerDependencies": {
     "@x402/core": "^2.12.0",

--- a/packages/x402/src/ethereum.ts
+++ b/packages/x402/src/ethereum.ts
@@ -1,10 +1,8 @@
-import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
-import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils';
+import { getChecksumAddress, isHexChecksumAddress } from '@metamask/utils';
 
 export type Address = `0x${string}`;
 export type Hex = `0x${string}`;
 
-const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/u;
 const HEX_REGEX = /^0x[0-9a-fA-F]*$/u;
 
 /**
@@ -24,44 +22,21 @@ export function isHex(value: unknown): value is Hex {
  * @returns The checksummed address.
  */
 export function getAddress(value: string): Address {
-  if (!ADDRESS_REGEX.test(value)) {
+  if (!isHexChecksumAddress(value)) {
     throw new Error('Invalid Ethereum address');
   }
 
-  const address = value.slice(2);
-  const lowerAddress = address.toLowerCase();
-  const upperAddress = address.toUpperCase();
-  const checksummedAddress = checksumAddress(lowerAddress);
+  const lowerAddress = value.toLowerCase();
+  const upperAddress = value.toUpperCase();
+  const checksummedAddress = getChecksumAddress(value);
 
   if (
-    address !== lowerAddress &&
-    address !== upperAddress &&
-    `0x${address}` !== checksummedAddress
+    value !== lowerAddress &&
+    value !== upperAddress &&
+    value !== checksummedAddress
   ) {
     throw new Error('Invalid Ethereum address checksum');
   }
 
   return checksummedAddress;
-}
-
-/**
- * Convert a lowercase Ethereum address body to EIP-55 checksum form.
- *
- * @param lowerAddress - 40-character lowercase hex address without 0x prefix.
- * @returns The checksummed address with 0x prefix.
- */
-function checksumAddress(lowerAddress: string): Address {
-  const addressHash = bytesToHex(keccak256(utf8ToBytes(lowerAddress)));
-  let checksummed = '0x';
-
-  for (let index = 0; index < lowerAddress.length; index += 1) {
-    const character = lowerAddress[index] as string;
-    const hashNibble = addressHash[index] as string;
-    checksummed +=
-      Number.parseInt(hashNibble, 16) >= 8
-        ? character.toUpperCase()
-        : character;
-  }
-
-  return checksummed as Address;
 }

--- a/packages/x402/src/ethereum.ts
+++ b/packages/x402/src/ethereum.ts
@@ -27,7 +27,7 @@ export function getAddress(value: string): Address {
   }
 
   const lowerAddress = value.toLowerCase();
-  const upperAddress = value.toUpperCase();
+  const upperAddress = `0x${value.slice(2).toUpperCase()}`;
   const checksummedAddress = getChecksumAddress(value);
 
   if (

--- a/packages/x402/src/ethereum.ts
+++ b/packages/x402/src/ethereum.ts
@@ -1,0 +1,67 @@
+import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils';
+
+export type Address = `0x${string}`;
+export type Hex = `0x${string}`;
+
+const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/u;
+const HEX_REGEX = /^0x[0-9a-fA-F]*$/u;
+
+/**
+ * Check whether a value is a 0x-prefixed hexadecimal string.
+ *
+ * @param value - Value to inspect.
+ * @returns True when the value is hex data.
+ */
+export function isHex(value: unknown): value is Hex {
+  return typeof value === 'string' && HEX_REGEX.test(value);
+}
+
+/**
+ * Validate and normalize an Ethereum address to its EIP-55 checksum form.
+ *
+ * @param value - Address string to normalize.
+ * @returns The checksummed address.
+ */
+export function getAddress(value: string): Address {
+  if (!ADDRESS_REGEX.test(value)) {
+    throw new Error('Invalid Ethereum address');
+  }
+
+  const address = value.slice(2);
+  const lowerAddress = address.toLowerCase();
+  const upperAddress = address.toUpperCase();
+  const checksummedAddress = checksumAddress(lowerAddress);
+
+  if (
+    address !== lowerAddress &&
+    address !== upperAddress &&
+    `0x${address}` !== checksummedAddress
+  ) {
+    throw new Error('Invalid Ethereum address checksum');
+  }
+
+  return checksummedAddress;
+}
+
+/**
+ * Convert a lowercase Ethereum address body to EIP-55 checksum form.
+ *
+ * @param lowerAddress - 40-character lowercase hex address without 0x prefix.
+ * @returns The checksummed address with 0x prefix.
+ */
+function checksumAddress(lowerAddress: string): Address {
+  const addressHash = bytesToHex(keccak256(utf8ToBytes(lowerAddress)));
+  let checksummed = '0x';
+
+  for (let index = 0; index < lowerAddress.length; index += 1) {
+    const character = lowerAddress[index] as string;
+    const hashNibble = addressHash[index] as string;
+    checksummed +=
+      Number.parseInt(hashNibble, 16) >= 8
+        ? character.toUpperCase()
+        : character;
+  }
+
+  return checksummed as Address;
+}

--- a/packages/x402/src/ethereum.ts
+++ b/packages/x402/src/ethereum.ts
@@ -1,19 +1,8 @@
-import { getChecksumAddress, isHexChecksumAddress } from '@metamask/utils';
-
-export type Address = `0x${string}`;
-export type Hex = `0x${string}`;
-
-const HEX_REGEX = /^0x[0-9a-fA-F]*$/u;
-
-/**
- * Check whether a value is a 0x-prefixed hexadecimal string.
- *
- * @param value - Value to inspect.
- * @returns True when the value is hex data.
- */
-export function isHex(value: unknown): value is Hex {
-  return typeof value === 'string' && HEX_REGEX.test(value);
-}
+import {
+  getChecksumAddress,
+  isHexChecksumAddress,
+  type Hex,
+} from '@metamask/utils';
 
 /**
  * Validate and normalize an Ethereum address to its EIP-55 checksum form.
@@ -21,7 +10,7 @@ export function isHex(value: unknown): value is Hex {
  * @param value - Address string to normalize.
  * @returns The checksummed address.
  */
-export function getAddress(value: string): Address {
+export function getAddress(value: string): Hex {
   if (!isHexChecksumAddress(value)) {
     throw new Error('Invalid Ethereum address');
   }

--- a/packages/x402/src/x402Client.ts
+++ b/packages/x402/src/x402Client.ts
@@ -1,4 +1,6 @@
-import { type Hex, getAddress, isHex } from './ethereum';
+import { isStrictHexString, type Hex } from '@metamask/utils';
+
+import { getAddress } from './ethereum';
 
 export type x402PaymentRequirements = {
   scheme: string;
@@ -49,7 +51,7 @@ export type x402Erc7710ClientConfig = {
 function normalizeDelegationPayload(
   payload: x402DelegationPaymentPayload,
 ): x402DelegationPaymentPayload {
-  if (!isHex(payload.permissionContext) || payload.permissionContext === '0x') {
+  if (!isStrictHexString(payload.permissionContext)) {
     throw new Error(
       'Invalid delegation payload: permissionContext must be non-empty hex data',
     );

--- a/packages/x402/src/x402Client.ts
+++ b/packages/x402/src/x402Client.ts
@@ -1,4 +1,4 @@
-import { type Hex, getAddress, isHex } from 'viem';
+import { type Hex, getAddress, isHex } from './ethereum';
 
 export type x402PaymentRequirements = {
   scheme: string;

--- a/packages/x402/src/x402Server.ts
+++ b/packages/x402/src/x402Server.ts
@@ -1,5 +1,4 @@
-import { type Address, getAddress } from 'viem';
-
+import { type Address, getAddress } from './ethereum';
 import type { x402PaymentRequirements } from './x402Client';
 
 export type x402Erc7710ServerConfig = {

--- a/packages/x402/src/x402Server.ts
+++ b/packages/x402/src/x402Server.ts
@@ -1,4 +1,6 @@
-import { type Address, getAddress } from './ethereum';
+import type { Hex } from '@metamask/utils';
+
+import { getAddress } from './ethereum';
 import type { x402PaymentRequirements } from './x402Client';
 
 export type x402Erc7710ServerConfig = {
@@ -13,7 +15,7 @@ export type x402Erc7710ServerConfig = {
  */
 function validateFacilitatorAddresses(
   publishedAddresses: unknown,
-): Address[] | undefined {
+): Hex[] | undefined {
   if (publishedAddresses === undefined) {
     return undefined;
   }
@@ -30,7 +32,7 @@ function validateFacilitatorAddresses(
     );
   }
 
-  const normalizedAddresses: Address[] = [];
+  const normalizedAddresses: Hex[] = [];
   const validationErrors: string[] = [];
 
   publishedAddresses.forEach((address, index) => {

--- a/packages/x402/test/x402Server.test.ts
+++ b/packages/x402/test/x402Server.test.ts
@@ -119,6 +119,20 @@ describe('x402Erc7710Server', () => {
     ]);
   });
 
+  it('normalizes all-uppercase facilitatorAddresses', async () => {
+    const server = new x402Erc7710Server();
+
+    const result = await server.enhancePaymentRequirements(baseRequirements, {
+      extra: {
+        facilitatorAddresses: ['0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'],
+      },
+    });
+
+    expect(result.extra?.facilitatorAddresses).toEqual([
+      '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa',
+    ]);
+  });
+
   it('throws when facilitatorAddresses is not an array', async () => {
     const server = new x402Erc7710Server();
 

--- a/packages/x402/test/x402Server.test.ts
+++ b/packages/x402/test/x402Server.test.ts
@@ -156,4 +156,18 @@ describe('x402Erc7710Server', () => {
       'Invalid facilitatorAddresses specified: facilitatorAddresses[0] must be a string; facilitatorAddresses[1] is not a valid address: "not-an-address"',
     );
   });
+
+  it('throws for invalid mixed-case facilitatorAddress checksums', async () => {
+    const server = new x402Erc7710Server();
+
+    await expect(
+      server.enhancePaymentRequirements(baseRequirements, {
+        extra: {
+          facilitatorAddresses: ['0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAB'],
+        },
+      }),
+    ).rejects.toThrow(
+      'Invalid facilitatorAddresses specified: facilitatorAddresses[0] is not a valid address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAB"',
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,18 +862,17 @@ __metadata:
   resolution: "@metamask/x402@workspace:packages/x402"
   dependencies:
     "@metamask/auto-changelog": "npm:^5.0.2"
+    "@noble/hashes": "npm:^1.8.0"
     "@x402/core": "npm:^2.12.0"
     "@x402/evm": "npm:^2.12.0"
     eslint: "npm:^9.39.2"
     prettier: "npm:^3.5.3"
     tsup: "npm:^8.5.0"
     typescript: "npm:5.5.4"
-    viem: "npm:2.31.4"
     vitest: "npm:^3.2.4"
   peerDependencies:
     "@x402/core": ^2.12.0
     "@x402/evm": ^2.12.0
-    viem: ^2.31.4
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,7 +862,7 @@ __metadata:
   resolution: "@metamask/x402@workspace:packages/x402"
   dependencies:
     "@metamask/auto-changelog": "npm:^5.0.2"
-    "@noble/hashes": "npm:^1.8.0"
+    "@metamask/utils": "npm:^11.4.0"
     "@x402/core": "npm:^2.12.0"
     "@x402/evm": "npm:^2.12.0"
     eslint: "npm:^9.39.2"


### PR DESCRIPTION
## Summary
- Replace the direct `viem` address/hex helpers in `@metamask/x402` with local Ethereum validation helpers.
- Keep EIP-55 checksum normalization for ERC-7710 delegation/facilitator addresses.
- Remove `viem` from `@metamask/x402` peer/dev dependencies and add focused checksum regression coverage.

## Verification
- `corepack yarn workspace @metamask/x402 lint`
- `corepack yarn workspace @metamask/x402 typecheck`
- `corepack yarn workspace @metamask/x402 test` — 3 files / 21 tests passed
- `corepack yarn workspace @metamask/x402 build`
- `git diff --check`

Closes #243

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency swap and localized validation helpers in the x402 package; behavior is covered by existing and new tests with no auth or payment flow changes.
> 
> **Overview**
> **@metamask/x402** no longer depends on **viem** for address and hex handling. **`@metamask/utils`** is added as a direct dependency, and a local **`getAddress`** helper in `ethereum.ts` validates EIP-55 checksums (rejecting invalid mixed-case) while still accepting all-lowercase or all-uppercase inputs for normalization.
> 
> Client and server paths now import **`getAddress`** and **`Hex`** from that helper / **`@metamask/utils`** instead of viem. Delegation **`permissionContext`** checks use **`isStrictHexString`** (replacing viem’s **`isHex`**), which still rejects empty **`0x`**. Facilitator address typing on the server uses **`Hex[]`** instead of viem’s **`Address`**.
> 
> **viem** is removed from peer and dev dependencies; the changelog and lockfile reflect the swap. Tests cover all-uppercase facilitator normalization and invalid mixed-case checksum errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d23e9dde22e71922588f8cb843ce1c39ab7eb13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->