### PR TITLE
x402 Payload now returns the root delegator, instead of the leaf delegator

### DIFF
--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Experimental `createx402DelegationProvider` added to @metamask/smart-accounts-kit/experimental ([#248](https://github.com/MetaMask/smart-accounts-kit/pull/248))
+- Experimental `createx402DelegationProvider` added to @metamask/smart-accounts-kit/experimental ([#248](https://github.com/MetaMask/smart-accounts-kit/pull/248), [#251](https://github.com/MetaMask/smart-accounts-kit/pull/251))
 - New `generateSalt` function added to @metamask/smart-accounts-kit/utils ([#248](https://github.com/MetaMask/smart-accounts-kit/pull/248))
 - ERC-7715 `token-approval-revocation` permission type ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226), [#237](https://github.com/MetaMask/smart-accounts-kit/pull/237))
 - `CaveatBuilder` for `ApprovalRevocationEnforcer`, deployment address added to `SmartAccountsEnvironment` ([#226](https://github.com/metamask/smart-accounts-kit/pull/226), [#237](https://github.com/MetaMask/smart-accounts-kit/pull/237))

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProvider.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProvider.ts
@@ -42,9 +42,10 @@ export function createx402DelegationProvider(
   ): Promise<x402DelegationProviderPaymentPayload> => {
     const {
       account,
+      createDelegationConfig,
       delegationManager,
       existingDelegations,
-      createDelegationConfig,
+      rootDelegator,
     } = await resolveDelegationCreationContext(config, requirements);
 
     const delegation = createOpenDelegation(createDelegationConfig);
@@ -76,7 +77,7 @@ export function createx402DelegationProvider(
     return {
       delegationManager,
       permissionContext,
-      delegator: delegation.delegator,
+      delegator: rootDelegator,
     };
   };
 }

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
@@ -63,9 +63,10 @@ type EnsureExpirySufficientlyConstrainedParams = {
  */
 export type DelegationCreationContext = {
   account: Account;
+  createDelegationConfig: Parameters<typeof createOpenDelegation>[0];
   delegationManager: Address;
   existingDelegations: Delegation[];
-  createDelegationConfig: Parameters<typeof createOpenDelegation>[0];
+  rootDelegator: Address;
 };
 
 /**
@@ -552,10 +553,14 @@ export const resolveDelegationCreationContext = async (
     };
   }
 
+  const rootDelegator =
+    existingDelegations[existingDelegations.length - 1]?.delegator ?? from;
+
   return {
     account,
+    createDelegationConfig,
     delegationManager,
     existingDelegations,
-    createDelegationConfig,
+    rootDelegator,
   };
 };

--- a/packages/smart-accounts-kit/test/experimental/x402DelegationProvider.test.ts
+++ b/packages/smart-accounts-kit/test/experimental/x402DelegationProvider.test.ts
@@ -48,9 +48,11 @@ const mockPayeeEnforcer = '0x2000000000000000000000000000000000000004' as Hex;
 const mockTimestampEnforcer =
   '0x2000000000000000000000000000000000000005' as Hex;
 const mockDelegator = '0x3000000000000000000000000000000000000003' as Hex;
+const mockRootDelegator = '0x3100000000000000000000000000000000000003' as Hex;
 const mockSignature = '0xabc123' as Hex;
 const mockTypedData = { domain: {}, message: {} };
 const mockPermissionContext = '0xfeed' as Hex;
+const mockParentPermissionContext = '0xbeef' as Hex;
 const mockAllowedCalldataTerms = '0x3333' as Hex;
 const mockGeneratedSalt =
   '0x1111111111111111111111111111111111111111111111111111111111111111' as Hex;
@@ -141,7 +143,16 @@ describe('createx402DelegationProvider', () => {
       mockTypedData,
     );
     delegationMocks.encodeDelegations.mockReturnValue(mockPermissionContext);
-    delegationMocks.decodeDelegations.mockReturnValue([]);
+    delegationMocks.decodeDelegations.mockReturnValue([
+      {
+        delegate: '0xb00000000000000000000000000000000000000b',
+        delegator: mockRootDelegator,
+        authority: mockAuthority,
+        caveats: [],
+        salt: '0x44',
+        signature: '0x55',
+      },
+    ]);
   });
 
   it('creates and signs a delegation using default from/salt values', async () => {
@@ -151,6 +162,7 @@ describe('createx402DelegationProvider', () => {
       account,
       environment,
       caveats: [],
+      parentPermissionContext: mockParentPermissionContext,
     });
 
     const result = await provider(mockRequirements);
@@ -182,16 +194,19 @@ describe('createx402DelegationProvider', () => {
       },
     );
     expect(account.signTypedData).toHaveBeenCalledWith(mockTypedData);
+    const decodedDelegations =
+      delegationMocks.decodeDelegations.mock.results[0]?.value ?? [];
     expect(delegationMocks.encodeDelegations).toHaveBeenCalledWith([
       {
         ...delegationMocks.createOpenDelegation.mock.results[0]?.value,
         signature: mockSignature,
       },
+      ...decodedDelegations,
     ]);
     expect(result).toStrictEqual({
       delegationManager: mockDelegationManager,
       permissionContext: mockPermissionContext,
-      delegator: mockDelegator,
+      delegator: mockRootDelegator,
     });
   });
 
@@ -202,6 +217,7 @@ describe('createx402DelegationProvider', () => {
       account,
       environment,
       caveats: [],
+      parentPermissionContext: mockParentPermissionContext,
     });
 
     await provider({
@@ -223,6 +239,7 @@ describe('createx402DelegationProvider', () => {
       account,
       environment,
       caveats: [],
+      parentPermissionContext: mockParentPermissionContext,
     });
 
     await expect(
@@ -240,6 +257,7 @@ describe('createx402DelegationProvider', () => {
     const provider = createx402DelegationProvider({
       account,
       environment: createMockEnvironment(),
+      parentPermissionContext: mockParentPermissionContext,
     } as x402DelegationProviderConfig);
 
     await expect(provider(mockRequirements)).rejects.toThrow(

--- a/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
+++ b/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
@@ -509,6 +509,7 @@ describe('x402DelegationProviderUtils', () => {
             environment: baseEnvironment,
           }),
         );
+        expect(result.rootDelegator).toBe(mockAccount.address);
       } finally {
         getEnvironmentSpy.mockRestore();
       }
@@ -554,6 +555,40 @@ describe('x402DelegationProviderUtils', () => {
           from: '0xba000000000000000000000000000000000000ba',
           salt: `0x${'55'.repeat(32)}`,
           environment: baseEnvironment,
+        }),
+      );
+      expect(result.rootDelegator).toBe(
+        '0xba000000000000000000000000000000000000ba',
+      );
+    });
+
+    it('uses from as rootDelegator when parentPermissionContext is not provided', async () => {
+      const from = '0xca000000000000000000000000000000000000ca' as const;
+
+      const result = await resolveDelegationCreationContext(
+        {
+          account: mockAccount,
+          environment: baseEnvironment,
+          caveats: [],
+          from,
+          salt: `0x${'99'.repeat(32)}`,
+        },
+        {
+          scheme: 'exact',
+          network: 'eip155:1',
+          asset: facilitatorA,
+          amount: '1',
+          payTo: payee,
+          maxTimeoutSeconds: 120,
+          extra: { facilitatorAddresses: [facilitatorA] },
+        },
+      );
+
+      expect(result.existingDelegations).toStrictEqual([]);
+      expect(result.rootDelegator).toBe(from);
+      expect(result.createDelegationConfig).toEqual(
+        expect.objectContaining({
+          from,
         }),
       );
     });
@@ -652,12 +687,14 @@ describe('x402DelegationProviderUtils', () => {
     });
 
     it('does not throw when facilitators are missing and redeemers are optional', async () => {
+      const parentDelegation = makeDelegation([]);
       await expect(
         resolveDelegationCreationContext(
           {
             account: mockAccount,
             environment: baseEnvironment,
             salt: `0x${'33'.repeat(32)}`,
+            parentPermissionContext: [parentDelegation],
           },
           {
             scheme: 'exact',
@@ -697,11 +734,13 @@ describe('x402DelegationProviderUtils', () => {
     });
 
     it('adds redeemer caveat from redeemers config addresses when facilitators are missing', async () => {
+      const parentDelegation = makeDelegation([]);
       const result = await resolveDelegationCreationContext(
         {
           account: mockAccount,
           environment: baseEnvironment,
           salt: `0x${'33'.repeat(32)}`,
+          parentPermissionContext: [parentDelegation],
           redeemers: {
             requireRedeemers: true,
             addresses: [facilitatorB],
@@ -732,6 +771,7 @@ describe('x402DelegationProviderUtils', () => {
     });
 
     it('resolves deferred redeemers configuration and addresses', async () => {
+      const parentDelegation = makeDelegation([]);
       const deferredRedeemerAddresses = vi.fn(async () => [facilitatorB]);
       const deferredRedeemersConfig = vi.fn(async () => ({
         requireRedeemers: true,
@@ -743,6 +783,7 @@ describe('x402DelegationProviderUtils', () => {
           account: mockAccount,
           environment: baseEnvironment,
           salt: `0x${'33'.repeat(32)}`,
+          parentPermissionContext: [parentDelegation],
           redeemers: deferredRedeemersConfig,
         },
         {
@@ -775,6 +816,7 @@ describe('x402DelegationProviderUtils', () => {
     it('resolves deferred expirySeconds and applies timestamp caveat', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+      const parentDelegation = makeDelegation([]);
 
       const deferredExpirySeconds = vi.fn(async () => 120);
       const result = await resolveDelegationCreationContext(
@@ -784,6 +826,7 @@ describe('x402DelegationProviderUtils', () => {
           caveats: [],
           salt: `0x${'66'.repeat(32)}`,
           expirySeconds: deferredExpirySeconds,
+          parentPermissionContext: [parentDelegation],
         },
         {
           scheme: 'exact',
@@ -816,6 +859,7 @@ describe('x402DelegationProviderUtils', () => {
     it('resolves synchronous deferred expirySeconds and applies timestamp caveat', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+      const parentDelegation = makeDelegation([]);
 
       const deferredExpirySeconds = vi.fn(() => 90);
       const result = await resolveDelegationCreationContext(
@@ -825,6 +869,7 @@ describe('x402DelegationProviderUtils', () => {
           caveats: [],
           salt: `0x${'66'.repeat(32)}`,
           expirySeconds: deferredExpirySeconds,
+          parentPermissionContext: [parentDelegation],
         },
         {
           scheme: 'exact',


### PR DESCRIPTION
## 📝 Description

The `x402DelegationProvider` was incorrectly returning the leaf delegator, instead of the root delegator.

This PR fixes that.

## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the meaning of `delegator` on an experimental payment API; correct for delegation chains but may break consumers that assumed the leaf delegator.
> 
> **Overview**
> The experimental **`createx402DelegationProvider`** payment payload now exposes the **root delegator** for the delegation chain instead of the **leaf** delegator from the newly signed open delegation.
> 
> **`resolveDelegationCreationContext`** computes **`rootDelegator`** as the delegator on the last entry in **`existingDelegations`** (from **`parentPermissionContext`**), or **`from`** when there is no parent chain, and the provider returns that address in **`delegator`**. Tests and the changelog entry for the experimental provider are updated accordingly.
> 
> Integrators that relied on the previous (incorrect) leaf **`delegator`** value will see a **behavior change** when redeeming or displaying x402 payloads with a parent permission context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3607751c3e8cd36c00a5ff46c055a1ed1f47f1d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->