### PR TITLE
Add MetaMask facilitator addresses as constants in @metamask/smart-accounts-kit/experimental

### DIFF
--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Constants `METAMASK_FACILITATOR_ADDRESSES`, `METAMASK_FACILITATOR_ADDRESSES_DEV` added to @metamask/smart-accounts-kit/experimental ([#255](https://github.com/metamask/smart-accounts-kit/pull/255))
+
 ## [1.6.0]
 
 ### Added

--- a/packages/smart-accounts-kit/src/experimental/index.ts
+++ b/packages/smart-accounts-kit/src/experimental/index.ts
@@ -13,4 +13,6 @@ export {
   type x402DelegationProviderPaymentPayload,
   type PaymentRequirements,
   type MaybeDeferred,
+  METAMASK_FACILITATOR_ADDRESSES,
+  METAMASK_FACILITATOR_ADDRESSES_DEV,
 } from './x402DelegationProvider';

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProvider.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProvider.ts
@@ -26,12 +26,12 @@ export type {
 
 export { parseEip155ChainId } from './x402DelegationProviderUtils';
 
-export const METAMASK_FACILITATOR_ADDRESSES: Address[] = [
-  '0xb01caea8c6c47bbf4f4b4c5080ca642043359c2e',
-  '0xc066ac5d385419b1a8c43a0e146fa439837a8b8c',
-  '0xb42f812a44c22cc6b861478900401ee759ebead6',
+export const METAMASK_FACILITATOR_ADDRESSES: readonly Address[] = [
+  '0xB01caEa8c6C47bbf4F4b4c5080Ca642043359C2E',
+  '0xC066ac5D385419B1A8c43A0E146fA439837a8B8c',
+  '0xB42F812A44c22cc6b861478900401ee759EbEAD6',
 ];
-export const METAMASK_FACILITATOR_ADDRESSES_DEV: Address[] = [
+export const METAMASK_FACILITATOR_ADDRESSES_DEV: readonly Address[] = [
   '0xb4827A2a066CD2Ef88560EFdf063dD05C6c41cC7',
 ];
 

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProvider.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProvider.ts
@@ -1,3 +1,5 @@
+import type { Address } from 'viem';
+
 import {
   createOpenDelegation,
   encodeDelegations,
@@ -23,6 +25,15 @@ export type {
 } from './x402DelegationProviderTypes';
 
 export { parseEip155ChainId } from './x402DelegationProviderUtils';
+
+export const METAMASK_FACILITATOR_ADDRESSES: Address[] = [
+  '0xb01caea8c6c47bbf4f4b4c5080ca642043359c2e',
+  '0xc066ac5d385419b1a8c43a0e146fa439837a8b8c',
+  '0xb42f812a44c22cc6b861478900401ee759ebead6',
+];
+export const METAMASK_FACILITATOR_ADDRESSES_DEV: Address[] = [
+  '0xb4827A2a066CD2Ef88560EFdf063dD05C6c41cC7',
+];
 
 /**
  * Creates a delegation provider function for x402 payment requirements.


### PR DESCRIPTION
## 📝 Description

When calling either `requestExecutionPermissions`or `createDelegationProvider`, it may be desirable to constrain redeemers to MetaMask facilitator signers.

This PR adds `METAMASK_FACILITATOR_ADDRESSES` and `METAMASK_FACILITATOR_ADDRESSES_DEV` constants to @metamask/smart-accounts-kit/experimental.

Normally, the facilitator will specify `facilitatorAddresses`, which will be added as a `redeemer` caveat. If the facilitator is not relaying the `facilitatorAddresses`, the caller may want to specify these manually.

```
const delegationProvider = createx402DelegationProvider({
  account,
  redeemers: {
    requireRedeemers: true,
    addresses: METAMASK_FACILITATOR_ADDRESSES
  },
});
```

Whe  requesting an ERC-7715 permission, it may be desired to constrain the permission to only redeemable via the MetaMask facilitator. 

Note: the `DelegationProvider` will not add an additional redeemer constraint if one already exists.

```
const permissions = await walletClient.requestExecutionPermissions([
  {
    ...
    rules: [{
      type: 'redeemer',
      addresses: METAMASK_FACILITATOR_ADDRESSES
    }]
  },
]);

```

## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public constants and changelog only; no delegation, signing, or permission enforcement logic changes.
> 
> **Overview**
> Adds **`METAMASK_FACILITATOR_ADDRESSES`** (three production facilitator signers) and **`METAMASK_FACILITATOR_ADDRESSES_DEV`** (one dev address) to `@metamask/smart-accounts-kit/experimental`, re-exported from `x402DelegationProvider` and the experimental package entry.
> 
> Callers can pass these lists into **`createx402DelegationProvider`** `redeemers.addresses` or ERC-7715 **`redeemer`** rules when the facilitator does not supply `facilitatorAddresses`, so delegations stay redeemable only via MetaMask facilitators. The **Unreleased** changelog documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5519e3265af46d9056ce9fc296e8f81f1322f218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->