### PR TITLE
fix: `createx402DelegationProvider` should resolve redeemer addresses as interesection of `facilitatorAddresses` and `redeemer.addresses`

### DIFF
--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Experimental `createx402DelegationProvider` now resolves redeemers as the intersection of `facilitatorAddresses` and `redeemer.addresses` ([#256](https://github.com/MetaMask/smart-accounts-kit/pull/256))
+
 ## [1.6.0]
 
 ### Added

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
@@ -251,7 +251,7 @@ export const ensureExpirySufficientlyConstrained = ({
  * @param options - Redeemer address inputs.
  * @param options.facilitatorAddresses - Optional facilitator addresses from the PaymentRequirements.
  * @param options.redeemerAddresses - Optional redeemer addresses from the RedeemersConfig.
- * @returns The allowed redeemer addresses.
+ * @returns The allowed redeemer addresses, or undefined if none are specified.
  */
 const resolveRedeemerAddresses = ({
   facilitatorAddresses,
@@ -275,9 +275,11 @@ const resolveRedeemerAddresses = ({
     redeemerAddresses.map(normalizeAddress),
   );
 
-  return normalizedFacilitatorAddresses.filter((address) =>
-    normalizedRedeemerAddressSet.has(address),
+  const redeemerAddressesIntersection = normalizedFacilitatorAddresses.filter(
+    (address) => normalizedRedeemerAddressSet.has(address),
   );
+
+  return redeemerAddressesIntersection;
 };
 
 /**
@@ -304,7 +306,13 @@ export const ensureRedeemerSufficientlyConstrained = ({
 }: EnsureRedeemerSufficientlyConstrainedParams): Caveat[] => {
   const redeemerEnforcerNormalized = normalizeAddress(redeemerEnforcer);
 
-  if (!redeemerAddresses || redeemerAddresses.length === 0) {
+  if (redeemerAddresses?.length === 0) {
+    throw new Error(
+      'No valid redeemer addresses were resolved. If both `redeemers.addresses` and `extra.facilitatorAddresses` are provided, they must overlap.',
+    );
+  }
+
+  if (!redeemerAddresses) {
     if (!requireRedeemers) {
       return caveats;
     }

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
@@ -34,7 +34,7 @@ type EnsureRedeemerSufficientlyConstrainedParams = {
   redeemerEnforcer: Hex;
   caveats: Caveat[];
   existingDelegations: Delegation[];
-  redeemerAddresses: Hex[];
+  redeemerAddresses: Address[] | undefined;
   requireRedeemers: boolean;
 };
 
@@ -56,6 +56,14 @@ type EnsureExpirySufficientlyConstrainedParams = {
   caveats: Caveat[];
   existingDelegations: Delegation[];
   expirySeconds: number;
+};
+
+/**
+ * Inputs for resolving allowed redeemer addresses.
+ */
+type ResolveRedeemerAddressesParams = {
+  facilitatorAddresses?: Address[];
+  redeemerAddresses?: Address[];
 };
 
 /**
@@ -237,6 +245,42 @@ export const ensureExpirySufficientlyConstrained = ({
 };
 
 /**
+ * Resolves the allowed redeemer addresses from the union of facilitator specified and caller specified redeemer addresses.
+ * If either are undefined, the other is returned.
+ *
+ * @param options - Redeemer address inputs.
+ * @param options.facilitatorAddresses - Optional facilitator addresses from the PaymentRequirements.
+ * @param options.redeemerAddresses - Optional redeemer addresses from the RedeemersConfig.
+ * @returns The allowed redeemer addresses.
+ */
+const resolveRedeemerAddresses = ({
+  facilitatorAddresses,
+  redeemerAddresses,
+}: ResolveRedeemerAddressesParams): Address[] | undefined => {
+  if (!facilitatorAddresses) {
+    if (!redeemerAddresses) {
+      return undefined;
+    }
+    return redeemerAddresses;
+  }
+
+  if (!redeemerAddresses) {
+    return facilitatorAddresses;
+  }
+
+  const normalizedFacilitatorAddresses =
+    facilitatorAddresses.map(normalizeAddress);
+
+  const normalizedRedeemerAddressSet = new Set(
+    redeemerAddresses.map(normalizeAddress),
+  );
+
+  return normalizedFacilitatorAddresses.filter((address) =>
+    normalizedRedeemerAddressSet.has(address),
+  );
+};
+
+/**
  * Ensures caveats include a sufficiently strict redeemer constraint.
  *
  * Returns the caveat list unchanged when an existing redeemer caveat is already
@@ -258,9 +302,9 @@ export const ensureRedeemerSufficientlyConstrained = ({
   redeemerAddresses,
   requireRedeemers,
 }: EnsureRedeemerSufficientlyConstrainedParams): Caveat[] => {
-  const redeemerAddressNormalized = normalizeAddress(redeemerEnforcer);
+  const redeemerEnforcerNormalized = normalizeAddress(redeemerEnforcer);
 
-  if (redeemerAddresses.length === 0) {
+  if (!redeemerAddresses || redeemerAddresses.length === 0) {
     if (!requireRedeemers) {
       return caveats;
     }
@@ -269,7 +313,7 @@ export const ensureRedeemerSufficientlyConstrained = ({
       caveats,
       existingDelegations,
       ({ enforcer }) =>
-        normalizeAddress(enforcer) === redeemerAddressNormalized,
+        normalizeAddress(enforcer) === redeemerEnforcerNormalized,
     );
 
     if (!hasExistingRedeemerCaveat) {
@@ -288,7 +332,7 @@ export const ensureRedeemerSufficientlyConstrained = ({
     caveats,
     existingDelegations,
     (caveat) => {
-      if (normalizeAddress(caveat.enforcer) !== redeemerAddressNormalized) {
+      if (normalizeAddress(caveat.enforcer) !== redeemerEnforcerNormalized) {
         return false;
       }
 
@@ -420,17 +464,16 @@ export const resolvex402DelegationCaveats = ({
     isScopeOptional: true,
   });
 
-  const allRedeemerAddresses = new Set(
-    [...(facilitatorAddresses ?? []), ...(redeemerAddresses ?? [])].map(
-      normalizeAddress,
-    ),
-  );
+  const resolvedRedeemerAddresses = resolveRedeemerAddresses({
+    facilitatorAddresses,
+    redeemerAddresses,
+  });
 
   const caveatsWithRedeemer = ensureRedeemerSufficientlyConstrained({
     redeemerEnforcer,
     caveats: initialCaveats,
     existingDelegations,
-    redeemerAddresses: Array.from(allRedeemerAddresses),
+    redeemerAddresses: resolvedRedeemerAddresses,
     requireRedeemers,
   });
 

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
@@ -308,7 +308,7 @@ export const ensureRedeemerSufficientlyConstrained = ({
 
   if (redeemerAddresses?.length === 0) {
     throw new Error(
-      'No valid redeemer addresses were resolved. If both `redeemers.addresses` and `extra.facilitatorAddresses` are provided, they must overlap.',
+      'No valid redeemer addresses were resolved. The intersection of `redeemers.addresses` and `extra.facilitatorAddresses` must be non-empty.',
     );
   }
 

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
@@ -34,6 +34,7 @@ type EnsureRedeemerSufficientlyConstrainedParams = {
   redeemerEnforcer: Hex;
   caveats: Caveat[];
   existingDelegations: Delegation[];
+  facilitatorAddresses: Address[] | undefined;
   redeemerAddresses: Address[] | undefined;
   requireRedeemers: boolean;
 };
@@ -61,10 +62,10 @@ type EnsureExpirySufficientlyConstrainedParams = {
 /**
  * Inputs for resolving allowed redeemer addresses.
  */
-type ResolveRedeemerAddressesParams = {
-  facilitatorAddresses?: Address[];
-  redeemerAddresses?: Address[];
-};
+type ResolveRedeemerAddressesParams = Pick<
+  EnsureRedeemerSufficientlyConstrainedParams,
+  'facilitatorAddresses' | 'redeemerAddresses'
+>;
 
 /**
  * Resolved context required to build and sign an x402 delegation.
@@ -245,13 +246,16 @@ export const ensureExpirySufficientlyConstrained = ({
 };
 
 /**
- * Resolves the allowed redeemer addresses from the union of facilitator specified and caller specified redeemer addresses.
- * If either are undefined, the other is returned.
+ * Resolves allowed redeemer addresses from facilitator and configured redeemer inputs.
+ *
+ * If both inputs are provided, returns their intersection.
+ * If only one input is provided, returns that input.
+ * If neither input is provided, returns undefined.
  *
  * @param options - Redeemer address inputs.
  * @param options.facilitatorAddresses - Optional facilitator addresses from the PaymentRequirements.
  * @param options.redeemerAddresses - Optional redeemer addresses from the RedeemersConfig.
- * @returns The allowed redeemer addresses, or undefined if none are specified.
+ * @returns Resolved allowed redeemer addresses, or undefined when no input is provided.
  */
 const resolveRedeemerAddresses = ({
   facilitatorAddresses,
@@ -288,40 +292,44 @@ const resolveRedeemerAddresses = ({
  * Returns the caveat list unchanged when an existing redeemer caveat is already
  * strict enough, or appends a new redeemer caveat scoped to facilitator addresses.
  *
- * @param options0 - Redeemer constraint evaluation inputs.
- * @param options0.redeemerEnforcer - Address of the redeemer enforcer caveat contract.
- * @param options0.caveats - Currently resolved caveats for the delegation being created.
- * @param options0.existingDelegations - Existing parent-chain delegations to inspect for inherited constraints.
- * @param options0.redeemerAddresses - Optional addresses to which redemption should be constrained.
- * @param options0.requireRedeemers - Whether at least one redeemer constraint must exist when no redeemer addresses are supplied.
+ * @param config - Redeemer constraint evaluation inputs.
+ * @param config.redeemerEnforcer - Address of the redeemer enforcer caveat contract.
+ * @param config.caveats - Currently resolved caveats for the delegation being created.
+ * @param config.existingDelegations - Existing parent-chain delegations to inspect for inherited constraints.
+ * @param config.redeemerAddresses - Optional addresses to which redemption should be constrained.
+ * @param config.requireRedeemers - Whether at least one redeemer constraint must exist.
  * @returns The original caveats when sufficiently constrained, otherwise caveats with a redeemer caveat appended.
- * @throws If no facilitator addresses are provided and no redeemer constraint exists.
+ * @throws If either facilitatorAddresses and/or redeemerAddresses are provided, but the intersection is empty.
+ * @throws If requireRedeemers is true, but no valid redeemer addresses are provided, and no existing redeemer caveat is found in the existingDelegations.
  */
-export const ensureRedeemerSufficientlyConstrained = ({
-  redeemerEnforcer,
-  caveats,
-  existingDelegations,
-  redeemerAddresses,
-  requireRedeemers,
-}: EnsureRedeemerSufficientlyConstrainedParams): Caveat[] => {
-  const redeemerEnforcerNormalized = normalizeAddress(redeemerEnforcer);
+export const ensureRedeemerSufficientlyConstrained = (
+  config: EnsureRedeemerSufficientlyConstrainedParams,
+): Caveat[] => {
+  // `redeemerAddresses` is the intersection of `facilitatorAddresses` and `redeemerAddresses`.
+  // If either is undefined, it implies no constraint is specified by that value, and the other is returned.
+  // If both are undefined, it implies that no constraint is specified overall.
+  const redeemerAddresses = resolveRedeemerAddresses(config);
 
+  // If the result is defined, but zero-length, it implies no redeemers are allowed, which is a non-satisfiable constraint, so an error is thrown.
   if (redeemerAddresses?.length === 0) {
     throw new Error(
-      'No valid redeemer addresses were resolved. The intersection of `redeemers.addresses` and `extra.facilitatorAddresses` must be non-empty.',
+      'No valid redeemer addresses were resolved. If both `redeemers.addresses` and `extra.facilitatorAddresses` are provided, they must overlap. If only one is provided, it must include at least one address.',
     );
   }
 
+  const redeemerEnforcer = normalizeAddress(config.redeemerEnforcer);
+
+  const { caveats, existingDelegations } = config;
+
   if (!redeemerAddresses) {
-    if (!requireRedeemers) {
+    if (!config.requireRedeemers) {
       return caveats;
     }
 
     const hasExistingRedeemerCaveat = hasMatchingCaveats(
       caveats,
       existingDelegations,
-      ({ enforcer }) =>
-        normalizeAddress(enforcer) === redeemerEnforcerNormalized,
+      ({ enforcer }) => normalizeAddress(enforcer) === redeemerEnforcer,
     );
 
     if (!hasExistingRedeemerCaveat) {
@@ -333,14 +341,13 @@ export const ensureRedeemerSufficientlyConstrained = ({
     return caveats;
   }
 
-  const redeemerAddressesNormalized = redeemerAddresses.map(normalizeAddress);
-  const redeemerAddressesSet = new Set(redeemerAddressesNormalized);
+  const redeemerAddressesSet = new Set(redeemerAddresses.map(normalizeAddress));
 
   const hasSupersedingRedeemerCaveat = hasMatchingCaveats(
     caveats,
     existingDelegations,
     (caveat) => {
-      if (normalizeAddress(caveat.enforcer) !== redeemerEnforcerNormalized) {
+      if (normalizeAddress(caveat.enforcer) !== redeemerEnforcer) {
         return false;
       }
 
@@ -348,7 +355,7 @@ export const ensureRedeemerSufficientlyConstrained = ({
         caveat.terms,
       ).redeemers.map(normalizeAddress);
 
-      // If this redeemer caveat only allows facilitator addresses, it is sufficiently constrained.
+      // If this redeemer caveat only allows redeemer addresses, it is sufficiently constrained.
       return allowedRedeemerAddresses.every((item) =>
         redeemerAddressesSet.has(item),
       );
@@ -472,16 +479,12 @@ export const resolvex402DelegationCaveats = ({
     isScopeOptional: true,
   });
 
-  const resolvedRedeemerAddresses = resolveRedeemerAddresses({
-    facilitatorAddresses,
-    redeemerAddresses,
-  });
-
   const caveatsWithRedeemer = ensureRedeemerSufficientlyConstrained({
     redeemerEnforcer,
+    facilitatorAddresses,
+    redeemerAddresses,
     caveats: initialCaveats,
     existingDelegations,
-    redeemerAddresses: resolvedRedeemerAddresses,
     requireRedeemers,
   });
 

--- a/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
+++ b/packages/smart-accounts-kit/src/experimental/x402DelegationProviderUtils.ts
@@ -317,9 +317,9 @@ export const ensureRedeemerSufficientlyConstrained = (
     );
   }
 
-  const redeemerEnforcer = normalizeAddress(config.redeemerEnforcer);
+  const { caveats, existingDelegations, redeemerEnforcer } = config;
 
-  const { caveats, existingDelegations } = config;
+  const redeemerEnforcerNormalized = normalizeAddress(redeemerEnforcer);
 
   if (!redeemerAddresses) {
     if (!config.requireRedeemers) {
@@ -329,7 +329,8 @@ export const ensureRedeemerSufficientlyConstrained = (
     const hasExistingRedeemerCaveat = hasMatchingCaveats(
       caveats,
       existingDelegations,
-      ({ enforcer }) => normalizeAddress(enforcer) === redeemerEnforcer,
+      ({ enforcer }) =>
+        normalizeAddress(enforcer) === redeemerEnforcerNormalized,
     );
 
     if (!hasExistingRedeemerCaveat) {
@@ -347,7 +348,7 @@ export const ensureRedeemerSufficientlyConstrained = (
     caveats,
     existingDelegations,
     (caveat) => {
-      if (normalizeAddress(caveat.enforcer) !== redeemerEnforcer) {
+      if (normalizeAddress(caveat.enforcer) !== redeemerEnforcerNormalized) {
         return false;
       }
 

--- a/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
+++ b/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
@@ -83,12 +83,11 @@ describe('x402DelegationProviderUtils', () => {
           redeemerEnforcer,
           caveats: [],
           existingDelegations: [],
+          facilitatorAddresses: undefined,
           redeemerAddresses: [],
           requireRedeemers: false,
         }),
-      ).toThrow(
-        'No valid redeemer addresses were resolved. The intersection of `redeemers.addresses` and `extra.facilitatorAddresses` must be non-empty.',
-      );
+      ).toThrow('No valid redeemer addresses were resolved.');
     });
 
     it('throws when redeemer addresses are empty and redeemers are required', () => {
@@ -97,12 +96,11 @@ describe('x402DelegationProviderUtils', () => {
           redeemerEnforcer,
           caveats: [],
           existingDelegations: [],
+          facilitatorAddresses: undefined,
           redeemerAddresses: [],
           requireRedeemers: true,
         }),
-      ).toThrow(
-        'No valid redeemer addresses were resolved. The intersection of `redeemers.addresses` and `extra.facilitatorAddresses` must be non-empty.',
-      );
+      ).toThrow('No valid redeemer addresses were resolved.');
     });
 
     it('returns caveats unchanged when redeemer addresses are missing and redeemers are optional', () => {
@@ -112,6 +110,7 @@ describe('x402DelegationProviderUtils', () => {
         redeemerEnforcer,
         caveats: initialCaveats,
         existingDelegations: [],
+        facilitatorAddresses: undefined,
         redeemerAddresses: undefined,
         requireRedeemers: false,
       });
@@ -125,6 +124,7 @@ describe('x402DelegationProviderUtils', () => {
           redeemerEnforcer,
           caveats: [],
           existingDelegations: [],
+          facilitatorAddresses: undefined,
           redeemerAddresses: undefined,
           requireRedeemers: true,
         }),
@@ -152,6 +152,7 @@ describe('x402DelegationProviderUtils', () => {
             },
           ]),
         ],
+        facilitatorAddresses: undefined,
         redeemerAddresses: undefined,
         requireRedeemers: true,
       });
@@ -172,6 +173,7 @@ describe('x402DelegationProviderUtils', () => {
         redeemerEnforcer,
         caveats: initialCaveats,
         existingDelegations: [],
+        facilitatorAddresses: undefined,
         redeemerAddresses: [facilitatorA, facilitatorB],
         requireRedeemers: true,
       });
@@ -196,6 +198,7 @@ describe('x402DelegationProviderUtils', () => {
             },
           ]),
         ],
+        facilitatorAddresses: undefined,
         redeemerAddresses: [facilitatorA, facilitatorB],
         requireRedeemers: true,
       });

--- a/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
+++ b/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
@@ -448,15 +448,15 @@ describe('x402DelegationProviderUtils', () => {
       ).toThrow('Expiry seconds must be a positive number');
     });
 
-    it('enforces redeemer caveats from the union of facilitator and configured redeemer addresses', () => {
+    it('enforces redeemer caveats from the intersection of facilitator and configured redeemer addresses', () => {
       const result = resolvex402DelegationCaveats({
         environment: baseEnvironment,
         caveatsConfig: [],
         existingDelegations: [],
-        facilitatorAddresses: [facilitatorA],
+        facilitatorAddresses: [facilitatorA, facilitatorB],
         payee,
         requireRedeemers: true,
-        redeemerAddresses: [facilitatorB],
+        redeemerAddresses: [facilitatorB, facilitatorC],
       });
 
       const redeemerCaveat = result.find(
@@ -467,12 +467,9 @@ describe('x402DelegationProviderUtils', () => {
         throw new Error('Expected redeemer caveat to be present');
       }
 
-      expect(decodeRedeemerTerms(redeemerCaveat.terms).redeemers).toEqual(
-        expect.arrayContaining([facilitatorA, facilitatorB]),
-      );
-      expect(decodeRedeemerTerms(redeemerCaveat.terms).redeemers).toHaveLength(
-        2,
-      );
+      expect(decodeRedeemerTerms(redeemerCaveat.terms).redeemers).toEqual([
+        facilitatorB,
+      ]);
     });
   });
 

--- a/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
+++ b/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
@@ -77,6 +77,34 @@ describe('x402DelegationProviderUtils', () => {
   });
 
   describe('ensureRedeemerSufficientlyConstrained', () => {
+    it('throws when redeemer addresses are empty and redeemers are not required', () => {
+      expect(() =>
+        ensureRedeemerSufficientlyConstrained({
+          redeemerEnforcer,
+          caveats: [],
+          existingDelegations: [],
+          redeemerAddresses: [],
+          requireRedeemers: false,
+        }),
+      ).toThrow(
+        'No valid redeemer addresses were resolved. If both `redeemers.addresses` and `extra.facilitatorAddresses` are provided, they must overlap.',
+      );
+    });
+
+    it('throws when redeemer addresses are empty and redeemers are required', () => {
+      expect(() =>
+        ensureRedeemerSufficientlyConstrained({
+          redeemerEnforcer,
+          caveats: [],
+          existingDelegations: [],
+          redeemerAddresses: [],
+          requireRedeemers: true,
+        }),
+      ).toThrow(
+        'No valid redeemer addresses were resolved. If both `redeemers.addresses` and `extra.facilitatorAddresses` are provided, they must overlap.',
+      );
+    });
+
     it('returns caveats unchanged when redeemer addresses are missing and redeemers are optional', () => {
       const initialCaveats: Caveat[] = [];
 
@@ -84,7 +112,7 @@ describe('x402DelegationProviderUtils', () => {
         redeemerEnforcer,
         caveats: initialCaveats,
         existingDelegations: [],
-        redeemerAddresses: [],
+        redeemerAddresses: undefined,
         requireRedeemers: false,
       });
 
@@ -97,7 +125,7 @@ describe('x402DelegationProviderUtils', () => {
           redeemerEnforcer,
           caveats: [],
           existingDelegations: [],
-          redeemerAddresses: [],
+          redeemerAddresses: undefined,
           requireRedeemers: true,
         }),
       ).toThrow('Redeemer must be constrained');
@@ -124,7 +152,7 @@ describe('x402DelegationProviderUtils', () => {
             },
           ]),
         ],
-        redeemerAddresses: [],
+        redeemerAddresses: undefined,
         requireRedeemers: true,
       });
 

--- a/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
+++ b/packages/smart-accounts-kit/test/experimental/x402DelegationProviderUtils.test.ts
@@ -87,7 +87,7 @@ describe('x402DelegationProviderUtils', () => {
           requireRedeemers: false,
         }),
       ).toThrow(
-        'No valid redeemer addresses were resolved. If both `redeemers.addresses` and `extra.facilitatorAddresses` are provided, they must overlap.',
+        'No valid redeemer addresses were resolved. The intersection of `redeemers.addresses` and `extra.facilitatorAddresses` must be non-empty.',
       );
     });
 
@@ -101,7 +101,7 @@ describe('x402DelegationProviderUtils', () => {
           requireRedeemers: true,
         }),
       ).toThrow(
-        'No valid redeemer addresses were resolved. If both `redeemers.addresses` and `extra.facilitatorAddresses` are provided, they must overlap.',
+        'No valid redeemer addresses were resolved. The intersection of `redeemers.addresses` and `extra.facilitatorAddresses` must be non-empty.',
       );
     });
 


### PR DESCRIPTION
## 📝 Description

Fixes #254

When `createx402DelegationProvider`, a redeemer caveat is added that contains the union of `facilitatorAddresses` and `redeemer` addresses specified in the params. 

## 🔄 What Changed?

With this change, the intersection of `facilitatorAddresses` and `redeemer` addresses is used instead. If only one of the two is specified, that value is used.

Note: if both the facilitator specifies `facilitatorAddresses` and the configuration specifies `redeemer.addresses`, they should be the same value (as the intersection will be used as the `redeemer` caveat terms.

## 🚀 Why?

If a caller specifies `redeemer` addresses, it would be reasonable to expect that only those addresses can redeem the delegation, whereas if the facilitator specifies `facilitatorAddresses`, the addresses that can redeem could be expanded to include other addresses.

## 🧪 How to Test?

Given the following snippet:

```
const delegationProvider = createx402DelegationProvider({
  account,
  parentPermissionContext: () => '0x...',
  redeemers: {
    requireRedeemers: true,
    addresses: ['0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', '0xb4827a2a066cd2ef88560efdf063dd05c6c41cc7']
  },
  expirySeconds: 15
});
```

And a facilitator that specifies `facilitatorAddresses`: `['0xb4827a2a066cd2ef88560efdf063dd05c6c41cc7']`

Previously:

```
  {
    type: 'redeemer',
    redeemers: [
      '0xb4827a2a066cd2ef88560efdf063dd05c6c41cc7',
      '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
    ]
  },
```

Now:

```
  {
    type: 'redeemer',
    redeemers: [ '0xb4827a2a066cd2ef88560efdf063dd05c6c41cc7' ]
  },
```

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [x] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change to who can redeem x402 delegations when both facilitator and config redeemer lists are supplied; incorrect overlap assumptions could block redemption or widen trust if callers relied on the old union.
> 
> **Overview**
> Experimental **`createx402DelegationProvider`** now builds redeemer caveats from the **intersection** of `PaymentRequirements.extra.facilitatorAddresses` and configured `redeemers.addresses`, instead of their **union**. When only one side is set, that list is used; when both are set, only overlapping addresses are allowed.
> 
> `ensureRedeemerSufficientlyConstrained` takes separate `facilitatorAddresses` and `redeemerAddresses` and uses new `resolveRedeemerAddresses` (normalized comparison). An **empty** resolved list (e.g. explicit `[]` or non-overlapping inputs) throws **`No valid redeemer addresses were resolved`** rather than skipping constraints. Changelog and unit tests were updated for intersection behavior and the new error path.
> 
> **Breaking:** delegations that previously allowed any address in either list will only allow addresses present in **both** when both inputs are provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e3c414ea63374045f4e5a0afb5160cdaee02be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->