### PR TITLE
chore: upgrade MetaMask action to v6 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,7 @@ jobs:
     name: Publish release
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       SLACK_WEBHOOK_URL:
         required: true
 
@@ -49,7 +49,7 @@ jobs:
           path: ./packages
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -60,6 +60,9 @@ jobs:
     environment: npm-publish
     runs-on: ubuntu-latest
     needs: publish-npm-dry-run
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -71,7 +74,7 @@ jobs:
           name: publish-release-artifacts-${{ github.sha }}
           path: ./packages
       - name: Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript-eslint": "^8.0.0",
     "viem": "2.31.4"
   },
-  "packageManager": "yarn@4.14.1",
+  "packageManager": "yarn@4.16.0",
   "engines": {
     "node": "^18.18 || >=20"
   },

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -179,7 +179,7 @@ module.exports = defineConfig({
       if (isChildWorkspace) {
         workspace.unset('packageManager');
       } else {
-        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.14.1');
+        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.16.0');
       }
 
       // All packages must specify a minimum Node.js version of 18.18.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10
 
 "@adraffy/ens-normalize@npm:^1.11.0":


### PR DESCRIPTION
## 📝 Description

Provide a brief description of the changes in this PR

## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production npm release workflows and auth (OIDC vs optional NPM_TOKEN); publish failures would block releases but application runtime code is unchanged.
> 
> **Overview**
> Upgrades release automation to **MetaMask/action-npm-publish@v6** for both the dry-run and production npm publish steps, aligning with the newer publish action (likely OIDC/trusted publishing support).
> 
> **GitHub Actions permissions** are updated so the `publish-release` reusable workflow caller and the `publish-npm` job grant **`id-token: write`** (with `contents: read` on the publish job). The **`NPM_TOKEN`** secret on `workflow_call` is now **optional**, so dry runs and OIDC-based publish paths do not require passing a token at the workflow boundary.
> 
> **Yarn** is bumped from **4.14.1** to **4.16.0** in `package.json`, enforced in `yarn.config.cjs`, with matching **`yarn.lock`** metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33dd85b31d272cb7c095c8467c2ef2f95e812084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->