### PR TITLE
chore: add read permissions for contents in publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,9 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
## 📝 Description

Adds a top-level default permissions block to the publish release workflow.

## 🔄 What Changed?

List the specific changes made:
- Added `permissions: contents: read` to `.github/workflows/publish-release.yml`.
- Kept job-specific permissions unchanged.

## 🚀 Why?

Explain the motivation behind these changes:
- Ensures the reusable publish workflow has an explicit read-only default permission scope.
- Preserves broader permissions only where individual jobs request them.

## 🧪 How to Test?

Describe how to test these changes:

- [x] Manual testing steps:
 1. Verified `.github/workflows/publish-release.yml` includes top-level `permissions: contents: read`.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [x] Changelog updated (if needed): N/A, CI-only change
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

CI-only workflow permissions update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permissions hardening with no application or runtime impact; release jobs that need write access still declare it explicitly.
> 
> **Overview**
> Adds a **workflow-level default** of `permissions: contents: read` to the reusable **Publish Release** workflow.
> 
> Job overrides are unchanged: `publish-release` still requests `contents: write` for release publishing, and `publish-npm` keeps its explicit `contents: read` plus `id-token: write`. Jobs that do not declare permissions (e.g. `publish-npm-dry-run`) now inherit read-only repo access instead of the workflow’s previous implicit defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcfbde5419785c88b9432553894805da47776b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->