### PR TITLE
feat: adds utility functions to create caveats array for each permission type

### DIFF
--- a/packages/7715-permission-types/CHANGELOG.md
+++ b/packages/7715-permission-types/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Utility functions to create caveats array for each permission type ([#265](https://github.com/MetaMask/smart-accounts-kit/pull/265))
+  - `createErc20TokenStreamCaveats()`
+  - `createErc20TokenPeriodicCaveats()`
+  - `createErc20TokenAllowanceCaveats()`
+  - `createNativeTokenStreamCaveats()`
+  - `createNativeTokenPeriodicCaveats()`
+  - `createNativeTokenAllowanceCaveats()`
+  - `createTokenApprovalRevocationCaveats()`
 - Add `makePermissionDecoderConfigs` to resolve the `PermissionDecoderConfig`s to be used with @metamask/gator-permissions-controller ([#259](https://github.com/MetaMask/smart-accounts-kit/pull/259))
 
 ## [0.7.1]

--- a/packages/7715-permission-types/src/index.ts
+++ b/packages/7715-permission-types/src/index.ts
@@ -22,6 +22,9 @@ export type {
 export type { PayeeRule, RedeemerRule, ExpiryRule } from './permissions';
 export {
   makePermissionDecoderConfigs,
+  createErc20TokenStreamCaveats,
+  type Erc20TokenStreamEnforcers,
+  type Erc20TokenStreamDecoderEnforcers,
   type DeployedContractsByName,
   type PermissionDecoderConfig,
 } from './permissions';

--- a/packages/7715-permission-types/src/index.ts
+++ b/packages/7715-permission-types/src/index.ts
@@ -21,10 +21,21 @@ export type {
 
 export type { PayeeRule, RedeemerRule, ExpiryRule } from './permissions';
 export {
+  createErc20TokenAllowanceCaveats,
+  type Erc20TokenAllowanceEnforcers,
+  createErc20TokenPeriodicCaveats,
+  type Erc20TokenPeriodicEnforcers,
   makePermissionDecoderConfigs,
   createErc20TokenStreamCaveats,
   type Erc20TokenStreamEnforcers,
-  type Erc20TokenStreamDecoderEnforcers,
+  createNativeTokenAllowanceCaveats,
+  type NativeTokenAllowanceEnforcers,
+  createNativeTokenPeriodicCaveats,
+  type NativeTokenPeriodicEnforcers,
+  createNativeTokenStreamCaveats,
+  type NativeTokenStreamEnforcers,
+  createTokenApprovalRevocationCaveats,
+  type TokenApprovalRevocationEnforcers,
   type DeployedContractsByName,
   type PermissionDecoderConfig,
 } from './permissions';

--- a/packages/7715-permission-types/src/index.ts
+++ b/packages/7715-permission-types/src/index.ts
@@ -17,6 +17,7 @@ export type {
   RevokeExecutionPermissionRequestParams,
   RevokeExecutionPermissionResponseResult,
   MetaMaskBasePermissionData,
+  Populated,
 } from './types';
 
 export type { PayeeRule, RedeemerRule, ExpiryRule } from './permissions';

--- a/packages/7715-permission-types/src/index.ts
+++ b/packages/7715-permission-types/src/index.ts
@@ -22,11 +22,11 @@ export type {
 
 export type { PayeeRule, RedeemerRule, ExpiryRule } from './permissions';
 export {
+  makePermissionDecoderConfigs,
   createErc20TokenAllowanceCaveats,
   type Erc20TokenAllowanceEnforcers,
   createErc20TokenPeriodicCaveats,
   type Erc20TokenPeriodicEnforcers,
-  makePermissionDecoderConfigs,
   createErc20TokenStreamCaveats,
   type Erc20TokenStreamEnforcers,
   createNativeTokenAllowanceCaveats,

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
@@ -1,3 +1,8 @@
+import type { Caveat } from '@metamask/delegation-core';
+import {
+  createERC20TokenPeriodTransferTerms,
+  createValueLteTerms,
+} from '@metamask/delegation-core';
 import { hexToNumber } from '@metamask/utils';
 
 import type { Erc20TokenAllowancePermission } from '../../types';
@@ -8,6 +13,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
+  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import {
@@ -110,4 +116,50 @@ function validateAndDecodeData(
   }
 
   return { tokenAddress, allowanceAmount, startTime };
+}
+
+/**
+ * Enforcers required to build ERC-20 token allowance caveats.
+ */
+export type Erc20TokenAllowanceEnforcers = Pick<
+  ChecksumEnforcersByChainId,
+  'erc20PeriodicEnforcer' | 'valueLteEnforcer'
+>;
+
+/**
+ * Builds the erc20-token-allowance caveats required for this permission type.
+ *
+ * @param options0 - Caveat builder arguments.
+ * @param options0.permission - Fully populated erc20-token-allowance permission data.
+ * @param options0.contracts - Enforcer addresses used to construct caveats.
+ * @returns The ERC-20 allowance and zero-value caveats.
+ */
+export async function createErc20TokenAllowanceCaveats({
+  permission,
+  contracts,
+}: {
+  permission: DeepRequired<Erc20TokenAllowancePermission>;
+  contracts: Erc20TokenAllowanceEnforcers;
+}): Promise<Caveat[]> {
+  const { tokenAddress, allowanceAmount, startTime } = permission.data;
+
+  const erc20PeriodCaveat: Caveat = {
+    enforcer: contracts.erc20PeriodicEnforcer,
+    terms: createERC20TokenPeriodTransferTerms({
+      tokenAddress,
+      periodAmount: BigInt(allowanceAmount),
+      // delegation-core accepts bigint for encoding although the type is `number`.
+      periodDuration: BigInt(UINT256_MAX) as unknown as number,
+      startDate: startTime,
+    }),
+    args: '0x',
+  };
+
+  const valueLteCaveat: Caveat = {
+    enforcer: contracts.valueLteEnforcer,
+    terms: createValueLteTerms({ maxValue: 0n }),
+    args: '0x',
+  };
+
+  return [erc20PeriodCaveat, valueLteCaveat];
 }

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
@@ -134,13 +134,13 @@ export type Erc20TokenAllowanceEnforcers = Pick<
  * @param options0.contracts - Enforcer addresses used to construct caveats.
  * @returns The ERC-20 allowance and zero-value caveats.
  */
-export async function createErc20TokenAllowanceCaveats({
+export function createErc20TokenAllowanceCaveats({
   permission,
   contracts,
 }: {
   permission: DeepRequired<Erc20TokenAllowancePermission>;
   contracts: Erc20TokenAllowanceEnforcers;
-}): Promise<Caveat[]> {
+}): Caveat[] {
   const { tokenAddress, allowanceAmount, startTime } = permission.data;
 
   const erc20PeriodCaveat: Caveat = {

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
@@ -5,7 +5,7 @@ import {
 } from '@metamask/delegation-core';
 import { hexToNumber } from '@metamask/utils';
 
-import type { Erc20TokenAllowancePermission } from '../../types';
+import type { Erc20TokenAllowancePermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
 import { erc20PayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
@@ -13,7 +13,6 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import {
@@ -138,7 +137,7 @@ export function createErc20TokenAllowanceCaveats({
   permission,
   contracts,
 }: {
-  permission: DeepRequired<Erc20TokenAllowancePermission>;
+  permission: Populated<Erc20TokenAllowancePermission>;
   contracts: Erc20TokenAllowanceEnforcers;
 }): Caveat[] {
   const { tokenAddress, allowanceAmount, startTime } = permission.data;

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
@@ -3,7 +3,7 @@ import {
   createERC20TokenPeriodTransferTerms,
   createValueLteTerms,
 } from '@metamask/delegation-core';
-import { hexToNumber } from '@metamask/utils';
+import { hexToBigInt, hexToNumber } from '@metamask/utils';
 
 import type { Erc20TokenAllowancePermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
@@ -141,12 +141,25 @@ export function createErc20TokenAllowanceCaveats({
   contracts: Erc20TokenAllowanceEnforcers;
 }): Caveat[] {
   const { tokenAddress, allowanceAmount, startTime } = permission.data;
+  const allowanceAmountBigInt = hexToBigInt(allowanceAmount);
+
+  if (allowanceAmountBigInt === 0n) {
+    throw new Error(
+      'Invalid erc20-token-allowance permission: allowanceAmount must be a positive number.',
+    );
+  }
+
+  if (startTime <= 0) {
+    throw new Error(
+      'Invalid erc20-token-allowance permission: startTime must be a positive number.',
+    );
+  }
 
   const erc20PeriodCaveat: Caveat = {
     enforcer: contracts.erc20PeriodicEnforcer,
     terms: createERC20TokenPeriodTransferTerms({
       tokenAddress,
-      periodAmount: BigInt(allowanceAmount),
+      periodAmount: allowanceAmountBigInt,
       // delegation-core accepts bigint for encoding although the type is `number`.
       periodDuration: BigInt(UINT256_MAX) as unknown as number,
       startDate: startTime,

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
@@ -13,7 +13,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  MakePermissionDecoderConfig,
+  PermissionDecoderConfig,
 } from '../types';
 import {
   getByteLength,
@@ -31,7 +31,7 @@ import {
  */
 export function makeErc20TokenAllowanceDecoderConfig(
   contractAddresses: ChecksumEnforcersByChainId,
-): MakePermissionDecoderConfig {
+): PermissionDecoderConfig {
   const {
     timestampEnforcer,
     erc20PeriodicEnforcer,

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
@@ -140,13 +140,13 @@ export type Erc20TokenPeriodicEnforcers = Pick<
  * @param options0.contracts - Enforcer addresses used to construct caveats.
  * @returns The ERC-20 periodic and zero-value caveats.
  */
-export async function createErc20TokenPeriodicCaveats({
+export function createErc20TokenPeriodicCaveats({
   permission,
   contracts,
 }: {
   permission: DeepRequired<Erc20TokenPeriodicPermission>;
   contracts: Erc20TokenPeriodicEnforcers;
-}): Promise<Caveat[]> {
+}): Caveat[] {
   const { tokenAddress, periodAmount, periodDuration, startTime } =
     permission.data;
 

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
@@ -1,4 +1,9 @@
-import { decodeERC20TokenPeriodTransferTerms } from '@metamask/delegation-core';
+import type { Caveat } from '@metamask/delegation-core';
+import {
+  createERC20TokenPeriodTransferTerms,
+  createValueLteTerms,
+  decodeERC20TokenPeriodTransferTerms,
+} from '@metamask/delegation-core';
 import { bigIntToHex } from '@metamask/utils';
 
 import type { Erc20TokenPeriodicPermission } from '../../types';
@@ -9,6 +14,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
+  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import {
@@ -116,4 +122,50 @@ function validateAndDecodeData(
     periodDuration,
     startTime,
   };
+}
+
+/**
+ * Enforcers required to build ERC-20 token periodic caveats.
+ */
+export type Erc20TokenPeriodicEnforcers = Pick<
+  ChecksumEnforcersByChainId,
+  'erc20PeriodicEnforcer' | 'valueLteEnforcer'
+>;
+
+/**
+ * Builds the erc20-token-periodic caveats required for this permission type.
+ *
+ * @param options0 - Caveat builder arguments.
+ * @param options0.permission - Fully populated erc20-token-periodic permission data.
+ * @param options0.contracts - Enforcer addresses used to construct caveats.
+ * @returns The ERC-20 periodic and zero-value caveats.
+ */
+export async function createErc20TokenPeriodicCaveats({
+  permission,
+  contracts,
+}: {
+  permission: DeepRequired<Erc20TokenPeriodicPermission>;
+  contracts: Erc20TokenPeriodicEnforcers;
+}): Promise<Caveat[]> {
+  const { tokenAddress, periodAmount, periodDuration, startTime } =
+    permission.data;
+
+  const erc20PeriodCaveat: Caveat = {
+    enforcer: contracts.erc20PeriodicEnforcer,
+    terms: createERC20TokenPeriodTransferTerms({
+      tokenAddress,
+      periodAmount: BigInt(periodAmount),
+      periodDuration,
+      startDate: startTime,
+    }),
+    args: '0x',
+  };
+
+  const valueLteCaveat: Caveat = {
+    enforcer: contracts.valueLteEnforcer,
+    terms: createValueLteTerms({ maxValue: 0n }),
+    args: '0x',
+  };
+
+  return [erc20PeriodCaveat, valueLteCaveat];
 }

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
@@ -4,7 +4,7 @@ import {
   createValueLteTerms,
   decodeERC20TokenPeriodTransferTerms,
 } from '@metamask/delegation-core';
-import { bigIntToHex } from '@metamask/utils';
+import { bigIntToHex, hexToBigInt } from '@metamask/utils';
 
 import type { Erc20TokenPeriodicPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
@@ -148,12 +148,37 @@ export function createErc20TokenPeriodicCaveats({
 }): Caveat[] {
   const { tokenAddress, periodAmount, periodDuration, startTime } =
     permission.data;
+  const periodAmountBigInt = hexToBigInt(periodAmount);
+
+  if (periodAmountBigInt === 0n) {
+    throw new Error(
+      'Invalid erc20-token-periodic permission: periodAmount must be a positive number.',
+    );
+  }
+
+  if (periodDuration <= 0) {
+    throw new Error(
+      'Invalid erc20-token-periodic permission: periodDuration must be a positive number.',
+    );
+  }
+
+  if (periodDuration > MAX_PERIOD_DURATION) {
+    throw new Error(
+      'Invalid erc20-token-periodic permission: periodDuration must be less than or equal to MAX_PERIOD_DURATION.',
+    );
+  }
+
+  if (startTime <= 0) {
+    throw new Error(
+      'Invalid erc20-token-periodic permission: startTime must be a positive number.',
+    );
+  }
 
   const erc20PeriodCaveat: Caveat = {
     enforcer: contracts.erc20PeriodicEnforcer,
     terms: createERC20TokenPeriodTransferTerms({
       tokenAddress,
-      periodAmount: BigInt(periodAmount),
+      periodAmount: periodAmountBigInt,
       periodDuration,
       startDate: startTime,
     }),

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
@@ -6,7 +6,7 @@ import {
 } from '@metamask/delegation-core';
 import { bigIntToHex } from '@metamask/utils';
 
-import type { Erc20TokenPeriodicPermission } from '../../types';
+import type { Erc20TokenPeriodicPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
 import { erc20PayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
@@ -14,7 +14,6 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import {
@@ -144,7 +143,7 @@ export function createErc20TokenPeriodicCaveats({
   permission,
   contracts,
 }: {
-  permission: DeepRequired<Erc20TokenPeriodicPermission>;
+  permission: Populated<Erc20TokenPeriodicPermission>;
   contracts: Erc20TokenPeriodicEnforcers;
 }): Caveat[] {
   const { tokenAddress, periodAmount, periodDuration, startTime } =

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
@@ -14,7 +14,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  MakePermissionDecoderConfig,
+  PermissionDecoderConfig,
 } from '../types';
 import {
   getTermsByEnforcer,
@@ -30,7 +30,7 @@ import {
  */
 export function makeErc20TokenPeriodicDecoderConfig(
   contractAddresses: ChecksumEnforcersByChainId,
-): MakePermissionDecoderConfig {
+): PermissionDecoderConfig {
   const {
     timestampEnforcer,
     erc20PeriodicEnforcer,

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
@@ -127,13 +127,13 @@ export type Erc20TokenStreamEnforcers = Pick<
  * @param options0.contracts - Enforcer addresses used to construct caveats.
  * @returns The ERC20 streaming and zero-value caveats.
  */
-export async function createErc20TokenStreamCaveats({
+export function createErc20TokenStreamCaveats({
   permission,
   contracts,
 }: {
   permission: DeepRequired<Erc20TokenStreamPermission>;
   contracts: Erc20TokenStreamEnforcers;
-}): Promise<Caveat[]> {
+}): Caveat[] {
   const { initialAmount, maxAmount, amountPerSecond, startTime } =
     permission.data;
 

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
@@ -1,4 +1,9 @@
-import { decodeERC20StreamingTerms } from '@metamask/delegation-core';
+import type { Caveat } from '@metamask/delegation-core';
+import {
+  createERC20StreamingTerms,
+  createValueLteTerms,
+  decodeERC20StreamingTerms,
+} from '@metamask/delegation-core';
 import { bigIntToHex } from '@metamask/utils';
 
 import type { Erc20TokenStreamPermission } from '../../types';
@@ -7,9 +12,10 @@ import { erc20PayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
 import type {
   ChecksumCaveat,
-  ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  MakePermissionDecoderConfig,
+  DeepRequired,
+  ChecksumEnforcersByChainId,
+  PermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer, ZERO_32_BYTES } from '../utils';
 
@@ -21,7 +27,7 @@ import { getTermsByEnforcer, ZERO_32_BYTES } from '../utils';
  */
 export function makeErc20TokenStreamDecoderConfig(
   contractAddresses: ChecksumEnforcersByChainId,
-): MakePermissionDecoderConfig {
+): PermissionDecoderConfig {
   const {
     timestampEnforcer,
     erc20StreamingEnforcer,
@@ -103,4 +109,55 @@ function validateAndDecodeData(
     amountPerSecond: bigIntToHex(amountPerSecond),
     startTime,
   };
+}
+
+/**
+ * Enforcers required to build ERC-20 token stream caveats.
+ */
+export type Erc20TokenStreamEnforcers = Pick<
+  ChecksumEnforcersByChainId,
+  'erc20StreamingEnforcer' | 'valueLteEnforcer'
+>;
+
+/**
+ * Builds the ERC-20 stream caveats required for this permission type.
+ *
+ * @param options0 - Caveat builder arguments.
+ * @param options0.permission - Fully populated ERC-20 stream permission data.
+ * @param options0.contracts - Enforcer addresses used to construct caveats.
+ * @returns The ERC20 streaming and zero-value caveats.
+ */
+export async function createErc20TokenStreamCaveats({
+  permission,
+  contracts,
+}: {
+  permission: DeepRequired<Erc20TokenStreamPermission>;
+  contracts: Erc20TokenStreamEnforcers;
+}): Promise<Caveat[]> {
+  const { initialAmount, maxAmount, amountPerSecond, startTime } =
+    permission.data;
+
+  // ERC20StreamingEnforcer: enforce token address, initial/max amount, amount per second, and start time.
+  const erc20StreamingCaveat: Caveat = {
+    enforcer: contracts.erc20StreamingEnforcer,
+    terms: createERC20StreamingTerms({
+      tokenAddress: permission.data.tokenAddress,
+      initialAmount: BigInt(initialAmount),
+      maxAmount: BigInt(maxAmount),
+      amountPerSecond: BigInt(amountPerSecond),
+      startTime,
+    }),
+    args: '0x',
+  };
+
+  // ValueLteEnforcer: allow no native value (e.g. msg.value must be 0).
+  const valueLteCaveat: Caveat = {
+    enforcer: contracts.valueLteEnforcer,
+    terms: createValueLteTerms({
+      maxValue: 0n,
+    }),
+    args: '0x',
+  };
+
+  return [erc20StreamingCaveat, valueLteCaveat];
 }

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
@@ -4,7 +4,7 @@ import {
   createValueLteTerms,
   decodeERC20StreamingTerms,
 } from '@metamask/delegation-core';
-import { bigIntToHex } from '@metamask/utils';
+import { bigIntToHex, hexToBigInt } from '@metamask/utils';
 
 import type { Erc20TokenStreamPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
@@ -135,15 +135,36 @@ export function createErc20TokenStreamCaveats({
 }): Caveat[] {
   const { initialAmount, maxAmount, amountPerSecond, startTime } =
     permission.data;
+  const initialAmountBigInt = hexToBigInt(initialAmount);
+  const maxAmountBigInt = hexToBigInt(maxAmount);
+  const amountPerSecondBigInt = hexToBigInt(amountPerSecond);
+
+  if (maxAmountBigInt <= initialAmountBigInt) {
+    throw new Error(
+      'Invalid erc20-token-stream permission: maxAmount must be greater than initialAmount.',
+    );
+  }
+
+  if (amountPerSecondBigInt === 0n) {
+    throw new Error(
+      'Invalid erc20-token-stream permission: amountPerSecond must be a positive number.',
+    );
+  }
+
+  if (startTime <= 0) {
+    throw new Error(
+      'Invalid erc20-token-stream permission: startTime must be a positive number.',
+    );
+  }
 
   // ERC20StreamingEnforcer: enforce token address, initial/max amount, amount per second, and start time.
   const erc20StreamingCaveat: Caveat = {
     enforcer: contracts.erc20StreamingEnforcer,
     terms: createERC20StreamingTerms({
       tokenAddress: permission.data.tokenAddress,
-      initialAmount: BigInt(initialAmount),
-      maxAmount: BigInt(maxAmount),
-      amountPerSecond: BigInt(amountPerSecond),
+      initialAmount: initialAmountBigInt,
+      maxAmount: maxAmountBigInt,
+      amountPerSecond: amountPerSecondBigInt,
       startTime,
     }),
     args: '0x',

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
@@ -6,14 +6,13 @@ import {
 } from '@metamask/delegation-core';
 import { bigIntToHex } from '@metamask/utils';
 
-import type { Erc20TokenStreamPermission } from '../../types';
+import type { Erc20TokenStreamPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
 import { erc20PayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
 import type {
   ChecksumCaveat,
   DecodedPermissionData,
-  DeepRequired,
   ChecksumEnforcersByChainId,
   PermissionDecoderConfig,
 } from '../types';
@@ -131,7 +130,7 @@ export function createErc20TokenStreamCaveats({
   permission,
   contracts,
 }: {
-  permission: DeepRequired<Erc20TokenStreamPermission>;
+  permission: Populated<Erc20TokenStreamPermission>;
   contracts: Erc20TokenStreamEnforcers;
 }): Caveat[] {
   const { initialAmount, maxAmount, amountPerSecond, startTime } =

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
@@ -1,3 +1,8 @@
+import type { Caveat } from '@metamask/delegation-core';
+import {
+  createExactCalldataTerms,
+  createNativeTokenPeriodTransferTerms,
+} from '@metamask/delegation-core';
 import { hexToNumber } from '@metamask/utils';
 
 import type { NativeTokenAllowancePermission } from '../../types';
@@ -8,6 +13,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
+  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import {
@@ -114,4 +120,49 @@ function validateAndDecodeData(
   }
 
   return { allowanceAmount, startTime };
+}
+
+/**
+ * Enforcers required to build native token allowance caveats.
+ */
+export type NativeTokenAllowanceEnforcers = Pick<
+  ChecksumEnforcersByChainId,
+  'nativeTokenPeriodicEnforcer' | 'exactCalldataEnforcer'
+>;
+
+/**
+ * Builds the native-token-allowance caveats required for this permission type.
+ *
+ * @param options0 - Caveat builder arguments.
+ * @param options0.permission - Fully populated native-token-allowance permission data.
+ * @param options0.contracts - Enforcer addresses used to construct caveats.
+ * @returns The native token allowance and exact-calldata caveats.
+ */
+export async function createNativeTokenAllowanceCaveats({
+  permission,
+  contracts,
+}: {
+  permission: DeepRequired<NativeTokenAllowancePermission>;
+  contracts: NativeTokenAllowanceEnforcers;
+}): Promise<Caveat[]> {
+  const { allowanceAmount, startTime } = permission.data;
+
+  const nativeTokenPeriodTransferCaveat: Caveat = {
+    enforcer: contracts.nativeTokenPeriodicEnforcer,
+    terms: createNativeTokenPeriodTransferTerms({
+      periodAmount: BigInt(allowanceAmount),
+      // delegation-core accepts bigint for encoding although the type is `number`.
+      periodDuration: BigInt(UINT256_MAX) as unknown as number,
+      startDate: startTime,
+    }),
+    args: '0x',
+  };
+
+  const exactCalldataCaveat: Caveat = {
+    enforcer: contracts.exactCalldataEnforcer,
+    terms: createExactCalldataTerms({ calldata: '0x' }),
+    args: '0x',
+  };
+
+  return [nativeTokenPeriodTransferCaveat, exactCalldataCaveat];
 }

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
@@ -138,13 +138,13 @@ export type NativeTokenAllowanceEnforcers = Pick<
  * @param options0.contracts - Enforcer addresses used to construct caveats.
  * @returns The native token allowance and exact-calldata caveats.
  */
-export async function createNativeTokenAllowanceCaveats({
+export function createNativeTokenAllowanceCaveats({
   permission,
   contracts,
 }: {
   permission: DeepRequired<NativeTokenAllowancePermission>;
   contracts: NativeTokenAllowanceEnforcers;
-}): Promise<Caveat[]> {
+}): Caveat[] {
   const { allowanceAmount, startTime } = permission.data;
 
   const nativeTokenPeriodTransferCaveat: Caveat = {

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
@@ -13,7 +13,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  MakePermissionDecoderConfig,
+  PermissionDecoderConfig,
 } from '../types';
 import {
   getByteLength,
@@ -31,7 +31,7 @@ import {
  */
 export function makeNativeTokenAllowanceDecoderConfig(
   contractAddresses: ChecksumEnforcersByChainId,
-): MakePermissionDecoderConfig {
+): PermissionDecoderConfig {
   const {
     timestampEnforcer,
     nativeTokenPeriodicEnforcer,

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
@@ -5,7 +5,7 @@ import {
 } from '@metamask/delegation-core';
 import { hexToNumber } from '@metamask/utils';
 
-import type { NativeTokenAllowancePermission } from '../../types';
+import type { NativeTokenAllowancePermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
 import { nativePayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
@@ -13,7 +13,6 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import {
@@ -142,7 +141,7 @@ export function createNativeTokenAllowanceCaveats({
   permission,
   contracts,
 }: {
-  permission: DeepRequired<NativeTokenAllowancePermission>;
+  permission: Populated<NativeTokenAllowancePermission>;
   contracts: NativeTokenAllowanceEnforcers;
 }): Caveat[] {
   const { allowanceAmount, startTime } = permission.data;

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
@@ -3,7 +3,7 @@ import {
   createExactCalldataTerms,
   createNativeTokenPeriodTransferTerms,
 } from '@metamask/delegation-core';
-import { hexToNumber } from '@metamask/utils';
+import { hexToBigInt, hexToNumber } from '@metamask/utils';
 
 import type { NativeTokenAllowancePermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
@@ -145,11 +145,24 @@ export function createNativeTokenAllowanceCaveats({
   contracts: NativeTokenAllowanceEnforcers;
 }): Caveat[] {
   const { allowanceAmount, startTime } = permission.data;
+  const allowanceAmountBigInt = hexToBigInt(allowanceAmount);
+
+  if (allowanceAmountBigInt === 0n) {
+    throw new Error(
+      'Invalid native-token-allowance permission: allowanceAmount must be a positive number.',
+    );
+  }
+
+  if (startTime <= 0) {
+    throw new Error(
+      'Invalid native-token-allowance permission: startTime must be a positive number.',
+    );
+  }
 
   const nativeTokenPeriodTransferCaveat: Caveat = {
     enforcer: contracts.nativeTokenPeriodicEnforcer,
     terms: createNativeTokenPeriodTransferTerms({
-      periodAmount: BigInt(allowanceAmount),
+      periodAmount: allowanceAmountBigInt,
       // delegation-core accepts bigint for encoding although the type is `number`.
       periodDuration: BigInt(UINT256_MAX) as unknown as number,
       startDate: startTime,

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
@@ -135,13 +135,13 @@ export type NativeTokenPeriodicEnforcers = Pick<
  * @param options0.contracts - Enforcer addresses used to construct caveats.
  * @returns The native token periodic and exact-calldata caveats.
  */
-export async function createNativeTokenPeriodicCaveats({
+export function createNativeTokenPeriodicCaveats({
   permission,
   contracts,
 }: {
   permission: DeepRequired<NativeTokenPeriodicPermission>;
   contracts: NativeTokenPeriodicEnforcers;
-}): Promise<Caveat[]> {
+}): Caveat[] {
   const { periodAmount, periodDuration, startTime } = permission.data;
 
   const nativeTokenPeriodTransferCaveat: Caveat = {

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
@@ -1,4 +1,9 @@
-import { decodeNativeTokenPeriodTransferTerms } from '@metamask/delegation-core';
+import type { Caveat } from '@metamask/delegation-core';
+import {
+  createExactCalldataTerms,
+  createNativeTokenPeriodTransferTerms,
+  decodeNativeTokenPeriodTransferTerms,
+} from '@metamask/delegation-core';
 import { bigIntToHex } from '@metamask/utils';
 
 import type { NativeTokenPeriodicPermission } from '../../types';
@@ -9,6 +14,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
+  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer, MAX_PERIOD_DURATION } from '../utils';
@@ -111,4 +117,48 @@ function validateAndDecodeData(
     periodDuration,
     startTime,
   };
+}
+
+/**
+ * Enforcers required to build native token periodic caveats.
+ */
+export type NativeTokenPeriodicEnforcers = Pick<
+  ChecksumEnforcersByChainId,
+  'nativeTokenPeriodicEnforcer' | 'exactCalldataEnforcer'
+>;
+
+/**
+ * Builds the native-token-periodic caveats required for this permission type.
+ *
+ * @param options0 - Caveat builder arguments.
+ * @param options0.permission - Fully populated native-token-periodic permission data.
+ * @param options0.contracts - Enforcer addresses used to construct caveats.
+ * @returns The native token periodic and exact-calldata caveats.
+ */
+export async function createNativeTokenPeriodicCaveats({
+  permission,
+  contracts,
+}: {
+  permission: DeepRequired<NativeTokenPeriodicPermission>;
+  contracts: NativeTokenPeriodicEnforcers;
+}): Promise<Caveat[]> {
+  const { periodAmount, periodDuration, startTime } = permission.data;
+
+  const nativeTokenPeriodTransferCaveat: Caveat = {
+    enforcer: contracts.nativeTokenPeriodicEnforcer,
+    terms: createNativeTokenPeriodTransferTerms({
+      periodAmount: BigInt(periodAmount),
+      periodDuration,
+      startDate: startTime,
+    }),
+    args: '0x',
+  };
+
+  const exactCalldataCaveat: Caveat = {
+    enforcer: contracts.exactCalldataEnforcer,
+    terms: createExactCalldataTerms({ calldata: '0x' }),
+    args: '0x',
+  };
+
+  return [nativeTokenPeriodTransferCaveat, exactCalldataCaveat];
 }

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
@@ -14,7 +14,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  MakePermissionDecoderConfig,
+  PermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer, MAX_PERIOD_DURATION } from '../utils';
 
@@ -26,7 +26,7 @@ import { getTermsByEnforcer, MAX_PERIOD_DURATION } from '../utils';
  */
 export function makeNativeTokenPeriodicDecoderConfig(
   contractAddresses: ChecksumEnforcersByChainId,
-): MakePermissionDecoderConfig {
+): PermissionDecoderConfig {
   const {
     timestampEnforcer,
     nativeTokenPeriodicEnforcer,

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
@@ -4,7 +4,7 @@ import {
   createNativeTokenPeriodTransferTerms,
   decodeNativeTokenPeriodTransferTerms,
 } from '@metamask/delegation-core';
-import { bigIntToHex } from '@metamask/utils';
+import { bigIntToHex, hexToBigInt } from '@metamask/utils';
 
 import type { NativeTokenPeriodicPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
@@ -142,11 +142,36 @@ export function createNativeTokenPeriodicCaveats({
   contracts: NativeTokenPeriodicEnforcers;
 }): Caveat[] {
   const { periodAmount, periodDuration, startTime } = permission.data;
+  const periodAmountBigInt = hexToBigInt(periodAmount);
+
+  if (periodAmountBigInt === 0n) {
+    throw new Error(
+      'Invalid native-token-periodic permission: periodAmount must be a positive number.',
+    );
+  }
+
+  if (periodDuration <= 0) {
+    throw new Error(
+      'Invalid native-token-periodic permission: periodDuration must be a positive number.',
+    );
+  }
+
+  if (periodDuration > MAX_PERIOD_DURATION) {
+    throw new Error(
+      'Invalid native-token-periodic permission: periodDuration must be less than or equal to MAX_PERIOD_DURATION.',
+    );
+  }
+
+  if (startTime <= 0) {
+    throw new Error(
+      'Invalid native-token-periodic permission: startTime must be a positive number.',
+    );
+  }
 
   const nativeTokenPeriodTransferCaveat: Caveat = {
     enforcer: contracts.nativeTokenPeriodicEnforcer,
     terms: createNativeTokenPeriodTransferTerms({
-      periodAmount: BigInt(periodAmount),
+      periodAmount: periodAmountBigInt,
       periodDuration,
       startDate: startTime,
     }),

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
@@ -6,7 +6,7 @@ import {
 } from '@metamask/delegation-core';
 import { bigIntToHex } from '@metamask/utils';
 
-import type { NativeTokenPeriodicPermission } from '../../types';
+import type { NativeTokenPeriodicPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
 import { nativePayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
@@ -14,7 +14,6 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer, MAX_PERIOD_DURATION } from '../utils';
@@ -139,7 +138,7 @@ export function createNativeTokenPeriodicCaveats({
   permission,
   contracts,
 }: {
-  permission: DeepRequired<NativeTokenPeriodicPermission>;
+  permission: Populated<NativeTokenPeriodicPermission>;
   contracts: NativeTokenPeriodicEnforcers;
 }): Caveat[] {
   const { periodAmount, periodDuration, startTime } = permission.data;

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
@@ -1,4 +1,9 @@
-import { decodeNativeTokenStreamingTerms } from '@metamask/delegation-core';
+import type { Caveat } from '@metamask/delegation-core';
+import {
+  createExactCalldataTerms,
+  createNativeTokenStreamingTerms,
+  decodeNativeTokenStreamingTerms,
+} from '@metamask/delegation-core';
 import { bigIntToHex } from '@metamask/utils';
 
 import type { NativeTokenStreamPermission } from '../../types';
@@ -9,6 +14,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
+  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer } from '../utils';
@@ -103,4 +109,50 @@ function validateAndDecodeData(
     amountPerSecond: bigIntToHex(amountPerSecond),
     startTime,
   };
+}
+
+/**
+ * Enforcers required to build native token stream caveats.
+ */
+export type NativeTokenStreamEnforcers = Pick<
+  ChecksumEnforcersByChainId,
+  'nativeTokenStreamingEnforcer' | 'exactCalldataEnforcer'
+>;
+
+/**
+ * Builds the native-token-stream caveats required for this permission type.
+ *
+ * @param options0 - Caveat builder arguments.
+ * @param options0.permission - Fully populated native-token-stream permission data.
+ * @param options0.contracts - Enforcer addresses used to construct caveats.
+ * @returns The native token streaming and exact-calldata caveats.
+ */
+export async function createNativeTokenStreamCaveats({
+  permission,
+  contracts,
+}: {
+  permission: DeepRequired<NativeTokenStreamPermission>;
+  contracts: NativeTokenStreamEnforcers;
+}): Promise<Caveat[]> {
+  const { initialAmount, maxAmount, amountPerSecond, startTime } =
+    permission.data;
+
+  const nativeTokenStreamingCaveat: Caveat = {
+    enforcer: contracts.nativeTokenStreamingEnforcer,
+    terms: createNativeTokenStreamingTerms({
+      initialAmount: BigInt(initialAmount),
+      maxAmount: BigInt(maxAmount),
+      amountPerSecond: BigInt(amountPerSecond),
+      startTime,
+    }),
+    args: '0x',
+  };
+
+  const exactCalldataCaveat: Caveat = {
+    enforcer: contracts.exactCalldataEnforcer,
+    terms: createExactCalldataTerms({ calldata: '0x' }),
+    args: '0x',
+  };
+
+  return [nativeTokenStreamingCaveat, exactCalldataCaveat];
 }

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
@@ -127,13 +127,13 @@ export type NativeTokenStreamEnforcers = Pick<
  * @param options0.contracts - Enforcer addresses used to construct caveats.
  * @returns The native token streaming and exact-calldata caveats.
  */
-export async function createNativeTokenStreamCaveats({
+export function createNativeTokenStreamCaveats({
   permission,
   contracts,
 }: {
   permission: DeepRequired<NativeTokenStreamPermission>;
   contracts: NativeTokenStreamEnforcers;
-}): Promise<Caveat[]> {
+}): Caveat[] {
   const { initialAmount, maxAmount, amountPerSecond, startTime } =
     permission.data;
 

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
@@ -6,7 +6,7 @@ import {
 } from '@metamask/delegation-core';
 import { bigIntToHex } from '@metamask/utils';
 
-import type { NativeTokenStreamPermission } from '../../types';
+import type { NativeTokenStreamPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
 import { nativePayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
@@ -14,7 +14,6 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer } from '../utils';
@@ -131,7 +130,7 @@ export function createNativeTokenStreamCaveats({
   permission,
   contracts,
 }: {
-  permission: DeepRequired<NativeTokenStreamPermission>;
+  permission: Populated<NativeTokenStreamPermission>;
   contracts: NativeTokenStreamEnforcers;
 }): Caveat[] {
   const { initialAmount, maxAmount, amountPerSecond, startTime } =

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
@@ -14,7 +14,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  MakePermissionDecoderConfig,
+  PermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer } from '../utils';
 
@@ -26,7 +26,7 @@ import { getTermsByEnforcer } from '../utils';
  */
 export function makeNativeTokenStreamDecoderConfig(
   contractAddresses: ChecksumEnforcersByChainId,
-): MakePermissionDecoderConfig {
+): PermissionDecoderConfig {
   const {
     timestampEnforcer,
     nativeTokenStreamingEnforcer,

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
@@ -4,7 +4,7 @@ import {
   createNativeTokenStreamingTerms,
   decodeNativeTokenStreamingTerms,
 } from '@metamask/delegation-core';
-import { bigIntToHex } from '@metamask/utils';
+import { bigIntToHex, hexToBigInt } from '@metamask/utils';
 
 import type { NativeTokenStreamPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
@@ -135,13 +135,34 @@ export function createNativeTokenStreamCaveats({
 }): Caveat[] {
   const { initialAmount, maxAmount, amountPerSecond, startTime } =
     permission.data;
+  const initialAmountBigInt = hexToBigInt(initialAmount);
+  const maxAmountBigInt = hexToBigInt(maxAmount);
+  const amountPerSecondBigInt = hexToBigInt(amountPerSecond);
+
+  if (maxAmountBigInt <= initialAmountBigInt) {
+    throw new Error(
+      'Invalid native-token-stream permission: maxAmount must be greater than initialAmount.',
+    );
+  }
+
+  if (amountPerSecondBigInt === 0n) {
+    throw new Error(
+      'Invalid native-token-stream permission: amountPerSecond must be a positive number.',
+    );
+  }
+
+  if (startTime <= 0) {
+    throw new Error(
+      'Invalid native-token-stream permission: startTime must be a positive number.',
+    );
+  }
 
   const nativeTokenStreamingCaveat: Caveat = {
     enforcer: contracts.nativeTokenStreamingEnforcer,
     terms: createNativeTokenStreamingTerms({
-      initialAmount: BigInt(initialAmount),
-      maxAmount: BigInt(maxAmount),
-      amountPerSecond: BigInt(amountPerSecond),
+      initialAmount: initialAmountBigInt,
+      maxAmount: maxAmountBigInt,
+      amountPerSecond: amountPerSecondBigInt,
       startTime,
     }),
     args: '0x',

--- a/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
@@ -1,4 +1,8 @@
-import { decodeApprovalRevocationTerms } from '@metamask/delegation-core';
+import type { Caveat } from '@metamask/delegation-core';
+import {
+  createApprovalRevocationTerms,
+  decodeApprovalRevocationTerms,
+} from '@metamask/delegation-core';
 
 import type { TokenApprovalRevocationPermission } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
@@ -6,6 +10,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
+  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer } from '../utils';
@@ -72,4 +77,36 @@ function validateAndDecodeData(
     permit2Lockdown,
     permit2InvalidateNonces,
   };
+}
+
+/**
+ * Enforcers required to build token approval revocation caveats.
+ */
+export type TokenApprovalRevocationEnforcers = Pick<
+  ChecksumEnforcersByChainId,
+  'approvalRevocationEnforcer'
+>;
+
+/**
+ * Builds the token-approval-revocation caveat required for this permission type.
+ *
+ * @param options0 - Caveat builder arguments.
+ * @param options0.permission - Fully populated token-approval-revocation permission data.
+ * @param options0.contracts - Enforcer addresses used to construct caveats.
+ * @returns A single approval-revocation caveat.
+ */
+export async function createTokenApprovalRevocationCaveats({
+  permission,
+  contracts,
+}: {
+  permission: DeepRequired<TokenApprovalRevocationPermission>;
+  contracts: TokenApprovalRevocationEnforcers;
+}): Promise<Caveat[]> {
+  const approvalRevocationCaveat: Caveat = {
+    enforcer: contracts.approvalRevocationEnforcer,
+    terms: createApprovalRevocationTerms(permission.data),
+    args: '0x',
+  };
+
+  return [approvalRevocationCaveat];
 }

--- a/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
@@ -95,13 +95,13 @@ export type TokenApprovalRevocationEnforcers = Pick<
  * @param options0.contracts - Enforcer addresses used to construct caveats.
  * @returns A single approval-revocation caveat.
  */
-export async function createTokenApprovalRevocationCaveats({
+export function createTokenApprovalRevocationCaveats({
   permission,
   contracts,
 }: {
   permission: DeepRequired<TokenApprovalRevocationPermission>;
   contracts: TokenApprovalRevocationEnforcers;
-}): Promise<Caveat[]> {
+}): Caveat[] {
   const approvalRevocationCaveat: Caveat = {
     enforcer: contracts.approvalRevocationEnforcer,
     terms: createApprovalRevocationTerms(permission.data),

--- a/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
@@ -10,7 +10,7 @@ import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  MakePermissionDecoderConfig,
+  PermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer } from '../utils';
 
@@ -22,7 +22,7 @@ import { getTermsByEnforcer } from '../utils';
  */
 export function makeTokenApprovalRevocationDecoderConfig(
   contractAddresses: ChecksumEnforcersByChainId,
-): MakePermissionDecoderConfig {
+): PermissionDecoderConfig {
   const { timestampEnforcer, approvalRevocationEnforcer, nonceEnforcer } =
     contractAddresses;
 

--- a/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
@@ -4,13 +4,12 @@ import {
   decodeApprovalRevocationTerms,
 } from '@metamask/delegation-core';
 
-import type { TokenApprovalRevocationPermission } from '../../types';
+import type { TokenApprovalRevocationPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
 import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
   DecodedPermissionData,
-  DeepRequired,
   MakePermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer } from '../utils';
@@ -99,7 +98,7 @@ export function createTokenApprovalRevocationCaveats({
   permission,
   contracts,
 }: {
-  permission: DeepRequired<TokenApprovalRevocationPermission>;
+  permission: Populated<TokenApprovalRevocationPermission>;
   contracts: TokenApprovalRevocationEnforcers;
 }): Caveat[] {
   const approvalRevocationCaveat: Caveat = {

--- a/packages/7715-permission-types/src/permissions/index.ts
+++ b/packages/7715-permission-types/src/permissions/index.ts
@@ -8,6 +8,12 @@ import { makeTokenApprovalRevocationDecoderConfig } from './caveats/tokenApprova
 import type { DeployedContractsByName, PermissionDecoderConfig } from './types';
 import { getChecksumEnforcersByChainId } from './utils';
 
+export {
+  createErc20TokenStreamCaveats,
+  type Erc20TokenStreamEnforcers,
+  type Erc20TokenStreamDecoderEnforcers,
+} from './caveats/erc20TokenStream';
+
 export type { ExpiryRule } from './rules/expiry';
 export type { PayeeRule } from './rules/payee';
 export type { RedeemerRule } from './rules/redeemer';

--- a/packages/7715-permission-types/src/permissions/index.ts
+++ b/packages/7715-permission-types/src/permissions/index.ts
@@ -11,8 +11,31 @@ import { getChecksumEnforcersByChainId } from './utils';
 export {
   createErc20TokenStreamCaveats,
   type Erc20TokenStreamEnforcers,
-  type Erc20TokenStreamDecoderEnforcers,
 } from './caveats/erc20TokenStream';
+export {
+  createErc20TokenPeriodicCaveats,
+  type Erc20TokenPeriodicEnforcers,
+} from './caveats/erc20TokenPeriodic';
+export {
+  createErc20TokenAllowanceCaveats,
+  type Erc20TokenAllowanceEnforcers,
+} from './caveats/erc20TokenAllowance';
+export {
+  createNativeTokenStreamCaveats,
+  type NativeTokenStreamEnforcers,
+} from './caveats/nativeTokenStream';
+export {
+  createNativeTokenPeriodicCaveats,
+  type NativeTokenPeriodicEnforcers,
+} from './caveats/nativeTokenPeriodic';
+export {
+  createNativeTokenAllowanceCaveats,
+  type NativeTokenAllowanceEnforcers,
+} from './caveats/nativeTokenAllowance';
+export {
+  createTokenApprovalRevocationCaveats,
+  type TokenApprovalRevocationEnforcers,
+} from './caveats/tokenApprovalRevocation';
 
 export type { ExpiryRule } from './rules/expiry';
 export type { PayeeRule } from './rules/payee';

--- a/packages/7715-permission-types/src/permissions/types.ts
+++ b/packages/7715-permission-types/src/permissions/types.ts
@@ -59,11 +59,6 @@ export type PermissionDecoderConfig = {
   ) => DecodedPermissionData;
 };
 
-/**
- * Alias kept to align with existing decoder factory naming.
- */
-export type MakePermissionDecoderConfig = PermissionDecoderConfig;
-
 export type PermissionDecoderSpec = (
   contractAddresses: ChecksumEnforcersByChainId,
 ) => PermissionDecoderConfig;

--- a/packages/7715-permission-types/src/permissions/types.ts
+++ b/packages/7715-permission-types/src/permissions/types.ts
@@ -95,3 +95,18 @@ export type PermissionDecoder = {
  * A map of deployed contract names to addresses for one chain.
  */
 export type DeployedContractsByName = Record<string, Hex>;
+
+/**
+ * Makes all properties in an object type required recursively.
+ * This includes nested objects and arrays.
+ * Also removes undefined from union types.
+ */
+export type DeepRequired<TParent> = TParent extends (infer U)[]
+  ? DeepRequired<U>[]
+  : TParent extends object
+    ? {
+        [P in keyof TParent]-?: DeepRequired<
+          Exclude<TParent[P], undefined | null>
+        >;
+      }
+    : Exclude<TParent, undefined | null>;

--- a/packages/7715-permission-types/src/permissions/types.ts
+++ b/packages/7715-permission-types/src/permissions/types.ts
@@ -95,18 +95,3 @@ export type PermissionDecoder = {
  * A map of deployed contract names to addresses for one chain.
  */
 export type DeployedContractsByName = Record<string, Hex>;
-
-/**
- * Makes all properties in an object type required recursively.
- * This includes nested objects and arrays.
- * Also removes undefined from union types.
- */
-export type DeepRequired<TParent> = TParent extends (infer U)[]
-  ? DeepRequired<U>[]
-  : TParent extends object
-    ? {
-        [P in keyof TParent]-?: DeepRequired<
-          Exclude<TParent[P], undefined | null>
-        >;
-      }
-    : Exclude<TParent, undefined | null>;

--- a/packages/7715-permission-types/src/types.ts
+++ b/packages/7715-permission-types/src/types.ts
@@ -53,6 +53,24 @@ export type MetaMaskBasePermissionData = {
 };
 
 /**
+ * Makes all properties in an object type required recursively.
+ * This includes nested objects and arrays.
+ * Also removes undefined and null from union types.
+ */
+type RecursivePopulated<TParent> = TParent extends (infer U)[]
+  ? RecursivePopulated<U>[]
+  : TParent extends object
+    ? {
+        [P in keyof TParent]-?: RecursivePopulated<
+          Exclude<TParent[P], undefined | null>
+        >;
+      }
+    : Exclude<TParent, undefined | null>;
+
+export type Populated<TParent extends BasePermission> =
+  RecursivePopulated<TParent>;
+
+/**
  * A permission to stream native tokens.
  *
  * data.initialAmount - is the initial amount of the native token to be streamed. Defaults to 0.

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
@@ -6,16 +6,24 @@ import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { makePermissionDecoderConfigs } from '../../../src/permissions';
-import { makeErc20TokenAllowanceDecoderConfig } from '../../../src/permissions/caveats/erc20TokenAllowance';
+import {
+  createErc20TokenAllowanceCaveats,
+  makeErc20TokenAllowanceDecoderConfig,
+  type Erc20TokenAllowanceEnforcers,
+} from '../../../src/permissions/caveats/erc20TokenAllowance';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type { ChecksumCaveat } from '../../../src/permissions/types';
+import type {
+  ChecksumCaveat,
+  DeepRequired,
+} from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   UINT256_MAX,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
+import type { Erc20TokenAllowancePermission } from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('erc20-token-allowance decoder config', () => {
@@ -160,5 +168,48 @@ describe('erc20-token-allowance decoder config', () => {
         'Invalid erc20-token-allowance terms: allowanceAmount must be a positive number',
       );
     });
+  });
+});
+
+describe('createErc20TokenAllowanceCaveats()', () => {
+  const tokenAddress = '0x1234567890123456789012345678901234567890' as const;
+  const allowanceAmount = '0x64' as const;
+  const startTime = 1729900800;
+
+  const contracts: Erc20TokenAllowanceEnforcers = {
+    erc20PeriodicEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
+  };
+
+  const permission: DeepRequired<Erc20TokenAllowancePermission> = {
+    type: 'erc20-token-allowance',
+    data: {
+      tokenAddress,
+      allowanceAmount,
+      startTime,
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  };
+
+  it('creates erc20Periodic and valueLte caveats', async () => {
+    const caveats = await createErc20TokenAllowanceCaveats({
+      permission,
+      contracts,
+    });
+    const expectedTerms = `0x${tokenAddress.slice(2)}${toWord(BigInt(allowanceAmount))}${UINT256_MAX.slice(2)}${toWord(startTime)}`;
+
+    expect(caveats).toStrictEqual([
+      {
+        enforcer: contracts.erc20PeriodicEnforcer,
+        terms: expectedTerms,
+        args: '0x',
+      },
+      {
+        enforcer: contracts.valueLteEnforcer,
+        terms: ZERO_32_BYTES,
+        args: '0x',
+      },
+    ]);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
@@ -212,4 +212,63 @@ describe('createErc20TokenAllowanceCaveats()', () => {
       },
     ]);
   });
+
+  it('rejects malformed numeric hex input', async () => {
+    const invalidPermission = {
+      ...permission,
+      data: {
+        ...permission.data,
+        allowanceAmount: 'not-hex' as Hex,
+      },
+    };
+
+    await expect(
+      createErc20TokenAllowanceCaveats({
+        permission: invalidPermission,
+        contracts,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('keeps valueLte caveat fixed at zero across varied inputs', async () => {
+    const variedPermission: DeepRequired<Erc20TokenAllowancePermission> = {
+      ...permission,
+      data: {
+        ...permission.data,
+        tokenAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        allowanceAmount:
+          '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        startTime: 1,
+      },
+    };
+
+    const caveats = await createErc20TokenAllowanceCaveats({
+      permission: variedPermission,
+      contracts,
+    });
+
+    expect(caveats[1]?.enforcer).toBe(contracts.valueLteEnforcer);
+    expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
+  });
+
+  it('encodes provided token address in allowance terms', async () => {
+    const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const permissionWithAltToken = {
+      ...permission,
+      data: {
+        ...permission.data,
+        tokenAddress: alternateTokenAddress,
+      },
+    };
+
+    const caveats = await createErc20TokenAllowanceCaveats({
+      permission: permissionWithAltToken,
+      contracts,
+    });
+
+    expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodicEnforcer);
+    expect(
+      caveats[0]?.terms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
+    ).toBe(true);
+  });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
@@ -192,8 +192,8 @@ describe('createErc20TokenAllowanceCaveats()', () => {
     isAdjustmentAllowed: true,
   };
 
-  it('creates erc20Periodic and valueLte caveats', async () => {
-    const caveats = await createErc20TokenAllowanceCaveats({
+  it('creates erc20Periodic and valueLte caveats', () => {
+    const caveats = createErc20TokenAllowanceCaveats({
       permission,
       contracts,
     });
@@ -213,7 +213,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
     ]);
   });
 
-  it('rejects malformed numeric hex input', async () => {
+  it('rejects malformed numeric hex input', () => {
     const invalidPermission = {
       ...permission,
       data: {
@@ -222,15 +222,15 @@ describe('createErc20TokenAllowanceCaveats()', () => {
       },
     };
 
-    await expect(
+    expect(() =>
       createErc20TokenAllowanceCaveats({
         permission: invalidPermission,
         contracts,
       }),
-    ).rejects.toThrow();
+    ).toThrow();
   });
 
-  it('keeps valueLte caveat fixed at zero across varied inputs', async () => {
+  it('keeps valueLte caveat fixed at zero across varied inputs', () => {
     const variedPermission: DeepRequired<Erc20TokenAllowancePermission> = {
       ...permission,
       data: {
@@ -242,7 +242,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
       },
     };
 
-    const caveats = await createErc20TokenAllowanceCaveats({
+    const caveats = createErc20TokenAllowanceCaveats({
       permission: variedPermission,
       contracts,
     });
@@ -251,7 +251,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
     expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
   });
 
-  it('encodes provided token address in allowance terms', async () => {
+  it('encodes provided token address in allowance terms', () => {
     const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     const permissionWithAltToken = {
       ...permission,
@@ -261,7 +261,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
       },
     };
 
-    const caveats = await createErc20TokenAllowanceCaveats({
+    const caveats = createErc20TokenAllowanceCaveats({
       permission: permissionWithAltToken,
       contracts,
     });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
@@ -14,16 +14,16 @@ import {
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type {
-  ChecksumCaveat,
-  DeepRequired,
-} from '../../../src/permissions/types';
+import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   UINT256_MAX,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
-import type { Erc20TokenAllowancePermission } from '../../../src/types';
+import type {
+  Erc20TokenAllowancePermission,
+  Populated,
+} from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('erc20-token-allowance decoder config', () => {
@@ -181,7 +181,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
     valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
-  const permission: DeepRequired<Erc20TokenAllowancePermission> = {
+  const permission: Populated<Erc20TokenAllowancePermission> = {
     type: 'erc20-token-allowance',
     data: {
       tokenAddress,
@@ -231,7 +231,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
   });
 
   it('keeps valueLte caveat fixed at zero across varied inputs', () => {
-    const variedPermission: DeepRequired<Erc20TokenAllowancePermission> = {
+    const variedPermission: Populated<Erc20TokenAllowancePermission> = {
       ...permission,
       data: {
         ...permission.data,

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
@@ -230,6 +230,40 @@ describe('createErc20TokenAllowanceCaveats()', () => {
     ).toThrow();
   });
 
+  it('rejects zero allowanceAmount', () => {
+    expect(() =>
+      createErc20TokenAllowanceCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            allowanceAmount: '0x0',
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-allowance permission: allowanceAmount must be a positive number.',
+    );
+  });
+
+  it('rejects when startTime is zero', () => {
+    expect(() =>
+      createErc20TokenAllowanceCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            startTime: 0,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-allowance permission: startTime must be a positive number.',
+    );
+  });
+
   it('keeps valueLte caveat fixed at zero across varied inputs', () => {
     const variedPermission: Populated<Erc20TokenAllowancePermission> = {
       ...permission,
@@ -252,7 +286,8 @@ describe('createErc20TokenAllowanceCaveats()', () => {
   });
 
   it('encodes provided token address in allowance terms', () => {
-    const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const alternateTokenAddress =
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Hex;
     const permissionWithAltToken = {
       ...permission,
       data: {
@@ -265,10 +300,11 @@ describe('createErc20TokenAllowanceCaveats()', () => {
       permission: permissionWithAltToken,
       contracts,
     });
+    const erc20AllowanceTerms = caveats[0]?.terms as Hex;
 
     expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodicEnforcer);
     expect(
-      caveats[0]?.terms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
+      erc20AllowanceTerms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
     ).toBe(true);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
@@ -224,8 +224,8 @@ describe('createErc20TokenPeriodicCaveats()', () => {
     isAdjustmentAllowed: true,
   };
 
-  it('creates erc20Periodic and valueLte caveats', async () => {
-    const caveats = await createErc20TokenPeriodicCaveats({
+  it('creates erc20Periodic and valueLte caveats', () => {
+    const caveats = createErc20TokenPeriodicCaveats({
       permission,
       contracts,
     });
@@ -245,7 +245,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
     ]);
   });
 
-  it('rejects malformed numeric hex input', async () => {
+  it('rejects malformed numeric hex input', () => {
     const invalidPermission = {
       ...permission,
       data: {
@@ -254,15 +254,15 @@ describe('createErc20TokenPeriodicCaveats()', () => {
       },
     };
 
-    await expect(
+    expect(() =>
       createErc20TokenPeriodicCaveats({
         permission: invalidPermission,
         contracts,
       }),
-    ).rejects.toThrow();
+    ).toThrow();
   });
 
-  it('keeps valueLte caveat fixed at zero across varied inputs', async () => {
+  it('keeps valueLte caveat fixed at zero across varied inputs', () => {
     const variedPermission: DeepRequired<Erc20TokenPeriodicPermission> = {
       ...permission,
       data: {
@@ -275,7 +275,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
       },
     };
 
-    const caveats = await createErc20TokenPeriodicCaveats({
+    const caveats = createErc20TokenPeriodicCaveats({
       permission: variedPermission,
       contracts,
     });
@@ -284,7 +284,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
     expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
   });
 
-  it('encodes provided token address in periodic terms', async () => {
+  it('encodes provided token address in periodic terms', () => {
     const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     const permissionWithAltToken = {
       ...permission,
@@ -294,7 +294,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
       },
     };
 
-    const caveats = await createErc20TokenPeriodicCaveats({
+    const caveats = createErc20TokenPeriodicCaveats({
       permission: permissionWithAltToken,
       contracts,
     });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
@@ -244,4 +244,64 @@ describe('createErc20TokenPeriodicCaveats()', () => {
       },
     ]);
   });
+
+  it('rejects malformed numeric hex input', async () => {
+    const invalidPermission = {
+      ...permission,
+      data: {
+        ...permission.data,
+        periodAmount: 'not-hex' as Hex,
+      },
+    };
+
+    await expect(
+      createErc20TokenPeriodicCaveats({
+        permission: invalidPermission,
+        contracts,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('keeps valueLte caveat fixed at zero across varied inputs', async () => {
+    const variedPermission: DeepRequired<Erc20TokenPeriodicPermission> = {
+      ...permission,
+      data: {
+        ...permission.data,
+        tokenAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        periodAmount:
+          '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        periodDuration: 1,
+        startTime: 1,
+      },
+    };
+
+    const caveats = await createErc20TokenPeriodicCaveats({
+      permission: variedPermission,
+      contracts,
+    });
+
+    expect(caveats[1]?.enforcer).toBe(contracts.valueLteEnforcer);
+    expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
+  });
+
+  it('encodes provided token address in periodic terms', async () => {
+    const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const permissionWithAltToken = {
+      ...permission,
+      data: {
+        ...permission.data,
+        tokenAddress: alternateTokenAddress,
+      },
+    };
+
+    const caveats = await createErc20TokenPeriodicCaveats({
+      permission: permissionWithAltToken,
+      contracts,
+    });
+
+    expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodicEnforcer);
+    expect(
+      caveats[0]?.terms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
+    ).toBe(true);
+  });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
@@ -6,16 +6,24 @@ import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { makePermissionDecoderConfigs } from '../../../src/permissions';
-import { makeErc20TokenPeriodicDecoderConfig } from '../../../src/permissions/caveats/erc20TokenPeriodic';
+import {
+  createErc20TokenPeriodicCaveats,
+  makeErc20TokenPeriodicDecoderConfig,
+  type Erc20TokenPeriodicEnforcers,
+} from '../../../src/permissions/caveats/erc20TokenPeriodic';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type { ChecksumCaveat } from '../../../src/permissions/types';
+import type {
+  ChecksumCaveat,
+  DeepRequired,
+} from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   MAX_PERIOD_DURATION,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
+import type { Erc20TokenPeriodicPermission } from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('erc20-token-periodic decoder config', () => {
@@ -190,5 +198,50 @@ describe('erc20-token-periodic decoder config', () => {
         startTime: START_TIME,
       });
     });
+  });
+});
+
+describe('createErc20TokenPeriodicCaveats()', () => {
+  const tokenAddress = '0x1234567890123456789012345678901234567890' as const;
+  const periodAmount = '0x64' as const;
+  const periodDuration = 86400;
+  const startTime = 1729900800;
+
+  const contracts: Erc20TokenPeriodicEnforcers = {
+    erc20PeriodicEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
+  };
+
+  const permission: DeepRequired<Erc20TokenPeriodicPermission> = {
+    type: 'erc20-token-periodic',
+    data: {
+      tokenAddress,
+      periodAmount,
+      periodDuration,
+      startTime,
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  };
+
+  it('creates erc20Periodic and valueLte caveats', async () => {
+    const caveats = await createErc20TokenPeriodicCaveats({
+      permission,
+      contracts,
+    });
+    const expectedTerms = `0x${tokenAddress.slice(2)}${toWord(BigInt(periodAmount))}${toWord(periodDuration)}${toWord(startTime)}`;
+
+    expect(caveats).toStrictEqual([
+      {
+        enforcer: contracts.erc20PeriodicEnforcer,
+        terms: expectedTerms,
+        args: '0x',
+      },
+      {
+        enforcer: contracts.valueLteEnforcer,
+        terms: ZERO_32_BYTES,
+        args: '0x',
+      },
+    ]);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
@@ -262,6 +262,74 @@ describe('createErc20TokenPeriodicCaveats()', () => {
     ).toThrow();
   });
 
+  it('rejects when periodAmount is zero', () => {
+    expect(() =>
+      createErc20TokenPeriodicCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            periodAmount: '0x0',
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-periodic permission: periodAmount must be a positive number.',
+    );
+  });
+
+  it('rejects when periodDuration is zero', () => {
+    expect(() =>
+      createErc20TokenPeriodicCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            periodDuration: 0,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-periodic permission: periodDuration must be a positive number.',
+    );
+  });
+
+  it('rejects when periodDuration exceeds MAX_PERIOD_DURATION', () => {
+    expect(() =>
+      createErc20TokenPeriodicCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            periodDuration: MAX_PERIOD_DURATION + 1,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-periodic permission: periodDuration must be less than or equal to MAX_PERIOD_DURATION.',
+    );
+  });
+
+  it('rejects when startTime is zero', () => {
+    expect(() =>
+      createErc20TokenPeriodicCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            startTime: 0,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-periodic permission: startTime must be a positive number.',
+    );
+  });
+
   it('keeps valueLte caveat fixed at zero across varied inputs', () => {
     const variedPermission: Populated<Erc20TokenPeriodicPermission> = {
       ...permission,
@@ -285,7 +353,8 @@ describe('createErc20TokenPeriodicCaveats()', () => {
   });
 
   it('encodes provided token address in periodic terms', () => {
-    const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const alternateTokenAddress =
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Hex;
     const permissionWithAltToken = {
       ...permission,
       data: {
@@ -298,10 +367,11 @@ describe('createErc20TokenPeriodicCaveats()', () => {
       permission: permissionWithAltToken,
       contracts,
     });
+    const erc20PeriodicTerms = caveats[0]?.terms as Hex;
 
     expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodicEnforcer);
     expect(
-      caveats[0]?.terms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
+      erc20PeriodicTerms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
     ).toBe(true);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
@@ -14,16 +14,16 @@ import {
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type {
-  ChecksumCaveat,
-  DeepRequired,
-} from '../../../src/permissions/types';
+import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   MAX_PERIOD_DURATION,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
-import type { Erc20TokenPeriodicPermission } from '../../../src/types';
+import type {
+  Erc20TokenPeriodicPermission,
+  Populated,
+} from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('erc20-token-periodic decoder config', () => {
@@ -212,7 +212,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
     valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
-  const permission: DeepRequired<Erc20TokenPeriodicPermission> = {
+  const permission: Populated<Erc20TokenPeriodicPermission> = {
     type: 'erc20-token-periodic',
     data: {
       tokenAddress,
@@ -263,7 +263,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
   });
 
   it('keeps valueLte caveat fixed at zero across varied inputs', () => {
-    const variedPermission: DeepRequired<Erc20TokenPeriodicPermission> = {
+    const variedPermission: Populated<Erc20TokenPeriodicPermission> = {
       ...permission,
       data: {
         ...permission.data,

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
@@ -207,8 +207,8 @@ describe('createErc20TokenStreamCaveats()', () => {
     isAdjustmentAllowed: true,
   };
 
-  it('creates erc20Streaming and valueLte caveats', async () => {
-    const caveats = await createErc20TokenStreamCaveats({
+  it('creates erc20Streaming and valueLte caveats', () => {
+    const caveats = createErc20TokenStreamCaveats({
       permission: mockPermission,
       contracts,
     });
@@ -233,7 +233,7 @@ describe('createErc20TokenStreamCaveats()', () => {
     ]);
   });
 
-  it('rejects malformed numeric hex input', async () => {
+  it('rejects malformed numeric hex input', () => {
     const invalidPermission = {
       ...mockPermission,
       data: {
@@ -242,15 +242,15 @@ describe('createErc20TokenStreamCaveats()', () => {
       },
     };
 
-    await expect(
+    expect(() =>
       createErc20TokenStreamCaveats({
         permission: invalidPermission,
         contracts,
       }),
-    ).rejects.toThrow();
+    ).toThrow();
   });
 
-  it('keeps valueLte caveat fixed at zero across varied inputs', async () => {
+  it('keeps valueLte caveat fixed at zero across varied inputs', () => {
     const variedPermission: DeepRequired<Erc20TokenStreamPermission> = {
       ...mockPermission,
       data: {
@@ -264,7 +264,7 @@ describe('createErc20TokenStreamCaveats()', () => {
       },
     };
 
-    const caveats = await createErc20TokenStreamCaveats({
+    const caveats = createErc20TokenStreamCaveats({
       permission: variedPermission,
       contracts,
     });
@@ -273,7 +273,7 @@ describe('createErc20TokenStreamCaveats()', () => {
     expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
   });
 
-  it('encodes provided token address in stream terms', async () => {
+  it('encodes provided token address in stream terms', () => {
     const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     const permission = {
       ...mockPermission,
@@ -283,7 +283,7 @@ describe('createErc20TokenStreamCaveats()', () => {
       },
     };
 
-    const caveats = await createErc20TokenStreamCaveats({
+    const caveats = createErc20TokenStreamCaveats({
       permission,
       contracts,
     });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
@@ -5,7 +5,7 @@ import {
 import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
-import { makePermissionDecoderConfigs} from '../../../src/permissions';
+import { makePermissionDecoderConfigs } from '../../../src/permissions';
 import {
   createErc20TokenStreamCaveats,
   type Erc20TokenStreamEnforcers,

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
@@ -5,16 +5,24 @@ import {
 import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
-import { makePermissionDecoderConfigs } from '../../../src/permissions';
-import { makeErc20TokenStreamDecoderConfig } from '../../../src/permissions/caveats/erc20TokenStream';
+import { makePermissionDecoderConfigs} from '../../../src/permissions';
+import {
+  createErc20TokenStreamCaveats,
+  type Erc20TokenStreamEnforcers,
+  makeErc20TokenStreamDecoderConfig,
+} from '../../../src/permissions/caveats/erc20TokenStream';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type { ChecksumCaveat } from '../../../src/permissions/types';
+import type {
+  ChecksumCaveat,
+  DeepRequired,
+} from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
+import type { Erc20TokenStreamPermission } from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('erc20-token-stream decoder config', () => {
@@ -171,5 +179,57 @@ describe('erc20-token-stream decoder config', () => {
         'Invalid erc20-token-stream terms: startTime must be a positive number',
       );
     });
+  });
+});
+
+describe('createErc20TokenStreamCaveats()', () => {
+  const initialAmount = '0x0de0b6b3a7640000' as const;
+  const maxAmount = '0x8ac7230489e80000' as const;
+  const amountPerSecond = '0x06f05b59d3b20000' as const;
+  const startTime = 1729900800; // 10/26/2024 00:00:00 UTC
+  const tokenAddress = '0x1234567890123456789012345678901234567890' as const;
+
+  const contracts: Erc20TokenStreamEnforcers = {
+    erc20StreamingEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
+  };
+
+  const mockPermission: DeepRequired<Erc20TokenStreamPermission> = {
+    type: 'erc20-token-stream',
+    data: {
+      initialAmount,
+      maxAmount,
+      amountPerSecond,
+      startTime,
+      tokenAddress,
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  };
+
+  it('creates erc20Streaming and valueLte caveats', async () => {
+    const caveats = await createErc20TokenStreamCaveats({
+      permission: mockPermission,
+      contracts,
+    });
+    const initialAmountHex = initialAmount.slice(2).padStart(64, '0');
+    const maxAmountHex = maxAmount.slice(2).padStart(64, '0');
+    const amountPerSecondHex = amountPerSecond.slice(2).padStart(64, '0');
+    const startTimeHex = startTime.toString(16).padStart(64, '0');
+    const erc20StreamingExpectedTerms = `0x${tokenAddress.slice(2)}${initialAmountHex}${maxAmountHex}${amountPerSecondHex}${startTimeHex}`;
+
+    expect(caveats).toStrictEqual([
+      {
+        enforcer: contracts.erc20StreamingEnforcer,
+        terms: erc20StreamingExpectedTerms,
+        args: '0x',
+      },
+      {
+        enforcer: contracts.valueLteEnforcer,
+        terms:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        args: '0x',
+      },
+    ]);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
@@ -232,4 +232,65 @@ describe('createErc20TokenStreamCaveats()', () => {
       },
     ]);
   });
+
+  it('rejects malformed numeric hex input', async () => {
+    const invalidPermission = {
+      ...mockPermission,
+      data: {
+        ...mockPermission.data,
+        initialAmount: 'not-hex' as Hex,
+      },
+    };
+
+    await expect(
+      createErc20TokenStreamCaveats({
+        permission: invalidPermission,
+        contracts,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('keeps valueLte caveat fixed at zero across varied inputs', async () => {
+    const variedPermission: DeepRequired<Erc20TokenStreamPermission> = {
+      ...mockPermission,
+      data: {
+        ...mockPermission.data,
+        tokenAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        initialAmount: '0x1',
+        maxAmount:
+          '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        amountPerSecond: '0x2',
+        startTime: 1,
+      },
+    };
+
+    const caveats = await createErc20TokenStreamCaveats({
+      permission: variedPermission,
+      contracts,
+    });
+
+    expect(caveats[1]?.enforcer).toBe(contracts.valueLteEnforcer);
+    expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
+  });
+
+  it('encodes provided token address in stream terms', async () => {
+    const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const permission = {
+      ...mockPermission,
+      data: {
+        ...mockPermission.data,
+        tokenAddress: alternateTokenAddress,
+      },
+    };
+
+    const caveats = await createErc20TokenStreamCaveats({
+      permission,
+      contracts,
+    });
+
+    expect(caveats[0]?.enforcer).toBe(contracts.erc20StreamingEnforcer);
+    expect(
+      caveats[0]?.terms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
+    ).toBe(true);
+  });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
@@ -14,15 +14,12 @@ import {
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type {
-  ChecksumCaveat,
-  DeepRequired,
-} from '../../../src/permissions/types';
+import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
-import type { Erc20TokenStreamPermission } from '../../../src/types';
+import type { Erc20TokenStreamPermission, Populated } from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('erc20-token-stream decoder config', () => {
@@ -194,7 +191,7 @@ describe('createErc20TokenStreamCaveats()', () => {
     valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
-  const mockPermission: DeepRequired<Erc20TokenStreamPermission> = {
+  const mockPermission: Populated<Erc20TokenStreamPermission> = {
     type: 'erc20-token-stream',
     data: {
       initialAmount,
@@ -251,7 +248,7 @@ describe('createErc20TokenStreamCaveats()', () => {
   });
 
   it('keeps valueLte caveat fixed at zero across varied inputs', () => {
-    const variedPermission: DeepRequired<Erc20TokenStreamPermission> = {
+    const variedPermission: Populated<Erc20TokenStreamPermission> = {
       ...mockPermission,
       data: {
         ...mockPermission.data,

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
@@ -247,6 +247,58 @@ describe('createErc20TokenStreamCaveats()', () => {
     ).toThrow();
   });
 
+  it('rejects when maxAmount equals initialAmount', () => {
+    expect(() =>
+      createErc20TokenStreamCaveats({
+        permission: {
+          ...mockPermission,
+          data: {
+            ...mockPermission.data,
+            initialAmount: '0x64',
+            maxAmount: '0x64',
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-stream permission: maxAmount must be greater than initialAmount.',
+    );
+  });
+
+  it('rejects when amountPerSecond is zero', () => {
+    expect(() =>
+      createErc20TokenStreamCaveats({
+        permission: {
+          ...mockPermission,
+          data: {
+            ...mockPermission.data,
+            amountPerSecond: '0x0',
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-stream permission: amountPerSecond must be a positive number.',
+    );
+  });
+
+  it('rejects when startTime is zero', () => {
+    expect(() =>
+      createErc20TokenStreamCaveats({
+        permission: {
+          ...mockPermission,
+          data: {
+            ...mockPermission.data,
+            startTime: 0,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid erc20-token-stream permission: startTime must be a positive number.',
+    );
+  });
+
   it('keeps valueLte caveat fixed at zero across varied inputs', () => {
     const variedPermission: Populated<Erc20TokenStreamPermission> = {
       ...mockPermission,
@@ -271,7 +323,8 @@ describe('createErc20TokenStreamCaveats()', () => {
   });
 
   it('encodes provided token address in stream terms', () => {
-    const alternateTokenAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const alternateTokenAddress =
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Hex;
     const permission = {
       ...mockPermission,
       data: {
@@ -284,10 +337,11 @@ describe('createErc20TokenStreamCaveats()', () => {
       permission,
       contracts,
     });
+    const erc20StreamingTerms = caveats[0]?.terms as Hex;
 
     expect(caveats[0]?.enforcer).toBe(contracts.erc20StreamingEnforcer);
     expect(
-      caveats[0]?.terms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
+      erc20StreamingTerms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
     ).toBe(true);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
@@ -6,15 +6,23 @@ import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { makePermissionDecoderConfigs } from '../../../src/permissions';
-import { makeNativeTokenAllowanceDecoderConfig } from '../../../src/permissions/caveats/nativeTokenAllowance';
+import {
+  createNativeTokenAllowanceCaveats,
+  makeNativeTokenAllowanceDecoderConfig,
+  type NativeTokenAllowanceEnforcers,
+} from '../../../src/permissions/caveats/nativeTokenAllowance';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type { ChecksumCaveat } from '../../../src/permissions/types';
+import type {
+  ChecksumCaveat,
+  DeepRequired,
+} from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   UINT256_MAX,
 } from '../../../src/permissions/utils';
+import type { NativeTokenAllowancePermission } from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('native-token-allowance decoder config', () => {
@@ -158,5 +166,46 @@ describe('native-token-allowance decoder config', () => {
         'Invalid native-token-allowance terms: allowanceAmount must be a positive number',
       );
     });
+  });
+});
+
+describe('createNativeTokenAllowanceCaveats()', () => {
+  const allowanceAmount = '0x64' as const;
+  const startTime = 1729900800;
+
+  const contracts: NativeTokenAllowanceEnforcers = {
+    nativeTokenPeriodicEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
+  };
+
+  const permission: DeepRequired<NativeTokenAllowancePermission> = {
+    type: 'native-token-allowance',
+    data: {
+      allowanceAmount,
+      startTime,
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  };
+
+  it('creates nativeTokenPeriodic and exactCalldata caveats', async () => {
+    const caveats = await createNativeTokenAllowanceCaveats({
+      permission,
+      contracts,
+    });
+    const expectedTerms = `0x${toWord(BigInt(allowanceAmount))}${UINT256_MAX.slice(2)}${toWord(startTime)}`;
+
+    expect(caveats).toStrictEqual([
+      {
+        enforcer: contracts.nativeTokenPeriodicEnforcer,
+        terms: expectedTerms,
+        args: '0x',
+      },
+      {
+        enforcer: contracts.exactCalldataEnforcer,
+        terms: '0x',
+        args: '0x',
+      },
+    ]);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
@@ -208,4 +208,41 @@ describe('createNativeTokenAllowanceCaveats()', () => {
       },
     ]);
   });
+
+  it('rejects malformed numeric hex input', async () => {
+    const invalidPermission = {
+      ...permission,
+      data: {
+        ...permission.data,
+        allowanceAmount: 'not-hex' as Hex,
+      },
+    };
+
+    await expect(
+      createNativeTokenAllowanceCaveats({
+        permission: invalidPermission,
+        contracts,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('keeps exactCalldata caveat fixed across varied inputs', async () => {
+    const variedPermission: DeepRequired<NativeTokenAllowancePermission> = {
+      ...permission,
+      data: {
+        ...permission.data,
+        allowanceAmount:
+          '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        startTime: 1,
+      },
+    };
+
+    const caveats = await createNativeTokenAllowanceCaveats({
+      permission: variedPermission,
+      contracts,
+    });
+
+    expect(caveats[1]?.enforcer).toBe(contracts.exactCalldataEnforcer);
+    expect(caveats[1]?.terms).toBe('0x');
+  });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
@@ -188,8 +188,8 @@ describe('createNativeTokenAllowanceCaveats()', () => {
     isAdjustmentAllowed: true,
   };
 
-  it('creates nativeTokenPeriodic and exactCalldata caveats', async () => {
-    const caveats = await createNativeTokenAllowanceCaveats({
+  it('creates nativeTokenPeriodic and exactCalldata caveats', () => {
+    const caveats = createNativeTokenAllowanceCaveats({
       permission,
       contracts,
     });
@@ -209,7 +209,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
     ]);
   });
 
-  it('rejects malformed numeric hex input', async () => {
+  it('rejects malformed numeric hex input', () => {
     const invalidPermission = {
       ...permission,
       data: {
@@ -218,15 +218,15 @@ describe('createNativeTokenAllowanceCaveats()', () => {
       },
     };
 
-    await expect(
+    expect(() =>
       createNativeTokenAllowanceCaveats({
         permission: invalidPermission,
         contracts,
       }),
-    ).rejects.toThrow();
+    ).toThrow();
   });
 
-  it('keeps exactCalldata caveat fixed across varied inputs', async () => {
+  it('keeps exactCalldata caveat fixed across varied inputs', () => {
     const variedPermission: DeepRequired<NativeTokenAllowancePermission> = {
       ...permission,
       data: {
@@ -237,7 +237,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
       },
     };
 
-    const caveats = await createNativeTokenAllowanceCaveats({
+    const caveats = createNativeTokenAllowanceCaveats({
       permission: variedPermission,
       contracts,
     });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
@@ -226,6 +226,40 @@ describe('createNativeTokenAllowanceCaveats()', () => {
     ).toThrow();
   });
 
+  it('rejects zero allowanceAmount', () => {
+    expect(() =>
+      createNativeTokenAllowanceCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            allowanceAmount: '0x0',
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-allowance permission: allowanceAmount must be a positive number.',
+    );
+  });
+
+  it('rejects when startTime is zero', () => {
+    expect(() =>
+      createNativeTokenAllowanceCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            startTime: 0,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-allowance permission: startTime must be a positive number.',
+    );
+  });
+
   it('keeps exactCalldata caveat fixed across varied inputs', () => {
     const variedPermission: Populated<NativeTokenAllowancePermission> = {
       ...permission,

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
@@ -14,15 +14,15 @@ import {
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type {
-  ChecksumCaveat,
-  DeepRequired,
-} from '../../../src/permissions/types';
+import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   UINT256_MAX,
 } from '../../../src/permissions/utils';
-import type { NativeTokenAllowancePermission } from '../../../src/types';
+import type {
+  NativeTokenAllowancePermission,
+  Populated,
+} from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('native-token-allowance decoder config', () => {
@@ -178,7 +178,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
     exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
-  const permission: DeepRequired<NativeTokenAllowancePermission> = {
+  const permission: Populated<NativeTokenAllowancePermission> = {
     type: 'native-token-allowance',
     data: {
       allowanceAmount,
@@ -227,7 +227,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
   });
 
   it('keeps exactCalldata caveat fixed across varied inputs', () => {
-    const variedPermission: DeepRequired<NativeTokenAllowancePermission> = {
+    const variedPermission: Populated<NativeTokenAllowancePermission> = {
       ...permission,
       data: {
         ...permission.data,

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
@@ -6,15 +6,23 @@ import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { makePermissionDecoderConfigs } from '../../../src/permissions';
-import { makeNativeTokenPeriodicDecoderConfig } from '../../../src/permissions/caveats/nativeTokenPeriodic';
+import {
+  createNativeTokenPeriodicCaveats,
+  makeNativeTokenPeriodicDecoderConfig,
+  type NativeTokenPeriodicEnforcers,
+} from '../../../src/permissions/caveats/nativeTokenPeriodic';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type { ChecksumCaveat } from '../../../src/permissions/types';
+import type {
+  ChecksumCaveat,
+  DeepRequired,
+} from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   MAX_PERIOD_DURATION,
 } from '../../../src/permissions/utils';
+import type { NativeTokenPeriodicPermission } from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('native-token-periodic decoder config', () => {
@@ -178,5 +186,49 @@ describe('native-token-periodic decoder config', () => {
         startTime: START_TIME,
       });
     });
+  });
+});
+
+describe('createNativeTokenPeriodicCaveats()', () => {
+  const periodAmount = '0x64' as const;
+  const periodDuration = 86400;
+  const startTime = 1729900800;
+
+  const contracts: NativeTokenPeriodicEnforcers = {
+    nativeTokenPeriodicEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
+  };
+
+  const permission: DeepRequired<NativeTokenPeriodicPermission> = {
+    type: 'native-token-periodic',
+    data: {
+      periodAmount,
+      periodDuration,
+      startTime,
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  };
+
+  it('creates nativeTokenPeriodic and exactCalldata caveats', async () => {
+    const caveats = await createNativeTokenPeriodicCaveats({
+      permission,
+      contracts,
+    });
+
+    const nativeTokenPeriodicExpectedTerms = `0x${toWord(BigInt(periodAmount))}${toWord(periodDuration)}${toWord(startTime)}`;
+
+    expect(caveats).toStrictEqual([
+      {
+        enforcer: contracts.nativeTokenPeriodicEnforcer,
+        terms: nativeTokenPeriodicExpectedTerms,
+        args: '0x',
+      },
+      {
+        enforcer: contracts.exactCalldataEnforcer,
+        terms: '0x',
+        args: '0x',
+      },
+    ]);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
@@ -210,8 +210,8 @@ describe('createNativeTokenPeriodicCaveats()', () => {
     isAdjustmentAllowed: true,
   };
 
-  it('creates nativeTokenPeriodic and exactCalldata caveats', async () => {
-    const caveats = await createNativeTokenPeriodicCaveats({
+  it('creates nativeTokenPeriodic and exactCalldata caveats', () => {
+    const caveats = createNativeTokenPeriodicCaveats({
       permission,
       contracts,
     });
@@ -232,7 +232,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
     ]);
   });
 
-  it('rejects malformed numeric hex input', async () => {
+  it('rejects malformed numeric hex input', () => {
     const invalidPermission = {
       ...permission,
       data: {
@@ -241,15 +241,15 @@ describe('createNativeTokenPeriodicCaveats()', () => {
       },
     };
 
-    await expect(
+    expect(() =>
       createNativeTokenPeriodicCaveats({
         permission: invalidPermission,
         contracts,
       }),
-    ).rejects.toThrow();
+    ).toThrow();
   });
 
-  it('keeps exactCalldata caveat fixed across varied inputs', async () => {
+  it('keeps exactCalldata caveat fixed across varied inputs', () => {
     const variedPermission: DeepRequired<NativeTokenPeriodicPermission> = {
       ...permission,
       data: {
@@ -261,7 +261,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
       },
     };
 
-    const caveats = await createNativeTokenPeriodicCaveats({
+    const caveats = createNativeTokenPeriodicCaveats({
       permission: variedPermission,
       contracts,
     });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
@@ -231,4 +231,42 @@ describe('createNativeTokenPeriodicCaveats()', () => {
       },
     ]);
   });
+
+  it('rejects malformed numeric hex input', async () => {
+    const invalidPermission = {
+      ...permission,
+      data: {
+        ...permission.data,
+        periodAmount: 'not-hex' as Hex,
+      },
+    };
+
+    await expect(
+      createNativeTokenPeriodicCaveats({
+        permission: invalidPermission,
+        contracts,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('keeps exactCalldata caveat fixed across varied inputs', async () => {
+    const variedPermission: DeepRequired<NativeTokenPeriodicPermission> = {
+      ...permission,
+      data: {
+        ...permission.data,
+        periodAmount:
+          '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        periodDuration: 1,
+        startTime: 1,
+      },
+    };
+
+    const caveats = await createNativeTokenPeriodicCaveats({
+      permission: variedPermission,
+      contracts,
+    });
+
+    expect(caveats[1]?.enforcer).toBe(contracts.exactCalldataEnforcer);
+    expect(caveats[1]?.terms).toBe('0x');
+  });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
@@ -14,15 +14,15 @@ import {
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type {
-  ChecksumCaveat,
-  DeepRequired,
-} from '../../../src/permissions/types';
+import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
   getChecksumEnforcersByChainId,
   MAX_PERIOD_DURATION,
 } from '../../../src/permissions/utils';
-import type { NativeTokenPeriodicPermission } from '../../../src/types';
+import type {
+  NativeTokenPeriodicPermission,
+  Populated,
+} from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('native-token-periodic decoder config', () => {
@@ -199,7 +199,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
     exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
-  const permission: DeepRequired<NativeTokenPeriodicPermission> = {
+  const permission: Populated<NativeTokenPeriodicPermission> = {
     type: 'native-token-periodic',
     data: {
       periodAmount,
@@ -250,7 +250,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
   });
 
   it('keeps exactCalldata caveat fixed across varied inputs', () => {
-    const variedPermission: DeepRequired<NativeTokenPeriodicPermission> = {
+    const variedPermission: Populated<NativeTokenPeriodicPermission> = {
       ...permission,
       data: {
         ...permission.data,

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
@@ -249,6 +249,74 @@ describe('createNativeTokenPeriodicCaveats()', () => {
     ).toThrow();
   });
 
+  it('rejects when periodAmount is zero', () => {
+    expect(() =>
+      createNativeTokenPeriodicCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            periodAmount: '0x0',
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-periodic permission: periodAmount must be a positive number.',
+    );
+  });
+
+  it('rejects when periodDuration is zero', () => {
+    expect(() =>
+      createNativeTokenPeriodicCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            periodDuration: 0,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-periodic permission: periodDuration must be a positive number.',
+    );
+  });
+
+  it('rejects when periodDuration exceeds MAX_PERIOD_DURATION', () => {
+    expect(() =>
+      createNativeTokenPeriodicCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            periodDuration: MAX_PERIOD_DURATION + 1,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-periodic permission: periodDuration must be less than or equal to MAX_PERIOD_DURATION.',
+    );
+  });
+
+  it('rejects when startTime is zero', () => {
+    expect(() =>
+      createNativeTokenPeriodicCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            startTime: 0,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-periodic permission: startTime must be a positive number.',
+    );
+  });
+
   it('keeps exactCalldata caveat fixed across varied inputs', () => {
     const variedPermission: Populated<NativeTokenPeriodicPermission> = {
       ...permission,

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
@@ -188,8 +188,8 @@ describe('createNativeTokenStreamCaveats()', () => {
     isAdjustmentAllowed: true,
   };
 
-  it('creates nativeTokenStreaming and exactCalldata caveats', async () => {
-    const caveats = await createNativeTokenStreamCaveats({
+  it('creates nativeTokenStreaming and exactCalldata caveats', () => {
+    const caveats = createNativeTokenStreamCaveats({
       permission,
       contracts,
     });
@@ -214,7 +214,7 @@ describe('createNativeTokenStreamCaveats()', () => {
     ]);
   });
 
-  it('rejects malformed numeric hex input', async () => {
+  it('rejects malformed numeric hex input', () => {
     const invalidPermission = {
       ...permission,
       data: {
@@ -223,15 +223,15 @@ describe('createNativeTokenStreamCaveats()', () => {
       },
     };
 
-    await expect(
+    expect(() =>
       createNativeTokenStreamCaveats({
         permission: invalidPermission,
         contracts,
       }),
-    ).rejects.toThrow();
+    ).toThrow();
   });
 
-  it('keeps exactCalldata caveat fixed across varied inputs', async () => {
+  it('keeps exactCalldata caveat fixed across varied inputs', () => {
     const variedPermission: DeepRequired<NativeTokenStreamPermission> = {
       ...permission,
       data: {
@@ -244,7 +244,7 @@ describe('createNativeTokenStreamCaveats()', () => {
       },
     };
 
-    const caveats = await createNativeTokenStreamCaveats({
+    const caveats = createNativeTokenStreamCaveats({
       permission: variedPermission,
       contracts,
     });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
@@ -213,4 +213,43 @@ describe('createNativeTokenStreamCaveats()', () => {
       },
     ]);
   });
+
+  it('rejects malformed numeric hex input', async () => {
+    const invalidPermission = {
+      ...permission,
+      data: {
+        ...permission.data,
+        initialAmount: 'not-hex' as Hex,
+      },
+    };
+
+    await expect(
+      createNativeTokenStreamCaveats({
+        permission: invalidPermission,
+        contracts,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('keeps exactCalldata caveat fixed across varied inputs', async () => {
+    const variedPermission: DeepRequired<NativeTokenStreamPermission> = {
+      ...permission,
+      data: {
+        ...permission.data,
+        initialAmount: '0x1',
+        maxAmount:
+          '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        amountPerSecond: '0x2',
+        startTime: 1,
+      },
+    };
+
+    const caveats = await createNativeTokenStreamCaveats({
+      permission: variedPermission,
+      contracts,
+    });
+
+    expect(caveats[1]?.enforcer).toBe(contracts.exactCalldataEnforcer);
+    expect(caveats[1]?.terms).toBe('0x');
+  });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
@@ -6,12 +6,20 @@ import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { makePermissionDecoderConfigs } from '../../../src/permissions';
-import { makeNativeTokenStreamDecoderConfig } from '../../../src/permissions/caveats/nativeTokenStream';
+import {
+  createNativeTokenStreamCaveats,
+  makeNativeTokenStreamDecoderConfig,
+  type NativeTokenStreamEnforcers,
+} from '../../../src/permissions/caveats/nativeTokenStream';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type { ChecksumCaveat } from '../../../src/permissions/types';
+import type {
+  ChecksumCaveat,
+  DeepRequired,
+} from '../../../src/permissions/types';
 import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
+import type { NativeTokenStreamPermission } from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('native-token-stream decoder config', () => {
@@ -154,5 +162,55 @@ describe('native-token-stream decoder config', () => {
         'Invalid native-token-stream terms: startTime must be a positive number',
       );
     });
+  });
+});
+
+describe('createNativeTokenStreamCaveats()', () => {
+  const initialAmount = '0x0de0b6b3a7640000' as const;
+  const maxAmount = '0x8ac7230489e80000' as const;
+  const amountPerSecond = '0x06f05b59d3b20000' as const;
+  const startTime = 1729900800;
+
+  const contracts: NativeTokenStreamEnforcers = {
+    nativeTokenStreamingEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
+  };
+
+  const permission: DeepRequired<NativeTokenStreamPermission> = {
+    type: 'native-token-stream',
+    data: {
+      initialAmount,
+      maxAmount,
+      amountPerSecond,
+      startTime,
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  };
+
+  it('creates nativeTokenStreaming and exactCalldata caveats', async () => {
+    const caveats = await createNativeTokenStreamCaveats({
+      permission,
+      contracts,
+    });
+
+    const initialAmountHex = initialAmount.slice(2).padStart(64, '0');
+    const maxAmountHex = maxAmount.slice(2).padStart(64, '0');
+    const amountPerSecondHex = amountPerSecond.slice(2).padStart(64, '0');
+    const startTimeHex = toWord(startTime);
+    const nativeTokenStreamingExpectedTerms = `0x${initialAmountHex}${maxAmountHex}${amountPerSecondHex}${startTimeHex}`;
+
+    expect(caveats).toStrictEqual([
+      {
+        enforcer: contracts.nativeTokenStreamingEnforcer,
+        terms: nativeTokenStreamingExpectedTerms,
+        args: '0x',
+      },
+      {
+        enforcer: contracts.exactCalldataEnforcer,
+        terms: '0x',
+        args: '0x',
+      },
+    ]);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
@@ -231,6 +231,58 @@ describe('createNativeTokenStreamCaveats()', () => {
     ).toThrow();
   });
 
+  it('rejects when maxAmount equals initialAmount', () => {
+    expect(() =>
+      createNativeTokenStreamCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            initialAmount: '0x64',
+            maxAmount: '0x64',
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-stream permission: maxAmount must be greater than initialAmount.',
+    );
+  });
+
+  it('rejects when amountPerSecond is zero', () => {
+    expect(() =>
+      createNativeTokenStreamCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            amountPerSecond: '0x0',
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-stream permission: amountPerSecond must be a positive number.',
+    );
+  });
+
+  it('rejects when startTime is zero', () => {
+    expect(() =>
+      createNativeTokenStreamCaveats({
+        permission: {
+          ...permission,
+          data: {
+            ...permission.data,
+            startTime: 0,
+          },
+        },
+        contracts,
+      }),
+    ).toThrow(
+      'Invalid native-token-stream permission: startTime must be a positive number.',
+    );
+  });
+
   it('keeps exactCalldata caveat fixed across varied inputs', () => {
     const variedPermission: Populated<NativeTokenStreamPermission> = {
       ...permission,

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
@@ -14,12 +14,12 @@ import {
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
-import type {
-  ChecksumCaveat,
-  DeepRequired,
-} from '../../../src/permissions/types';
+import type { ChecksumCaveat } from '../../../src/permissions/types';
 import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
-import type { NativeTokenStreamPermission } from '../../../src/types';
+import type {
+  NativeTokenStreamPermission,
+  Populated,
+} from '../../../src/types';
 import { toWord } from '../../test-utils';
 
 describe('native-token-stream decoder config', () => {
@@ -176,7 +176,7 @@ describe('createNativeTokenStreamCaveats()', () => {
     exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
-  const permission: DeepRequired<NativeTokenStreamPermission> = {
+  const permission: Populated<NativeTokenStreamPermission> = {
     type: 'native-token-stream',
     data: {
       initialAmount,
@@ -232,7 +232,7 @@ describe('createNativeTokenStreamCaveats()', () => {
   });
 
   it('keeps exactCalldata caveat fixed across varied inputs', () => {
-    const variedPermission: DeepRequired<NativeTokenStreamPermission> = {
+    const variedPermission: Populated<NativeTokenStreamPermission> = {
       ...permission,
       data: {
         ...permission.data,

--- a/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
@@ -165,4 +165,57 @@ describe('createTokenApprovalRevocationCaveats()', () => {
       },
     ]);
   });
+
+  it('creates single-flag approvalRevocation caveat', async () => {
+    const singleFlagPermission: DeepRequired<TokenApprovalRevocationPermission> =
+      {
+        ...permission,
+        data: {
+          ...permission.data,
+          erc20Approve: true,
+          erc721Approve: false,
+          erc721SetApprovalForAll: false,
+          permit2Approve: false,
+          permit2Lockdown: false,
+          permit2InvalidateNonces: false,
+        },
+      };
+
+    const caveats = await createTokenApprovalRevocationCaveats({
+      permission: singleFlagPermission,
+      contracts,
+    });
+
+    expect(caveats).toStrictEqual([
+      {
+        enforcer: contracts.approvalRevocationEnforcer,
+        terms: '0x01',
+        args: '0x',
+      },
+    ]);
+  });
+
+  it('rejects empty-mask approvalRevocation when all flags are false', async () => {
+    const noFlagPermission: DeepRequired<TokenApprovalRevocationPermission> = {
+      ...permission,
+      data: {
+        ...permission.data,
+        erc20Approve: false,
+        erc721Approve: false,
+        erc721SetApprovalForAll: false,
+        permit2Approve: false,
+        permit2Lockdown: false,
+        permit2InvalidateNonces: false,
+      },
+    };
+
+    await expect(
+      createTokenApprovalRevocationCaveats({
+        permission: noFlagPermission,
+        contracts,
+      }),
+    ).rejects.toThrow(
+      'Invalid ApprovalRevocation terms: at least one revocation primitive must be enabled',
+    );
+  });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
@@ -151,8 +151,8 @@ describe('createTokenApprovalRevocationCaveats()', () => {
     isAdjustmentAllowed: true,
   };
 
-  it('creates approvalRevocation caveat', async () => {
-    const caveats = await createTokenApprovalRevocationCaveats({
+  it('creates approvalRevocation caveat', () => {
+    const caveats = createTokenApprovalRevocationCaveats({
       permission,
       contracts,
     });
@@ -166,7 +166,7 @@ describe('createTokenApprovalRevocationCaveats()', () => {
     ]);
   });
 
-  it('creates single-flag approvalRevocation caveat', async () => {
+  it('creates single-flag approvalRevocation caveat', () => {
     const singleFlagPermission: DeepRequired<TokenApprovalRevocationPermission> =
       {
         ...permission,
@@ -181,7 +181,7 @@ describe('createTokenApprovalRevocationCaveats()', () => {
         },
       };
 
-    const caveats = await createTokenApprovalRevocationCaveats({
+    const caveats = createTokenApprovalRevocationCaveats({
       permission: singleFlagPermission,
       contracts,
     });
@@ -195,7 +195,7 @@ describe('createTokenApprovalRevocationCaveats()', () => {
     ]);
   });
 
-  it('rejects empty-mask approvalRevocation when all flags are false', async () => {
+  it('rejects empty-mask approvalRevocation when all flags are false', () => {
     const noFlagPermission: DeepRequired<TokenApprovalRevocationPermission> = {
       ...permission,
       data: {
@@ -209,12 +209,12 @@ describe('createTokenApprovalRevocationCaveats()', () => {
       },
     };
 
-    await expect(
+    expect(() =>
       createTokenApprovalRevocationCaveats({
         permission: noFlagPermission,
         contracts,
       }),
-    ).rejects.toThrow(
+    ).toThrow(
       'Invalid ApprovalRevocation terms: at least one revocation primitive must be enabled',
     );
   });

--- a/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
@@ -6,10 +6,18 @@ import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { makePermissionDecoderConfigs } from '../../../src/permissions';
-import { makeTokenApprovalRevocationDecoderConfig } from '../../../src/permissions/caveats/tokenApprovalRevocation';
+import {
+  createTokenApprovalRevocationCaveats,
+  makeTokenApprovalRevocationDecoderConfig,
+  type TokenApprovalRevocationEnforcers,
+} from '../../../src/permissions/caveats/tokenApprovalRevocation';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
-import type { ChecksumCaveat } from '../../../src/permissions/types';
+import type {
+  ChecksumCaveat,
+  DeepRequired,
+} from '../../../src/permissions/types';
 import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
+import type { TokenApprovalRevocationPermission } from '../../../src/types';
 
 describe('token-approval-revocation decoder config', () => {
   const chainId = CHAIN_ID.sepolia;
@@ -121,5 +129,40 @@ describe('token-approval-revocation decoder config', () => {
         permit2InvalidateNonces: true,
       });
     });
+  });
+});
+
+describe('createTokenApprovalRevocationCaveats()', () => {
+  const contracts: TokenApprovalRevocationEnforcers = {
+    approvalRevocationEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+  };
+
+  const permission: DeepRequired<TokenApprovalRevocationPermission> = {
+    type: 'token-approval-revocation',
+    data: {
+      erc20Approve: true,
+      erc721Approve: true,
+      erc721SetApprovalForAll: true,
+      permit2Approve: true,
+      permit2Lockdown: true,
+      permit2InvalidateNonces: true,
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  };
+
+  it('creates approvalRevocation caveat', async () => {
+    const caveats = await createTokenApprovalRevocationCaveats({
+      permission,
+      contracts,
+    });
+
+    expect(caveats).toStrictEqual([
+      {
+        enforcer: contracts.approvalRevocationEnforcer,
+        terms: '0x3f',
+        args: '0x',
+      },
+    ]);
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
@@ -12,12 +12,12 @@ import {
   type TokenApprovalRevocationEnforcers,
 } from '../../../src/permissions/caveats/tokenApprovalRevocation';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
-import type {
-  ChecksumCaveat,
-  DeepRequired,
-} from '../../../src/permissions/types';
+import type { ChecksumCaveat } from '../../../src/permissions/types';
 import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
-import type { TokenApprovalRevocationPermission } from '../../../src/types';
+import type {
+  TokenApprovalRevocationPermission,
+  Populated,
+} from '../../../src/types';
 
 describe('token-approval-revocation decoder config', () => {
   const chainId = CHAIN_ID.sepolia;
@@ -137,7 +137,7 @@ describe('createTokenApprovalRevocationCaveats()', () => {
     approvalRevocationEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
   };
 
-  const permission: DeepRequired<TokenApprovalRevocationPermission> = {
+  const permission: Populated<TokenApprovalRevocationPermission> = {
     type: 'token-approval-revocation',
     data: {
       erc20Approve: true,
@@ -167,19 +167,18 @@ describe('createTokenApprovalRevocationCaveats()', () => {
   });
 
   it('creates single-flag approvalRevocation caveat', () => {
-    const singleFlagPermission: DeepRequired<TokenApprovalRevocationPermission> =
-      {
-        ...permission,
-        data: {
-          ...permission.data,
-          erc20Approve: true,
-          erc721Approve: false,
-          erc721SetApprovalForAll: false,
-          permit2Approve: false,
-          permit2Lockdown: false,
-          permit2InvalidateNonces: false,
-        },
-      };
+    const singleFlagPermission: Populated<TokenApprovalRevocationPermission> = {
+      ...permission,
+      data: {
+        ...permission.data,
+        erc20Approve: true,
+        erc721Approve: false,
+        erc721SetApprovalForAll: false,
+        permit2Approve: false,
+        permit2Lockdown: false,
+        permit2InvalidateNonces: false,
+      },
+    };
 
     const caveats = createTokenApprovalRevocationCaveats({
       permission: singleFlagPermission,
@@ -196,7 +195,7 @@ describe('createTokenApprovalRevocationCaveats()', () => {
   });
 
   it('rejects empty-mask approvalRevocation when all flags are false', () => {
-    const noFlagPermission: DeepRequired<TokenApprovalRevocationPermission> = {
+    const noFlagPermission: Populated<TokenApprovalRevocationPermission> = {
       ...permission,
       data: {
         ...permission.data,


### PR DESCRIPTION
## 📝 Description

This PR adds utility functions to create caveats array for each permission type to @metamask/7715-permission-types. These were migrated from @metamask/gator-permissions-snap.

## 🔄 What Changed?

Adds new utility functions that accept a populated permission object, and specific caveat addresses, and returns the `Caveat<Hex>[]` representing that permission.
  - `createErc20TokenStreamCaveats()`
  - `createErc20TokenPeriodicCaveats()`
  - `createErc20TokenAllowanceCaveats()`
  - `createNativeTokenStreamCaveats()`
  - `createNativeTokenPeriodicCaveats()`
  - `createNativeTokenAllowanceCaveats()`
  - `createTokenApprovalRevocationCaveats()`

## 🚀 Why?

Presently when adding new permission types to MetaMask Advanced Permissions, changes must be made across a number of different repositories. By centralising the permission definitions into a single repository, it allows us to add a permission definition in one place (@metamask/7715-permission-types), and simply update dependencies across @metamask/gator-permissions-controller, @metamask/gator-permissions-snap, @metamask/smart-accounts-kit, and MetaMask clients.

This change is migrating one of the components needed to achieve that vision.

## 🧪 How to Test?

The changes in this PR are integrated into @metamask/gator-permissions-snap in this draft PR https://github.com/MetaMask/snap-7715-permissions/pull/363. Adding a reference to @metamask/7715-permission-types with the changes from this PR, then validate with the following steps:

- Grant each of the permission types, with varying options selected
- Ensure that the signature confirmation matches the snap confirmation (this is dependent on the caveats encoding implemented in this pr)
- Validate the decoded caveat terms on the snap development page

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect caveat encoding or validation could grant wrong token/native limits or approvals on-chain; changes are additive with broad test coverage but touch security-sensitive permission construction.
> 
> **Overview**
> Adds **encode-path** helpers in `@metamask/7715-permission-types` so consumers can turn a fully specified ERC-7715 permission into the `Caveat[]` used on-chain, mirroring the existing decoder logic. Seven `create*Caveats()` functions cover ERC-20/native stream, periodic, and allowance types plus token-approval-revocation, each paired with a small `*Enforcers` type for the enforcer addresses they need.
> 
> Inputs are typed with a new exported **`Populated<T>`** helper (recursive required fields, no null/undefined). Builders validate amounts, durations, stream bounds, and start times before calling `@metamask/delegation-core` term encoders; ERC-20 paths also attach a zero **`valueLte`** caveat, native paths attach empty **`exactCalldata`**, and revocation builds a single approval-revocation caveat.
> 
> Public exports are wired through `src/index.ts` and `permissions/index.ts`, changelog is updated, and vitest suites exercise happy paths and validation errors. Decoder factories now return **`PermissionDecoderConfig`** directly and the **`MakePermissionDecoderConfig`** alias is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939ce235fd925b7223d1adceca1813fb3c791479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->