### PR TITLE
Revert "Release/34.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [34.0.0]
-
 ## [33.0.0]
 
 ## [32.0.0]
@@ -63,8 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0]
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@34.0.0...HEAD
-[34.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@33.0.0...delegator-sdk-monorepo@34.0.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@33.0.0...HEAD
 [33.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@32.0.0...delegator-sdk-monorepo@33.0.0
 [32.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@31.0.0...delegator-sdk-monorepo@32.0.0
 [31.0.0]: https://github.com/metamask/smart-accounts-kit/compare/delegator-sdk-monorepo@30.0.0...delegator-sdk-monorepo@31.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delegator-sdk-monorepo",
-  "version": "34.0.0",
+  "version": "33.0.0",
   "license": "(MIT-0 OR Apache-2.0)",
   "private": true,
   "repository": {

--- a/packages/7715-permission-types/CHANGELOG.md
+++ b/packages/7715-permission-types/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.0]
-
 ### Added
 
-- Utility functions to create caveats array for each permission type ([#265](https://github.com/metamask/smart-accounts-kit/pull/265))
+- Utility functions to create caveats array for each permission type ([#265](https://github.com/MetaMask/smart-accounts-kit/pull/265))
   - `createErc20TokenStreamCaveats()`
   - `createErc20TokenPeriodicCaveats()`
   - `createErc20TokenAllowanceCaveats()`
@@ -19,24 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `createNativeTokenPeriodicCaveats()`
   - `createNativeTokenAllowanceCaveats()`
   - `createTokenApprovalRevocationCaveats()`
-- Function `makePermissionDecoderConfigs` to resolve the `PermissionDecoderConfig`s to be used with @metamask/gator-permissions-controller ([#259](https://github.com/metamask/smart-accounts-kit/pull/259))
-- Permission schema metadata and MetaMask facilitator address utilities ([#267](https://github.com/metamask/smart-accounts-kit/pull/267))
+- Add `makePermissionDecoderConfigs` to resolve the `PermissionDecoderConfig`s to be used with @metamask/gator-permissions-controller ([#259](https://github.com/MetaMask/smart-accounts-kit/pull/259))
+- Add permission schema metadata and MetaMask facilitator address utilities ([#267](https://github.com/MetaMask/smart-accounts-kit/pull/267))
 
 ## [0.7.1]
 
 ### Fixed
 
-- Rename `permit2ApproveZero` to `permit2Approve` in `TokenApprovalRevocationPermission` ERC-7715 permission data ([#237](https://github.com/metamask/smart-accounts-kit/pull/237))
+- Rename `permit2ApproveZero` to `permit2Approve` in `TokenApprovalRevocationPermission` ERC-7715 permission data ([#237](https://github.com/MetaMask/smart-accounts-kit/pull/237))
 
 ## [0.7.0]
 
 ### Added
 
-- New permission type `token-approval-revocation` ([#226](https://github.com/metamask/smart-accounts-kit/pull/226))
+- New permission type `token-approval-revocation` ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226))
 
 ### Deprecated
 
-- Deprecated `erc20-token-revocation` in favor of `token-approval-revocation` ([#226](https://github.com/metamask/smart-accounts-kit/pull/226))
+- Deprecated `erc20-token-revocation` in favor of `token-approval-revocation` ([#226](https://github.com/MetaMask/smart-accounts-kit/pull/226))
 
 ## [0.6.0]
 
@@ -58,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New permission type `erc20-token-revocation` ([#110](https://github.com/metamask/smart-accounts-kit/pull/110))
+- New permission type `erc20-token-revocation` ([#110](https://github.com/MetaMask/smart-accounts-kit/pull/110))
 
 ## [0.3.0]
 
@@ -72,8 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Type definitions for EIP-7715 Execution Permissions, and definitions for permission types supported by MetaMask
 
-[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.8.0...HEAD
-[0.8.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.7.1...@metamask/7715-permission-types@0.8.0
+[Unreleased]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.7.1...HEAD
 [0.7.1]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.7.0...@metamask/7715-permission-types@0.7.1
 [0.7.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.6.0...@metamask/7715-permission-types@0.7.0
 [0.6.0]: https://github.com/metamask/smart-accounts-kit/compare/@metamask/7715-permission-types@0.5.0...@metamask/7715-permission-types@0.6.0

--- a/packages/7715-permission-types/package.json
+++ b/packages/7715-permission-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/7715-permission-types",
-  "version": "0.8.0",
+  "version": "0.7.1",
   "description": "Permission types for the ERC-7715",
   "license": "(MIT-0 OR Apache-2.0)",
   "type": "module",

--- a/packages/smart-accounts-kit/CHANGELOG.md
+++ b/packages/smart-accounts-kit/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Experimental `createx402DelegationProvider` now resolves redeemers as the intersection of `facilitatorAddresses` and `redeemer.addresses` ([#256](https://github.com/MetaMask/smart-accounts-kit/pull/256))
-- Bump @metamask/7715-permission-types from `^0.7.1` to `^0.8.0` ([#269](https://github.com/MetaMask/smart-accounts-kit/pull/269))
 
 ## [1.6.0]
 

--- a/packages/smart-accounts-kit/package.json
+++ b/packages/smart-accounts-kit/package.json
@@ -124,7 +124,7 @@
     }
   },
   "dependencies": {
-    "@metamask/7715-permission-types": "^0.8.0",
+    "@metamask/7715-permission-types": "^0.7.1",
     "@metamask/delegation-abis": "^1.1.0",
     "@metamask/delegation-core": "^2.2.1",
     "@metamask/delegation-deployments": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,7 +754,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/7715-permission-types@npm:^0.8.0, @metamask/7715-permission-types@workspace:packages/7715-permission-types":
+"@metamask/7715-permission-types@npm:^0.7.1, @metamask/7715-permission-types@workspace:packages/7715-permission-types":
   version: 0.0.0-use.local
   resolution: "@metamask/7715-permission-types@workspace:packages/7715-permission-types"
   dependencies:
@@ -961,7 +961,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.4.0"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.1"
-    "@metamask/7715-permission-types": "npm:^0.8.0"
+    "@metamask/7715-permission-types": "npm:^0.7.1"
     "@metamask/auto-changelog": "npm:^6.1.1"
     "@metamask/delegation-abis": "npm:^1.1.0"
     "@metamask/delegation-core": "npm:^2.2.1"


### PR DESCRIPTION
Reverts MetaMask/smart-accounts-kit#269

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reverting a release affects consumers who may have already taken 34.0.0 / 0.8.0; dependency resolution changes but runtime code in this PR is unchanged.
> 
> **Overview**
> Reverts **Release/34.0.0** (PR #269), rolling published version metadata back to the pre-release state.
> 
> **Monorepo** `delegator-sdk-monorepo` goes from **34.0.0** to **33.0.0**; root `CHANGELOG.md` drops the `[34.0.0]` section and fixes compare links so `[Unreleased]` is `33.0.0...HEAD`.
> 
> **@metamask/7715-permission-types** is reset from **0.8.0** to **0.7.1**. Its changelog no longer has a dedicated `[0.8.0]` release block; the caveat helpers, `makePermissionDecoderConfigs`, and facilitator utilities are listed under `[Unreleased]` again (with some PR link casing normalized to `MetaMask`).
> 
> **@metamask/smart-accounts-kit** dependency on `@metamask/7715-permission-types` is pinned back to **`^0.7.1`** (from `^0.8.0`), and the `[Unreleased]` note about that bump is removed. **`yarn.lock`** is updated to match.
> 
> No application source changes appear in the diff—only versions, changelogs, and the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d454803d83588424014021d62290c6f88b4560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->