### PR TITLE
Fix incorrect name of caveats used in caveat factory functions

### DIFF
--- a/packages/7715-permission-types/CHANGELOG.md
+++ b/packages/7715-permission-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Incorrectly named caveats used in caveat factory functions ([#274](https://github.com/MetaMask/smart-accounts-kit/pull/274))
+  - erc20PeriodicEnforcer is now erc20PeriodTransferEnforcer
+  - nativeTokenPeriodicEnforcer is now nativeTokenPeriodTransferEnforcer
+
 ## [0.8.0]
 
 ### Added

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
@@ -34,7 +34,7 @@ export function makeErc20TokenAllowanceDecoderConfig(
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
-    erc20PeriodicEnforcer,
+    erc20PeriodTransferEnforcer,
     valueLteEnforcer,
     nonceEnforcer,
     allowedCalldataEnforcer,
@@ -50,7 +50,7 @@ export function makeErc20TokenAllowanceDecoderConfig(
       allowedCalldataEnforcer, // payee rule
     ],
     requiredEnforcers: {
-      [erc20PeriodicEnforcer]: 1,
+      [erc20PeriodTransferEnforcer]: 1,
       [valueLteEnforcer]: 1,
       [nonceEnforcer]: 1,
     },
@@ -70,7 +70,7 @@ function validateAndDecodeData(
   caveats: ChecksumCaveat[],
   contractAddresses: ChecksumEnforcersByChainId,
 ): DecodedPermissionData<Erc20TokenAllowancePermission> {
-  const { erc20PeriodicEnforcer, valueLteEnforcer } = contractAddresses;
+  const { erc20PeriodTransferEnforcer, valueLteEnforcer } = contractAddresses;
 
   const valueLteTerms = getTermsByEnforcer({
     caveats,
@@ -82,7 +82,7 @@ function validateAndDecodeData(
 
   const terms = getTermsByEnforcer({
     caveats,
-    enforcer: erc20PeriodicEnforcer,
+    enforcer: erc20PeriodTransferEnforcer,
   });
 
   const EXPECTED_TERMS_BYTELENGTH = 116; // 20 + 32 + 32 + 32
@@ -122,7 +122,7 @@ function validateAndDecodeData(
  */
 export type Erc20TokenAllowanceEnforcers = Pick<
   ChecksumEnforcersByChainId,
-  'erc20PeriodicEnforcer' | 'valueLteEnforcer'
+  'erc20PeriodTransferEnforcer' | 'valueLteEnforcer'
 >;
 
 /**
@@ -156,7 +156,7 @@ export function createErc20TokenAllowanceCaveats({
   }
 
   const erc20PeriodCaveat: Caveat = {
-    enforcer: contracts.erc20PeriodicEnforcer,
+    enforcer: contracts.erc20PeriodTransferEnforcer,
     terms: createERC20TokenPeriodTransferTerms({
       tokenAddress,
       periodAmount: allowanceAmountBigInt,

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
@@ -33,7 +33,7 @@ export function makeErc20TokenPeriodicDecoderConfig(
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
-    erc20PeriodicEnforcer,
+    erc20PeriodTransferEnforcer,
     valueLteEnforcer,
     nonceEnforcer,
     allowedCalldataEnforcer,
@@ -49,7 +49,7 @@ export function makeErc20TokenPeriodicDecoderConfig(
       allowedCalldataEnforcer, // payee rule
     ],
     requiredEnforcers: {
-      [erc20PeriodicEnforcer]: 1,
+      [erc20PeriodTransferEnforcer]: 1,
       [valueLteEnforcer]: 1,
       [nonceEnforcer]: 1,
     },
@@ -69,7 +69,7 @@ function validateAndDecodeData(
   caveats: ChecksumCaveat[],
   contractAddresses: ChecksumEnforcersByChainId,
 ): DecodedPermissionData<Erc20TokenPeriodicPermission> {
-  const { erc20PeriodicEnforcer, valueLteEnforcer } = contractAddresses;
+  const { erc20PeriodTransferEnforcer, valueLteEnforcer } = contractAddresses;
 
   const valueLteTerms = getTermsByEnforcer({
     caveats,
@@ -81,7 +81,7 @@ function validateAndDecodeData(
 
   const terms = getTermsByEnforcer({
     caveats,
-    enforcer: erc20PeriodicEnforcer,
+    enforcer: erc20PeriodTransferEnforcer,
   });
 
   const {
@@ -128,7 +128,7 @@ function validateAndDecodeData(
  */
 export type Erc20TokenPeriodicEnforcers = Pick<
   ChecksumEnforcersByChainId,
-  'erc20PeriodicEnforcer' | 'valueLteEnforcer'
+  'erc20PeriodTransferEnforcer' | 'valueLteEnforcer'
 >;
 
 /**
@@ -175,7 +175,7 @@ export function createErc20TokenPeriodicCaveats({
   }
 
   const erc20PeriodCaveat: Caveat = {
-    enforcer: contracts.erc20PeriodicEnforcer,
+    enforcer: contracts.erc20PeriodTransferEnforcer,
     terms: createERC20TokenPeriodTransferTerms({
       tokenAddress,
       periodAmount: periodAmountBigInt,

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
@@ -34,7 +34,7 @@ export function makeNativeTokenAllowanceDecoderConfig(
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
-    nativeTokenPeriodicEnforcer,
+    nativeTokenPeriodTransferEnforcer,
     exactCalldataEnforcer,
     nonceEnforcer,
     allowedTargetsEnforcer,
@@ -50,7 +50,7 @@ export function makeNativeTokenAllowanceDecoderConfig(
       allowedTargetsEnforcer, // payee rule
     ],
     requiredEnforcers: {
-      [nativeTokenPeriodicEnforcer]: 1,
+      [nativeTokenPeriodTransferEnforcer]: 1,
       [exactCalldataEnforcer]: 1,
       [nonceEnforcer]: 1,
     },
@@ -70,7 +70,7 @@ function validateAndDecodeData(
   caveats: ChecksumCaveat[],
   contractAddresses: ChecksumEnforcersByChainId,
 ): DecodedPermissionData<NativeTokenAllowancePermission> {
-  const { nativeTokenPeriodicEnforcer, exactCalldataEnforcer } =
+  const { nativeTokenPeriodTransferEnforcer, exactCalldataEnforcer } =
     contractAddresses;
 
   const exactCalldataTerms = getTermsByEnforcer({
@@ -84,7 +84,7 @@ function validateAndDecodeData(
 
   const terms = getTermsByEnforcer({
     caveats,
-    enforcer: nativeTokenPeriodicEnforcer,
+    enforcer: nativeTokenPeriodTransferEnforcer,
   });
 
   const EXPECTED_TERMS_BYTELENGTH = 96; // 32 + 32 + 32
@@ -126,7 +126,7 @@ function validateAndDecodeData(
  */
 export type NativeTokenAllowanceEnforcers = Pick<
   ChecksumEnforcersByChainId,
-  'nativeTokenPeriodicEnforcer' | 'exactCalldataEnforcer'
+  'nativeTokenPeriodTransferEnforcer' | 'exactCalldataEnforcer'
 >;
 
 /**
@@ -160,7 +160,7 @@ export function createNativeTokenAllowanceCaveats({
   }
 
   const nativeTokenPeriodTransferCaveat: Caveat = {
-    enforcer: contracts.nativeTokenPeriodicEnforcer,
+    enforcer: contracts.nativeTokenPeriodTransferEnforcer,
     terms: createNativeTokenPeriodTransferTerms({
       periodAmount: allowanceAmountBigInt,
       // delegation-core accepts bigint for encoding although the type is `number`.

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
@@ -29,7 +29,7 @@ export function makeNativeTokenPeriodicDecoderConfig(
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
-    nativeTokenPeriodicEnforcer,
+    nativeTokenPeriodTransferEnforcer,
     exactCalldataEnforcer,
     nonceEnforcer,
     allowedTargetsEnforcer,
@@ -45,7 +45,7 @@ export function makeNativeTokenPeriodicDecoderConfig(
       allowedTargetsEnforcer, // payee rule
     ],
     requiredEnforcers: {
-      [nativeTokenPeriodicEnforcer]: 1,
+      [nativeTokenPeriodTransferEnforcer]: 1,
       [exactCalldataEnforcer]: 1,
       [nonceEnforcer]: 1,
     },
@@ -65,7 +65,7 @@ function validateAndDecodeData(
   caveats: ChecksumCaveat[],
   contractAddresses: ChecksumEnforcersByChainId,
 ): DecodedPermissionData<NativeTokenPeriodicPermission> {
-  const { nativeTokenPeriodicEnforcer, exactCalldataEnforcer } =
+  const { nativeTokenPeriodTransferEnforcer, exactCalldataEnforcer } =
     contractAddresses;
 
   const exactCalldataTerms = getTermsByEnforcer({
@@ -79,7 +79,7 @@ function validateAndDecodeData(
 
   const terms = getTermsByEnforcer({
     caveats,
-    enforcer: nativeTokenPeriodicEnforcer,
+    enforcer: nativeTokenPeriodTransferEnforcer,
   });
   const {
     periodAmount,
@@ -123,7 +123,7 @@ function validateAndDecodeData(
  */
 export type NativeTokenPeriodicEnforcers = Pick<
   ChecksumEnforcersByChainId,
-  'nativeTokenPeriodicEnforcer' | 'exactCalldataEnforcer'
+  'nativeTokenPeriodTransferEnforcer' | 'exactCalldataEnforcer'
 >;
 
 /**
@@ -169,7 +169,7 @@ export function createNativeTokenPeriodicCaveats({
   }
 
   const nativeTokenPeriodTransferCaveat: Caveat = {
-    enforcer: contracts.nativeTokenPeriodicEnforcer,
+    enforcer: contracts.nativeTokenPeriodTransferEnforcer,
     terms: createNativeTokenPeriodTransferTerms({
       periodAmount: periodAmountBigInt,
       periodDuration,

--- a/packages/7715-permission-types/src/permissions/types.ts
+++ b/packages/7715-permission-types/src/permissions/types.ts
@@ -7,9 +7,9 @@ import type { Hex, PermissionTypes, Rule } from '../types';
  */
 export type ChecksumEnforcersByChainId = {
   erc20StreamingEnforcer: Hex;
-  erc20PeriodicEnforcer: Hex;
+  erc20PeriodTransferEnforcer: Hex;
   nativeTokenStreamingEnforcer: Hex;
-  nativeTokenPeriodicEnforcer: Hex;
+  nativeTokenPeriodTransferEnforcer: Hex;
   approvalRevocationEnforcer: Hex;
   exactCalldataEnforcer: Hex;
   valueLteEnforcer: Hex;

--- a/packages/7715-permission-types/src/permissions/utils.ts
+++ b/packages/7715-permission-types/src/permissions/utils.ts
@@ -176,13 +176,13 @@ export const getChecksumEnforcersByChainId = (
   const erc20StreamingEnforcer = getChecksumContractAddress(
     ENFORCER_CONTRACT_NAMES.ERC20StreamingEnforcer,
   );
-  const erc20PeriodicEnforcer = getChecksumContractAddress(
+  const erc20PeriodTransferEnforcer = getChecksumContractAddress(
     ENFORCER_CONTRACT_NAMES.ERC20PeriodTransferEnforcer,
   );
   const nativeTokenStreamingEnforcer = getChecksumContractAddress(
     ENFORCER_CONTRACT_NAMES.NativeTokenStreamingEnforcer,
   );
-  const nativeTokenPeriodicEnforcer = getChecksumContractAddress(
+  const nativeTokenPeriodTransferEnforcer = getChecksumContractAddress(
     ENFORCER_CONTRACT_NAMES.NativeTokenPeriodTransferEnforcer,
   );
   const approvalRevocationEnforcer = getChecksumContractAddress(
@@ -212,9 +212,9 @@ export const getChecksumEnforcersByChainId = (
 
   return {
     erc20StreamingEnforcer,
-    erc20PeriodicEnforcer,
+    erc20PeriodTransferEnforcer,
     nativeTokenStreamingEnforcer,
-    nativeTokenPeriodicEnforcer,
+    nativeTokenPeriodTransferEnforcer,
     approvalRevocationEnforcer,
     exactCalldataEnforcer,
     valueLteEnforcer,

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
@@ -31,7 +31,7 @@ describe('erc20-token-allowance decoder config', () => {
   const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
   const {
     timestampEnforcer,
-    erc20PeriodicEnforcer,
+    erc20PeriodTransferEnforcer,
     valueLteEnforcer,
     nonceEnforcer,
     allowedCalldataEnforcer,
@@ -52,7 +52,7 @@ describe('erc20-token-allowance decoder config', () => {
     valueLteTerms: Hex = ZERO_32_BYTES,
   ): ChecksumCaveat[] => [
     {
-      enforcer: erc20PeriodicEnforcer,
+      enforcer: erc20PeriodTransferEnforcer,
       terms: erc20PeriodicTerms,
       args: '0x',
     },
@@ -71,7 +71,7 @@ describe('erc20-token-allowance decoder config', () => {
   describe('static configuration', () => {
     it('exposes expected required enforcers', () => {
       expect(decoder.requiredEnforcers).toStrictEqual({
-        [erc20PeriodicEnforcer]: 1,
+        [erc20PeriodTransferEnforcer]: 1,
         [valueLteEnforcer]: 1,
         [nonceEnforcer]: 1,
       });
@@ -177,7 +177,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
   const startTime = 1729900800;
 
   const contracts: Erc20TokenAllowanceEnforcers = {
-    erc20PeriodicEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    erc20PeriodTransferEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
@@ -201,7 +201,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.erc20PeriodicEnforcer,
+        enforcer: contracts.erc20PeriodTransferEnforcer,
         terms: expectedTerms,
         args: '0x',
       },
@@ -302,7 +302,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
     });
     const erc20AllowanceTerms = caveats[0]?.terms as Hex;
 
-    expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodicEnforcer);
+    expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodTransferEnforcer);
     expect(
       erc20AllowanceTerms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
     ).toBe(true);

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
@@ -31,7 +31,7 @@ describe('erc20-token-periodic decoder config', () => {
   const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
   const {
     timestampEnforcer,
-    erc20PeriodicEnforcer,
+    erc20PeriodTransferEnforcer,
     valueLteEnforcer,
     nonceEnforcer,
     allowedCalldataEnforcer,
@@ -67,7 +67,7 @@ describe('erc20-token-periodic decoder config', () => {
     valueLteTerms: Hex = ZERO_32_BYTES,
   ): ChecksumCaveat[] => [
     {
-      enforcer: erc20PeriodicEnforcer,
+      enforcer: erc20PeriodTransferEnforcer,
       terms,
       args: '0x',
     },
@@ -86,7 +86,7 @@ describe('erc20-token-periodic decoder config', () => {
   describe('static configuration', () => {
     it('exposes expected required enforcers', () => {
       expect(decoder.requiredEnforcers).toStrictEqual({
-        [erc20PeriodicEnforcer]: 1,
+        [erc20PeriodTransferEnforcer]: 1,
         [valueLteEnforcer]: 1,
         [nonceEnforcer]: 1,
       });
@@ -208,7 +208,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
   const startTime = 1729900800;
 
   const contracts: Erc20TokenPeriodicEnforcers = {
-    erc20PeriodicEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    erc20PeriodTransferEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
@@ -233,7 +233,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.erc20PeriodicEnforcer,
+        enforcer: contracts.erc20PeriodTransferEnforcer,
         terms: expectedTerms,
         args: '0x',
       },
@@ -369,7 +369,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
     });
     const erc20PeriodicTerms = caveats[0]?.terms as Hex;
 
-    expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodicEnforcer);
+    expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodTransferEnforcer);
     expect(
       erc20PeriodicTerms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
     ).toBe(true);

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
@@ -30,7 +30,7 @@ describe('native-token-allowance decoder config', () => {
   const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
   const {
     timestampEnforcer,
-    nativeTokenPeriodicEnforcer,
+    nativeTokenPeriodTransferEnforcer,
     exactCalldataEnforcer,
     nonceEnforcer,
     allowedTargetsEnforcer,
@@ -51,7 +51,7 @@ describe('native-token-allowance decoder config', () => {
     exactCalldataTerms: Hex = '0x',
   ): ChecksumCaveat[] => [
     {
-      enforcer: nativeTokenPeriodicEnforcer,
+      enforcer: nativeTokenPeriodTransferEnforcer,
       terms: nativeTokenPeriodicTerms,
       args: '0x',
     },
@@ -70,7 +70,7 @@ describe('native-token-allowance decoder config', () => {
   describe('static configuration', () => {
     it('exposes expected required enforcers', () => {
       expect(decoder.requiredEnforcers).toStrictEqual({
-        [nativeTokenPeriodicEnforcer]: 1,
+        [nativeTokenPeriodTransferEnforcer]: 1,
         [exactCalldataEnforcer]: 1,
         [nonceEnforcer]: 1,
       });
@@ -174,7 +174,8 @@ describe('createNativeTokenAllowanceCaveats()', () => {
   const startTime = 1729900800;
 
   const contracts: NativeTokenAllowanceEnforcers = {
-    nativeTokenPeriodicEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    nativeTokenPeriodTransferEnforcer:
+      '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
@@ -197,7 +198,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.nativeTokenPeriodicEnforcer,
+        enforcer: contracts.nativeTokenPeriodTransferEnforcer,
         terms: expectedTerms,
         args: '0x',
       },

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
@@ -30,7 +30,7 @@ describe('native-token-periodic decoder config', () => {
   const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
   const {
     timestampEnforcer,
-    nativeTokenPeriodicEnforcer,
+    nativeTokenPeriodTransferEnforcer,
     exactCalldataEnforcer,
     nonceEnforcer,
     allowedTargetsEnforcer,
@@ -57,7 +57,7 @@ describe('native-token-periodic decoder config', () => {
     exactCalldataTerms: Hex = '0x',
   ): ChecksumCaveat[] => [
     {
-      enforcer: nativeTokenPeriodicEnforcer,
+      enforcer: nativeTokenPeriodTransferEnforcer,
       terms: nativeTokenPeriodicTerms,
       args: '0x',
     },
@@ -76,7 +76,7 @@ describe('native-token-periodic decoder config', () => {
   describe('static configuration', () => {
     it('exposes expected required enforcers', () => {
       expect(decoder.requiredEnforcers).toStrictEqual({
-        [nativeTokenPeriodicEnforcer]: 1,
+        [nativeTokenPeriodTransferEnforcer]: 1,
         [exactCalldataEnforcer]: 1,
         [nonceEnforcer]: 1,
       });
@@ -195,7 +195,8 @@ describe('createNativeTokenPeriodicCaveats()', () => {
   const startTime = 1729900800;
 
   const contracts: NativeTokenPeriodicEnforcers = {
-    nativeTokenPeriodicEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
+    nativeTokenPeriodTransferEnforcer:
+      '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
 
@@ -220,7 +221,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.nativeTokenPeriodicEnforcer,
+        enforcer: contracts.nativeTokenPeriodTransferEnforcer,
         terms: nativeTokenPeriodicExpectedTerms,
         args: '0x',
       },


### PR DESCRIPTION
## 📝 Description

The caveat enforcer names defined in the deployed contracts object used when constructing caveats for 7715 permission requests used incorrect caveat names.

## 🔄 What Changed?

- `erc20PeriodicEnforcer` is now `erc20PeriodTransferEnforcer`
- `nativeTokenPeriodicEnforcer` is now `nativeTokenPeriodTransferEnforcer`

## 🚀 Why?

This aligns with the actual caveat names as per @metamask/delegation-deployments package

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking TypeScript API for anyone using the old `*PeriodicEnforcer` property names; behavior of caveat construction should be unchanged since addresses were already resolved from PeriodTransfer enforcer contracts.
> 
> **Overview**
> Renames **`ChecksumEnforcersByChainId`** keys so they match `@metamask/delegation-deployments` contract names: `erc20PeriodicEnforcer` → **`erc20PeriodTransferEnforcer`** and `nativeTokenPeriodicEnforcer` → **`nativeTokenPeriodTransferEnforcer`**.
> 
> That rename is threaded through ERC-20/native **allowance** and **periodic** caveat builders and decoders, `getChecksumEnforcersByChainId` return shape, related `Pick<>` enforcer types, tests, and the package changelog. **On-chain enforcer addresses and caveat encoding are unchanged**—only the public property names on the enforcer map were wrong before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5392a2366c75b6874ca25208daf6a58e3b1fcf3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->