### PR TITLE
feat: add I18nValue type to permission types

### DIFF
--- a/packages/7715-permission-types/CHANGELOG.md
+++ b/packages/7715-permission-types/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `I18nValue` type ([#275](https://github.com/MetaMask/smart-accounts-kit/pull/275))
+
 ## [0.8.0]
 
 ### Added

--- a/packages/7715-permission-types/CHANGELOG.md
+++ b/packages/7715-permission-types/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Export `I18nValue` type ([#275](https://github.com/MetaMask/smart-accounts-kit/pull/275))
+
 ### Fixed
 
 - Incorrectly named caveats used in caveat factory functions ([#274](https://github.com/MetaMask/smart-accounts-kit/pull/274))

--- a/packages/7715-permission-types/src/index.ts
+++ b/packages/7715-permission-types/src/index.ts
@@ -70,6 +70,7 @@ export type {
   ExpiryField,
   FieldView,
   I18nFunction,
+  I18nValue,
   JustificationField,
   ListField,
   NetworkField,


### PR DESCRIPTION
## 📝 Description

Provide a brief description of the changes in this PR

## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive type-only public export with no behavior changes; low risk for consumers.
> 
> **Overview**
> **Public API:** `@metamask/7715-permission-types` now re-exports the **`I18nValue`** type from the package entry (`src/index.ts`), alongside existing permission schema types like `I18nFunction`.
> 
> **Docs:** The unreleased changelog records the new export under **Added**.
> 
> Consumers can type permission UI/schema values that are either plain strings or `{ key, args? }` translation objects without importing from internal `permissions/schema` paths. No runtime or type-definition changes beyond making an existing internal type part of the published surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7c215341594405b627eb43e9e6d5456eeb018f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->