### PR TITLE
chore: `EnforcerAddressesByName` has enforcer name specific keys

### DIFF
--- a/packages/7715-permission-types/CHANGELOG.md
+++ b/packages/7715-permission-types/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `makePermissionDecoderConfigs` now accepts `EnforcerAddressesByName`, which is keyed with specific contract names ([#278](https://github.com/MetaMask/smart-accounts-kit/pull/278))
+  - Removes `ChecksumEnforcersByChainId` and `DeployedContractsByName` types
+
 ## [0.9.0]
 
 ### Added

--- a/packages/7715-permission-types/src/index.ts
+++ b/packages/7715-permission-types/src/index.ts
@@ -37,7 +37,7 @@ export {
   type NativeTokenStreamEnforcers,
   createTokenApprovalRevocationCaveats,
   type TokenApprovalRevocationEnforcers,
-  type DeployedContractsByName,
+  type EnforcerAddressesByName,
   type PermissionDecoderConfig,
 } from './permissions';
 export {

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenAllowance.ts
@@ -11,7 +11,7 @@ import { erc20PayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
 import type {
   ChecksumCaveat,
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   DecodedPermissionData,
   PermissionDecoderConfig,
 } from '../types';
@@ -30,7 +30,7 @@ import {
  * @returns The erc20-token-allowance permission decoder configuration.
  */
 export function makeErc20TokenAllowanceDecoderConfig(
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
@@ -68,7 +68,7 @@ export function makeErc20TokenAllowanceDecoderConfig(
  */
 function validateAndDecodeData(
   caveats: ChecksumCaveat[],
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): DecodedPermissionData<Erc20TokenAllowancePermission> {
   const { erc20PeriodTransferEnforcer, valueLteEnforcer } = contractAddresses;
 
@@ -121,7 +121,7 @@ function validateAndDecodeData(
  * Enforcers required to build ERC-20 token allowance caveats.
  */
 export type Erc20TokenAllowanceEnforcers = Pick<
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   'erc20PeriodTransferEnforcer' | 'valueLteEnforcer'
 >;
 

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenPeriodic.ts
@@ -12,7 +12,7 @@ import { erc20PayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
 import type {
   ChecksumCaveat,
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   DecodedPermissionData,
   PermissionDecoderConfig,
 } from '../types';
@@ -29,7 +29,7 @@ import {
  * @returns The erc20-token-periodic permission decoder configuration.
  */
 export function makeErc20TokenPeriodicDecoderConfig(
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
@@ -67,7 +67,7 @@ export function makeErc20TokenPeriodicDecoderConfig(
  */
 function validateAndDecodeData(
   caveats: ChecksumCaveat[],
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): DecodedPermissionData<Erc20TokenPeriodicPermission> {
   const { erc20PeriodTransferEnforcer, valueLteEnforcer } = contractAddresses;
 
@@ -127,7 +127,7 @@ function validateAndDecodeData(
  * Enforcers required to build ERC-20 token periodic caveats.
  */
 export type Erc20TokenPeriodicEnforcers = Pick<
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   'erc20PeriodTransferEnforcer' | 'valueLteEnforcer'
 >;
 

--- a/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/erc20TokenStream.ts
@@ -13,7 +13,7 @@ import { redeemerRuleDecoder } from '../rules/redeemer';
 import type {
   ChecksumCaveat,
   DecodedPermissionData,
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   PermissionDecoderConfig,
 } from '../types';
 import { getTermsByEnforcer, ZERO_32_BYTES } from '../utils';
@@ -25,7 +25,7 @@ import { getTermsByEnforcer, ZERO_32_BYTES } from '../utils';
  * @returns The erc20-token-stream permission decoder configuration.
  */
 export function makeErc20TokenStreamDecoderConfig(
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
@@ -63,7 +63,7 @@ export function makeErc20TokenStreamDecoderConfig(
  */
 function validateAndDecodeData(
   caveats: ChecksumCaveat[],
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): DecodedPermissionData<Erc20TokenStreamPermission> {
   const { erc20StreamingEnforcer, valueLteEnforcer } = contractAddresses;
 
@@ -114,7 +114,7 @@ function validateAndDecodeData(
  * Enforcers required to build ERC-20 token stream caveats.
  */
 export type Erc20TokenStreamEnforcers = Pick<
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   'erc20StreamingEnforcer' | 'valueLteEnforcer'
 >;
 

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenAllowance.ts
@@ -11,7 +11,7 @@ import { nativePayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
 import type {
   ChecksumCaveat,
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   DecodedPermissionData,
   PermissionDecoderConfig,
 } from '../types';
@@ -30,7 +30,7 @@ import {
  * @returns The native-token-allowance permission decoder configuration.
  */
 export function makeNativeTokenAllowanceDecoderConfig(
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
@@ -68,7 +68,7 @@ export function makeNativeTokenAllowanceDecoderConfig(
  */
 function validateAndDecodeData(
   caveats: ChecksumCaveat[],
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): DecodedPermissionData<NativeTokenAllowancePermission> {
   const { nativeTokenPeriodTransferEnforcer, exactCalldataEnforcer } =
     contractAddresses;
@@ -125,7 +125,7 @@ function validateAndDecodeData(
  * Enforcers required to build native token allowance caveats.
  */
 export type NativeTokenAllowanceEnforcers = Pick<
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   'nativeTokenPeriodTransferEnforcer' | 'exactCalldataEnforcer'
 >;
 

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenPeriodic.ts
@@ -12,7 +12,7 @@ import { nativePayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
 import type {
   ChecksumCaveat,
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   DecodedPermissionData,
   PermissionDecoderConfig,
 } from '../types';
@@ -25,7 +25,7 @@ import { getTermsByEnforcer, MAX_PERIOD_DURATION } from '../utils';
  * @returns The native-token-periodic permission decoder configuration.
  */
 export function makeNativeTokenPeriodicDecoderConfig(
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
@@ -63,7 +63,7 @@ export function makeNativeTokenPeriodicDecoderConfig(
  */
 function validateAndDecodeData(
   caveats: ChecksumCaveat[],
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): DecodedPermissionData<NativeTokenPeriodicPermission> {
   const { nativeTokenPeriodTransferEnforcer, exactCalldataEnforcer } =
     contractAddresses;
@@ -122,7 +122,7 @@ function validateAndDecodeData(
  * Enforcers required to build native token periodic caveats.
  */
 export type NativeTokenPeriodicEnforcers = Pick<
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   'nativeTokenPeriodTransferEnforcer' | 'exactCalldataEnforcer'
 >;
 

--- a/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/nativeTokenStream.ts
@@ -12,7 +12,7 @@ import { nativePayeeRuleDecoder } from '../rules/payee';
 import { redeemerRuleDecoder } from '../rules/redeemer';
 import type {
   ChecksumCaveat,
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   DecodedPermissionData,
   PermissionDecoderConfig,
 } from '../types';
@@ -25,7 +25,7 @@ import { getTermsByEnforcer } from '../utils';
  * @returns The native-token-stream permission decoder configuration.
  */
 export function makeNativeTokenStreamDecoderConfig(
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): PermissionDecoderConfig {
   const {
     timestampEnforcer,
@@ -63,7 +63,7 @@ export function makeNativeTokenStreamDecoderConfig(
  */
 function validateAndDecodeData(
   caveats: ChecksumCaveat[],
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): DecodedPermissionData<NativeTokenStreamPermission> {
   const { nativeTokenStreamingEnforcer, exactCalldataEnforcer } =
     contractAddresses;
@@ -114,7 +114,7 @@ function validateAndDecodeData(
  * Enforcers required to build native token stream caveats.
  */
 export type NativeTokenStreamEnforcers = Pick<
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   'nativeTokenStreamingEnforcer' | 'exactCalldataEnforcer'
 >;
 

--- a/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
+++ b/packages/7715-permission-types/src/permissions/caveats/tokenApprovalRevocation.ts
@@ -8,7 +8,7 @@ import type { TokenApprovalRevocationPermission, Populated } from '../../types';
 import { expiryRuleDecoder } from '../rules/expiry';
 import type {
   ChecksumCaveat,
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   DecodedPermissionData,
   PermissionDecoderConfig,
 } from '../types';
@@ -21,7 +21,7 @@ import { getTermsByEnforcer } from '../utils';
  * @returns The token-approval-revocation permission decoder configuration.
  */
 export function makeTokenApprovalRevocationDecoderConfig(
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): PermissionDecoderConfig {
   const { timestampEnforcer, approvalRevocationEnforcer, nonceEnforcer } =
     contractAddresses;
@@ -50,7 +50,7 @@ export function makeTokenApprovalRevocationDecoderConfig(
  */
 function validateAndDecodeData(
   caveats: ChecksumCaveat[],
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ): DecodedPermissionData<TokenApprovalRevocationPermission> {
   const { approvalRevocationEnforcer } = contractAddresses;
 
@@ -82,7 +82,7 @@ function validateAndDecodeData(
  * Enforcers required to build token approval revocation caveats.
  */
 export type TokenApprovalRevocationEnforcers = Pick<
-  ChecksumEnforcersByChainId,
+  EnforcerAddressesByName,
   'approvalRevocationEnforcer'
 >;
 

--- a/packages/7715-permission-types/src/permissions/index.ts
+++ b/packages/7715-permission-types/src/permissions/index.ts
@@ -5,8 +5,8 @@ import { makeNativeTokenAllowanceDecoderConfig } from './caveats/nativeTokenAllo
 import { makeNativeTokenPeriodicDecoderConfig } from './caveats/nativeTokenPeriodic';
 import { makeNativeTokenStreamDecoderConfig } from './caveats/nativeTokenStream';
 import { makeTokenApprovalRevocationDecoderConfig } from './caveats/tokenApprovalRevocation';
-import type { DeployedContractsByName, PermissionDecoderConfig } from './types';
-import { getChecksumEnforcersByChainId } from './utils';
+import type { EnforcerAddressesByName, PermissionDecoderConfig } from './types';
+import { checksumEnforcerAddresses } from './utils';
 
 export {
   createErc20TokenStreamCaveats,
@@ -40,7 +40,7 @@ export {
 export type { ExpiryRule } from './rules/expiry';
 export type { PayeeRule } from './rules/payee';
 export type { RedeemerRule } from './rules/redeemer';
-export type { DeployedContractsByName, PermissionDecoderConfig };
+export type { EnforcerAddressesByName, PermissionDecoderConfig };
 export {
   DAY,
   FORTNIGHT,
@@ -87,6 +87,7 @@ export type {
   TokenResolution,
   TokenVariant,
 } from './schema';
+
 /**
  * Builds the canonical set of permission decoders for a chain.
  *
@@ -94,17 +95,17 @@ export type {
  * @returns The full set of permission decoders for the chain.
  */
 export const makePermissionDecoderConfigs = (
-  contracts: DeployedContractsByName,
+  contracts: EnforcerAddressesByName,
 ): PermissionDecoderConfig[] => {
-  const contractAddresses = getChecksumEnforcersByChainId(contracts);
+  const enforcerAddresses = checksumEnforcerAddresses(contracts);
 
   return [
-    makeNativeTokenStreamDecoderConfig(contractAddresses),
-    makeNativeTokenPeriodicDecoderConfig(contractAddresses),
-    makeNativeTokenAllowanceDecoderConfig(contractAddresses),
-    makeErc20TokenStreamDecoderConfig(contractAddresses),
-    makeErc20TokenPeriodicDecoderConfig(contractAddresses),
-    makeErc20TokenAllowanceDecoderConfig(contractAddresses),
-    makeTokenApprovalRevocationDecoderConfig(contractAddresses),
+    makeNativeTokenStreamDecoderConfig(enforcerAddresses),
+    makeNativeTokenPeriodicDecoderConfig(enforcerAddresses),
+    makeNativeTokenAllowanceDecoderConfig(enforcerAddresses),
+    makeErc20TokenStreamDecoderConfig(enforcerAddresses),
+    makeErc20TokenPeriodicDecoderConfig(enforcerAddresses),
+    makeErc20TokenAllowanceDecoderConfig(enforcerAddresses),
+    makeTokenApprovalRevocationDecoderConfig(enforcerAddresses),
   ];
 };

--- a/packages/7715-permission-types/src/permissions/types.ts
+++ b/packages/7715-permission-types/src/permissions/types.ts
@@ -2,24 +2,6 @@ import type { Caveat } from '@metamask/delegation-core';
 
 import type { Hex, PermissionTypes, Rule } from '../types';
 
-/**
- * Checksummed enforcer contract addresses for a chain (from getChecksumEnforcersByChainId).
- */
-export type ChecksumEnforcersByChainId = {
-  erc20StreamingEnforcer: Hex;
-  erc20PeriodTransferEnforcer: Hex;
-  nativeTokenStreamingEnforcer: Hex;
-  nativeTokenPeriodTransferEnforcer: Hex;
-  approvalRevocationEnforcer: Hex;
-  exactCalldataEnforcer: Hex;
-  valueLteEnforcer: Hex;
-  timestampEnforcer: Hex;
-  nonceEnforcer: Hex;
-  allowedCalldataEnforcer: Hex;
-  allowedTargetsEnforcer: Hex;
-  redeemerEnforcer: Hex;
-};
-
 /** Caveat with checksummed enforcer address; used by rule decode functions. */
 export type ChecksumCaveat = Caveat<Hex>;
 
@@ -39,7 +21,7 @@ export type PermissionType = PermissionTypes['type'];
  * A function that inspects checksummed caveats and optionally produces a Rule.
  */
 export type RuleDecoder = (args: {
-  contractAddresses: ChecksumEnforcersByChainId;
+  contractAddresses: EnforcerAddressesByName;
   caveats: ChecksumCaveat[];
   requiredEnforcers: Map<Hex, number>;
 }) => Rule | null;
@@ -49,18 +31,18 @@ export type RuleDecoder = (args: {
  */
 export type PermissionDecoderConfig = {
   permissionType: PermissionType;
-  contractAddresses: ChecksumEnforcersByChainId;
+  contractAddresses: EnforcerAddressesByName;
   optionalEnforcers: Hex[];
   requiredEnforcers: Record<Hex, number>;
   rules: RuleDecoder[];
   validateAndDecodeData: (
     caveats: ChecksumCaveat[],
-    contractAddresses: ChecksumEnforcersByChainId,
+    contractAddresses: EnforcerAddressesByName,
   ) => DecodedPermissionData;
 };
 
 export type PermissionDecoderSpec = (
-  contractAddresses: ChecksumEnforcersByChainId,
+  contractAddresses: EnforcerAddressesByName,
 ) => PermissionDecoderConfig;
 
 /**
@@ -86,7 +68,21 @@ export type PermissionDecoder = {
   validateAndDecodePermission: (caveats: Caveat[]) => ValidateAndDecodeResult;
 };
 
+export type EnforcerContractName =
+  | 'erc20StreamingEnforcer'
+  | 'erc20PeriodTransferEnforcer'
+  | 'nativeTokenStreamingEnforcer'
+  | 'nativeTokenPeriodTransferEnforcer'
+  | 'approvalRevocationEnforcer'
+  | 'exactCalldataEnforcer'
+  | 'valueLteEnforcer'
+  | 'timestampEnforcer'
+  | 'nonceEnforcer'
+  | 'allowedCalldataEnforcer'
+  | 'allowedTargetsEnforcer'
+  | 'redeemerEnforcer';
+
 /**
- * A map of deployed contract names to addresses for one chain.
+ * A map of enforcer contract names to addresses.
  */
-export type DeployedContractsByName = Record<string, Hex>;
+export type EnforcerAddressesByName = Record<EnforcerContractName, Hex>;

--- a/packages/7715-permission-types/src/permissions/utils.ts
+++ b/packages/7715-permission-types/src/permissions/utils.ts
@@ -1,6 +1,6 @@
 import { getChecksumAddress } from '@metamask/utils';
 
-import type { ChecksumCaveat, ChecksumEnforcersByChainId } from './types';
+import type { ChecksumCaveat, EnforcerAddressesByName } from './types';
 import type { Hex } from '../types';
 
 /**
@@ -25,21 +25,6 @@ export const ERC20_APPROVE_ZERO_AMOUNT_TERMS =
 
 /** Maximum period duration in seconds. */
 export const MAX_PERIOD_DURATION = 10 * 365 * 24 * 60 * 60;
-
-const ENFORCER_CONTRACT_NAMES = {
-  ERC20PeriodTransferEnforcer: 'ERC20PeriodTransferEnforcer',
-  ERC20StreamingEnforcer: 'ERC20StreamingEnforcer',
-  ApprovalRevocationEnforcer: 'ApprovalRevocationEnforcer',
-  ExactCalldataEnforcer: 'ExactCalldataEnforcer',
-  NativeTokenPeriodTransferEnforcer: 'NativeTokenPeriodTransferEnforcer',
-  NativeTokenStreamingEnforcer: 'NativeTokenStreamingEnforcer',
-  TimestampEnforcer: 'TimestampEnforcer',
-  ValueLteEnforcer: 'ValueLteEnforcer',
-  NonceEnforcer: 'NonceEnforcer',
-  AllowedCalldataEnforcer: 'AllowedCalldataEnforcer',
-  AllowedTargetsEnforcer: 'AllowedTargetsEnforcer',
-  RedeemerEnforcer: 'RedeemerEnforcer',
-};
 
 /**
  * Gets the terms for a given enforcer from a list of caveats.
@@ -160,68 +145,35 @@ export function splitHex<const TLengths extends readonly number[]>(
  * @param contracts - Deployed contract-name-to-address map for a chain.
  * @returns Checksummed enforcer addresses keyed by known enforcer role.
  */
-export const getChecksumEnforcersByChainId = (
-  contracts: Record<string, Hex>,
-): ChecksumEnforcersByChainId => {
-  const getChecksumContractAddress = (contractName: string): Hex => {
-    const address = contracts[contractName];
-
-    if (!address) {
-      throw new Error(`Contract not found: ${contractName}`);
-    }
-
-    return getChecksumAddress(address);
-  };
-
-  const erc20StreamingEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.ERC20StreamingEnforcer,
-  );
-  const erc20PeriodTransferEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.ERC20PeriodTransferEnforcer,
-  );
-  const nativeTokenStreamingEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.NativeTokenStreamingEnforcer,
-  );
-  const nativeTokenPeriodTransferEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.NativeTokenPeriodTransferEnforcer,
-  );
-  const approvalRevocationEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.ApprovalRevocationEnforcer,
-  );
-  const exactCalldataEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.ExactCalldataEnforcer,
-  );
-  const valueLteEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.ValueLteEnforcer,
-  );
-  const timestampEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.TimestampEnforcer,
-  );
-  const nonceEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.NonceEnforcer,
-  );
-  const allowedCalldataEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.AllowedCalldataEnforcer,
-  );
-  const allowedTargetsEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.AllowedTargetsEnforcer,
-  );
-  const redeemerEnforcer = getChecksumContractAddress(
-    ENFORCER_CONTRACT_NAMES.RedeemerEnforcer,
-  );
-
+export const checksumEnforcerAddresses = (
+  contracts: EnforcerAddressesByName,
+): EnforcerAddressesByName => {
   return {
-    erc20StreamingEnforcer,
-    erc20PeriodTransferEnforcer,
-    nativeTokenStreamingEnforcer,
-    nativeTokenPeriodTransferEnforcer,
-    approvalRevocationEnforcer,
-    exactCalldataEnforcer,
-    valueLteEnforcer,
-    timestampEnforcer,
-    nonceEnforcer,
-    allowedCalldataEnforcer,
-    allowedTargetsEnforcer,
-    redeemerEnforcer,
+    erc20StreamingEnforcer: getChecksumAddress(
+      contracts.erc20StreamingEnforcer,
+    ),
+    erc20PeriodTransferEnforcer: getChecksumAddress(
+      contracts.erc20PeriodTransferEnforcer,
+    ),
+    nativeTokenStreamingEnforcer: getChecksumAddress(
+      contracts.nativeTokenStreamingEnforcer,
+    ),
+    nativeTokenPeriodTransferEnforcer: getChecksumAddress(
+      contracts.nativeTokenPeriodTransferEnforcer,
+    ),
+    approvalRevocationEnforcer: getChecksumAddress(
+      contracts.approvalRevocationEnforcer,
+    ),
+    exactCalldataEnforcer: getChecksumAddress(contracts.exactCalldataEnforcer),
+    valueLteEnforcer: getChecksumAddress(contracts.valueLteEnforcer),
+    timestampEnforcer: getChecksumAddress(contracts.timestampEnforcer),
+    nonceEnforcer: getChecksumAddress(contracts.nonceEnforcer),
+    allowedCalldataEnforcer: getChecksumAddress(
+      contracts.allowedCalldataEnforcer,
+    ),
+    allowedTargetsEnforcer: getChecksumAddress(
+      contracts.allowedTargetsEnforcer,
+    ),
+    redeemerEnforcer: getChecksumAddress(contracts.redeemerEnforcer),
   };
 };

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenAllowance.test.ts
@@ -1,7 +1,3 @@
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
@@ -16,7 +12,7 @@ import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
-  getChecksumEnforcersByChainId,
+  checksumEnforcerAddresses,
   UINT256_MAX,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
@@ -24,11 +20,10 @@ import type {
   Erc20TokenAllowancePermission,
   Populated,
 } from '../../../src/types';
-import { toWord } from '../../test-utils';
+import { contracts, toWord } from '../../test-utils';
 
 describe('erc20-token-allowance decoder config', () => {
-  const chainId = CHAIN_ID.sepolia;
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
+  const enforcers = checksumEnforcerAddresses(contracts);
   const {
     timestampEnforcer,
     erc20PeriodTransferEnforcer,
@@ -36,10 +31,8 @@ describe('erc20-token-allowance decoder config', () => {
     nonceEnforcer,
     allowedCalldataEnforcer,
     redeemerEnforcer,
-  } = getChecksumEnforcersByChainId(contracts);
-  const decoder = makeErc20TokenAllowanceDecoderConfig(
-    getChecksumEnforcersByChainId(contracts),
-  );
+  } = enforcers;
+  const decoder = makeErc20TokenAllowanceDecoderConfig(enforcers);
   const TOKEN_ADDRESS_HEX = 'aa'.repeat(20);
   const ALLOWANCE_AMOUNT_HEX = toWord(100n);
   const START_TIME = 1715664;
@@ -176,7 +169,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
   const allowanceAmount = '0x64' as const;
   const startTime = 1729900800;
 
-  const contracts: Erc20TokenAllowanceEnforcers = {
+  const enforcers: Erc20TokenAllowanceEnforcers = {
     erc20PeriodTransferEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
@@ -195,18 +188,18 @@ describe('createErc20TokenAllowanceCaveats()', () => {
   it('creates erc20Periodic and valueLte caveats', () => {
     const caveats = createErc20TokenAllowanceCaveats({
       permission,
-      contracts,
+      contracts: enforcers,
     });
     const expectedTerms = `0x${tokenAddress.slice(2)}${toWord(BigInt(allowanceAmount))}${UINT256_MAX.slice(2)}${toWord(startTime)}`;
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.erc20PeriodTransferEnforcer,
+        enforcer: enforcers.erc20PeriodTransferEnforcer,
         terms: expectedTerms,
         args: '0x',
       },
       {
-        enforcer: contracts.valueLteEnforcer,
+        enforcer: enforcers.valueLteEnforcer,
         terms: ZERO_32_BYTES,
         args: '0x',
       },
@@ -225,7 +218,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
     expect(() =>
       createErc20TokenAllowanceCaveats({
         permission: invalidPermission,
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow();
   });
@@ -240,7 +233,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
             allowanceAmount: '0x0',
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-allowance permission: allowanceAmount must be a positive number.',
@@ -257,7 +250,7 @@ describe('createErc20TokenAllowanceCaveats()', () => {
             startTime: 0,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-allowance permission: startTime must be a positive number.',
@@ -278,10 +271,10 @@ describe('createErc20TokenAllowanceCaveats()', () => {
 
     const caveats = createErc20TokenAllowanceCaveats({
       permission: variedPermission,
-      contracts,
+      contracts: enforcers,
     });
 
-    expect(caveats[1]?.enforcer).toBe(contracts.valueLteEnforcer);
+    expect(caveats[1]?.enforcer).toBe(enforcers.valueLteEnforcer);
     expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
   });
 
@@ -298,11 +291,11 @@ describe('createErc20TokenAllowanceCaveats()', () => {
 
     const caveats = createErc20TokenAllowanceCaveats({
       permission: permissionWithAltToken,
-      contracts,
+      contracts: enforcers,
     });
     const erc20AllowanceTerms = caveats[0]?.terms as Hex;
 
-    expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodTransferEnforcer);
+    expect(caveats[0]?.enforcer).toBe(enforcers.erc20PeriodTransferEnforcer);
     expect(
       erc20AllowanceTerms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
     ).toBe(true);

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenPeriodic.test.ts
@@ -1,7 +1,3 @@
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
@@ -16,7 +12,7 @@ import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
-  getChecksumEnforcersByChainId,
+  checksumEnforcerAddresses,
   MAX_PERIOD_DURATION,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
@@ -24,11 +20,10 @@ import type {
   Erc20TokenPeriodicPermission,
   Populated,
 } from '../../../src/types';
-import { toWord } from '../../test-utils';
+import { contracts, toWord } from '../../test-utils';
 
 describe('erc20-token-periodic decoder config', () => {
-  const chainId = CHAIN_ID.sepolia;
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
+  const enforcers = checksumEnforcerAddresses(contracts);
   const {
     timestampEnforcer,
     erc20PeriodTransferEnforcer,
@@ -36,10 +31,8 @@ describe('erc20-token-periodic decoder config', () => {
     nonceEnforcer,
     allowedCalldataEnforcer,
     redeemerEnforcer,
-  } = getChecksumEnforcersByChainId(contracts);
-  const decoder = makeErc20TokenPeriodicDecoderConfig(
-    getChecksumEnforcersByChainId(contracts),
-  );
+  } = enforcers;
+  const decoder = makeErc20TokenPeriodicDecoderConfig(enforcers);
 
   const TOKEN_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Hex;
   const START_TIME = 1715664;
@@ -207,7 +200,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
   const periodDuration = 86400;
   const startTime = 1729900800;
 
-  const contracts: Erc20TokenPeriodicEnforcers = {
+  const enforcers: Erc20TokenPeriodicEnforcers = {
     erc20PeriodTransferEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
@@ -227,18 +220,18 @@ describe('createErc20TokenPeriodicCaveats()', () => {
   it('creates erc20Periodic and valueLte caveats', () => {
     const caveats = createErc20TokenPeriodicCaveats({
       permission,
-      contracts,
+      contracts: enforcers,
     });
     const expectedTerms = `0x${tokenAddress.slice(2)}${toWord(BigInt(periodAmount))}${toWord(periodDuration)}${toWord(startTime)}`;
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.erc20PeriodTransferEnforcer,
+        enforcer: enforcers.erc20PeriodTransferEnforcer,
         terms: expectedTerms,
         args: '0x',
       },
       {
-        enforcer: contracts.valueLteEnforcer,
+        enforcer: enforcers.valueLteEnforcer,
         terms: ZERO_32_BYTES,
         args: '0x',
       },
@@ -257,7 +250,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
     expect(() =>
       createErc20TokenPeriodicCaveats({
         permission: invalidPermission,
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow();
   });
@@ -272,7 +265,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
             periodAmount: '0x0',
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-periodic permission: periodAmount must be a positive number.',
@@ -289,7 +282,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
             periodDuration: 0,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-periodic permission: periodDuration must be a positive number.',
@@ -306,7 +299,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
             periodDuration: MAX_PERIOD_DURATION + 1,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-periodic permission: periodDuration must be less than or equal to MAX_PERIOD_DURATION.',
@@ -323,7 +316,7 @@ describe('createErc20TokenPeriodicCaveats()', () => {
             startTime: 0,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-periodic permission: startTime must be a positive number.',
@@ -345,10 +338,10 @@ describe('createErc20TokenPeriodicCaveats()', () => {
 
     const caveats = createErc20TokenPeriodicCaveats({
       permission: variedPermission,
-      contracts,
+      contracts: enforcers,
     });
 
-    expect(caveats[1]?.enforcer).toBe(contracts.valueLteEnforcer);
+    expect(caveats[1]?.enforcer).toBe(enforcers.valueLteEnforcer);
     expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
   });
 
@@ -365,11 +358,11 @@ describe('createErc20TokenPeriodicCaveats()', () => {
 
     const caveats = createErc20TokenPeriodicCaveats({
       permission: permissionWithAltToken,
-      contracts,
+      contracts: enforcers,
     });
     const erc20PeriodicTerms = caveats[0]?.terms as Hex;
 
-    expect(caveats[0]?.enforcer).toBe(contracts.erc20PeriodTransferEnforcer);
+    expect(caveats[0]?.enforcer).toBe(enforcers.erc20PeriodTransferEnforcer);
     expect(
       erc20PeriodicTerms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
     ).toBe(true);

--- a/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/erc20TokenStream.test.ts
@@ -1,7 +1,3 @@
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
@@ -16,15 +12,14 @@ import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
-  getChecksumEnforcersByChainId,
+  checksumEnforcerAddresses,
   ZERO_32_BYTES,
 } from '../../../src/permissions/utils';
 import type { Erc20TokenStreamPermission, Populated } from '../../../src/types';
-import { toWord } from '../../test-utils';
+import { contracts, toWord } from '../../test-utils';
 
 describe('erc20-token-stream decoder config', () => {
-  const chainId = CHAIN_ID.sepolia;
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
+  const enforcers = checksumEnforcerAddresses(contracts);
   const {
     timestampEnforcer,
     erc20StreamingEnforcer,
@@ -32,10 +27,8 @@ describe('erc20-token-stream decoder config', () => {
     nonceEnforcer,
     allowedCalldataEnforcer,
     redeemerEnforcer,
-  } = getChecksumEnforcersByChainId(contracts);
-  const decoder = makeErc20TokenStreamDecoderConfig(
-    getChecksumEnforcersByChainId(contracts),
-  );
+  } = enforcers;
+  const decoder = makeErc20TokenStreamDecoderConfig(enforcers);
   const TOKEN_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Hex;
   const START_TIME = 1715664;
   const makeTerms = ({
@@ -186,7 +179,7 @@ describe('createErc20TokenStreamCaveats()', () => {
   const startTime = 1729900800; // 10/26/2024 00:00:00 UTC
   const tokenAddress = '0x1234567890123456789012345678901234567890' as const;
 
-  const contracts: Erc20TokenStreamEnforcers = {
+  const enforcers: Erc20TokenStreamEnforcers = {
     erc20StreamingEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     valueLteEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
@@ -207,7 +200,7 @@ describe('createErc20TokenStreamCaveats()', () => {
   it('creates erc20Streaming and valueLte caveats', () => {
     const caveats = createErc20TokenStreamCaveats({
       permission: mockPermission,
-      contracts,
+      contracts: enforcers,
     });
     const initialAmountHex = initialAmount.slice(2).padStart(64, '0');
     const maxAmountHex = maxAmount.slice(2).padStart(64, '0');
@@ -217,12 +210,12 @@ describe('createErc20TokenStreamCaveats()', () => {
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.erc20StreamingEnforcer,
+        enforcer: enforcers.erc20StreamingEnforcer,
         terms: erc20StreamingExpectedTerms,
         args: '0x',
       },
       {
-        enforcer: contracts.valueLteEnforcer,
+        enforcer: enforcers.valueLteEnforcer,
         terms:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
         args: '0x',
@@ -242,7 +235,7 @@ describe('createErc20TokenStreamCaveats()', () => {
     expect(() =>
       createErc20TokenStreamCaveats({
         permission: invalidPermission,
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow();
   });
@@ -258,7 +251,7 @@ describe('createErc20TokenStreamCaveats()', () => {
             maxAmount: '0x64',
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-stream permission: maxAmount must be greater than initialAmount.',
@@ -275,7 +268,7 @@ describe('createErc20TokenStreamCaveats()', () => {
             amountPerSecond: '0x0',
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-stream permission: amountPerSecond must be a positive number.',
@@ -292,7 +285,7 @@ describe('createErc20TokenStreamCaveats()', () => {
             startTime: 0,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid erc20-token-stream permission: startTime must be a positive number.',
@@ -315,10 +308,10 @@ describe('createErc20TokenStreamCaveats()', () => {
 
     const caveats = createErc20TokenStreamCaveats({
       permission: variedPermission,
-      contracts,
+      contracts: enforcers,
     });
 
-    expect(caveats[1]?.enforcer).toBe(contracts.valueLteEnforcer);
+    expect(caveats[1]?.enforcer).toBe(enforcers.valueLteEnforcer);
     expect(caveats[1]?.terms).toBe(ZERO_32_BYTES);
   });
 
@@ -335,11 +328,11 @@ describe('createErc20TokenStreamCaveats()', () => {
 
     const caveats = createErc20TokenStreamCaveats({
       permission,
-      contracts,
+      contracts: enforcers,
     });
     const erc20StreamingTerms = caveats[0]?.terms as Hex;
 
-    expect(caveats[0]?.enforcer).toBe(contracts.erc20StreamingEnforcer);
+    expect(caveats[0]?.enforcer).toBe(enforcers.erc20StreamingEnforcer);
     expect(
       erc20StreamingTerms.startsWith(`0x${alternateTokenAddress.slice(2)}`),
     ).toBe(true);

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenAllowance.test.ts
@@ -1,7 +1,3 @@
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
@@ -16,18 +12,17 @@ import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
-  getChecksumEnforcersByChainId,
+  checksumEnforcerAddresses,
   UINT256_MAX,
 } from '../../../src/permissions/utils';
 import type {
   NativeTokenAllowancePermission,
   Populated,
 } from '../../../src/types';
-import { toWord } from '../../test-utils';
+import { contracts, toWord } from '../../test-utils';
 
 describe('native-token-allowance decoder config', () => {
-  const chainId = CHAIN_ID.sepolia;
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
+  const enforcers = checksumEnforcerAddresses(contracts);
   const {
     timestampEnforcer,
     nativeTokenPeriodTransferEnforcer,
@@ -35,10 +30,8 @@ describe('native-token-allowance decoder config', () => {
     nonceEnforcer,
     allowedTargetsEnforcer,
     redeemerEnforcer,
-  } = getChecksumEnforcersByChainId(contracts);
-  const decoder = makeNativeTokenAllowanceDecoderConfig(
-    getChecksumEnforcersByChainId(contracts),
-  );
+  } = enforcers;
+  const decoder = makeNativeTokenAllowanceDecoderConfig(enforcers);
 
   const ALLOWANCE_AMOUNT_HEX = toWord(100n);
   const START_TIME = 1715664;
@@ -173,7 +166,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
   const allowanceAmount = '0x64' as const;
   const startTime = 1729900800;
 
-  const contracts: NativeTokenAllowanceEnforcers = {
+  const enforcers: NativeTokenAllowanceEnforcers = {
     nativeTokenPeriodTransferEnforcer:
       '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
@@ -192,18 +185,18 @@ describe('createNativeTokenAllowanceCaveats()', () => {
   it('creates nativeTokenPeriodic and exactCalldata caveats', () => {
     const caveats = createNativeTokenAllowanceCaveats({
       permission,
-      contracts,
+      contracts: enforcers,
     });
     const expectedTerms = `0x${toWord(BigInt(allowanceAmount))}${UINT256_MAX.slice(2)}${toWord(startTime)}`;
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.nativeTokenPeriodTransferEnforcer,
+        enforcer: enforcers.nativeTokenPeriodTransferEnforcer,
         terms: expectedTerms,
         args: '0x',
       },
       {
-        enforcer: contracts.exactCalldataEnforcer,
+        enforcer: enforcers.exactCalldataEnforcer,
         terms: '0x',
         args: '0x',
       },
@@ -222,7 +215,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
     expect(() =>
       createNativeTokenAllowanceCaveats({
         permission: invalidPermission,
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow();
   });
@@ -237,7 +230,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
             allowanceAmount: '0x0',
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-allowance permission: allowanceAmount must be a positive number.',
@@ -254,7 +247,7 @@ describe('createNativeTokenAllowanceCaveats()', () => {
             startTime: 0,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-allowance permission: startTime must be a positive number.',
@@ -274,10 +267,10 @@ describe('createNativeTokenAllowanceCaveats()', () => {
 
     const caveats = createNativeTokenAllowanceCaveats({
       permission: variedPermission,
-      contracts,
+      contracts: enforcers,
     });
 
-    expect(caveats[1]?.enforcer).toBe(contracts.exactCalldataEnforcer);
+    expect(caveats[1]?.enforcer).toBe(enforcers.exactCalldataEnforcer);
     expect(caveats[1]?.terms).toBe('0x');
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenPeriodic.test.ts
@@ -1,7 +1,3 @@
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
@@ -16,18 +12,17 @@ import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
 import {
-  getChecksumEnforcersByChainId,
+  checksumEnforcerAddresses,
   MAX_PERIOD_DURATION,
 } from '../../../src/permissions/utils';
 import type {
   NativeTokenPeriodicPermission,
   Populated,
 } from '../../../src/types';
-import { toWord } from '../../test-utils';
+import { contracts, toWord } from '../../test-utils';
 
 describe('native-token-periodic decoder config', () => {
-  const chainId = CHAIN_ID.sepolia;
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
+  const enforcers = checksumEnforcerAddresses(contracts);
   const {
     timestampEnforcer,
     nativeTokenPeriodTransferEnforcer,
@@ -35,10 +30,8 @@ describe('native-token-periodic decoder config', () => {
     nonceEnforcer,
     allowedTargetsEnforcer,
     redeemerEnforcer,
-  } = getChecksumEnforcersByChainId(contracts);
-  const decoder = makeNativeTokenPeriodicDecoderConfig(
-    getChecksumEnforcersByChainId(contracts),
-  );
+  } = enforcers;
+  const decoder = makeNativeTokenPeriodicDecoderConfig(enforcers);
   const START_TIME = 1715664;
   const makeTerms = ({
     periodAmount = 100n,
@@ -194,7 +187,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
   const periodDuration = 86400;
   const startTime = 1729900800;
 
-  const contracts: NativeTokenPeriodicEnforcers = {
+  const enforcers: NativeTokenPeriodicEnforcers = {
     nativeTokenPeriodTransferEnforcer:
       '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
@@ -214,19 +207,19 @@ describe('createNativeTokenPeriodicCaveats()', () => {
   it('creates nativeTokenPeriodic and exactCalldata caveats', () => {
     const caveats = createNativeTokenPeriodicCaveats({
       permission,
-      contracts,
+      contracts: enforcers,
     });
 
     const nativeTokenPeriodicExpectedTerms = `0x${toWord(BigInt(periodAmount))}${toWord(periodDuration)}${toWord(startTime)}`;
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.nativeTokenPeriodTransferEnforcer,
+        enforcer: enforcers.nativeTokenPeriodTransferEnforcer,
         terms: nativeTokenPeriodicExpectedTerms,
         args: '0x',
       },
       {
-        enforcer: contracts.exactCalldataEnforcer,
+        enforcer: enforcers.exactCalldataEnforcer,
         terms: '0x',
         args: '0x',
       },
@@ -245,7 +238,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
     expect(() =>
       createNativeTokenPeriodicCaveats({
         permission: invalidPermission,
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow();
   });
@@ -260,7 +253,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
             periodAmount: '0x0',
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-periodic permission: periodAmount must be a positive number.',
@@ -277,7 +270,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
             periodDuration: 0,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-periodic permission: periodDuration must be a positive number.',
@@ -294,7 +287,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
             periodDuration: MAX_PERIOD_DURATION + 1,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-periodic permission: periodDuration must be less than or equal to MAX_PERIOD_DURATION.',
@@ -311,7 +304,7 @@ describe('createNativeTokenPeriodicCaveats()', () => {
             startTime: 0,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-periodic permission: startTime must be a positive number.',
@@ -332,10 +325,10 @@ describe('createNativeTokenPeriodicCaveats()', () => {
 
     const caveats = createNativeTokenPeriodicCaveats({
       permission: variedPermission,
-      contracts,
+      contracts: enforcers,
     });
 
-    expect(caveats[1]?.enforcer).toBe(contracts.exactCalldataEnforcer);
+    expect(caveats[1]?.enforcer).toBe(enforcers.exactCalldataEnforcer);
     expect(caveats[1]?.terms).toBe('0x');
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/nativeTokenStream.test.ts
@@ -1,7 +1,3 @@
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import { bigIntToHex, type Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
@@ -15,16 +11,15 @@ import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
-import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
+import { checksumEnforcerAddresses } from '../../../src/permissions/utils';
 import type {
   NativeTokenStreamPermission,
   Populated,
 } from '../../../src/types';
-import { toWord } from '../../test-utils';
+import { contracts, toWord } from '../../test-utils';
 
 describe('native-token-stream decoder config', () => {
-  const chainId = CHAIN_ID.sepolia;
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
+  const enforcers = checksumEnforcerAddresses(contracts);
   const {
     timestampEnforcer,
     nativeTokenStreamingEnforcer,
@@ -32,10 +27,8 @@ describe('native-token-stream decoder config', () => {
     nonceEnforcer,
     allowedTargetsEnforcer,
     redeemerEnforcer,
-  } = getChecksumEnforcersByChainId(contracts);
-  const decoder = makeNativeTokenStreamDecoderConfig(
-    getChecksumEnforcersByChainId(contracts),
-  );
+  } = enforcers;
+  const decoder = makeNativeTokenStreamDecoderConfig(enforcers);
   const START_TIME = 1715664;
   const makeTerms = ({
     initialAmount = 10n,
@@ -171,7 +164,7 @@ describe('createNativeTokenStreamCaveats()', () => {
   const amountPerSecond = '0x06f05b59d3b20000' as const;
   const startTime = 1729900800;
 
-  const contracts: NativeTokenStreamEnforcers = {
+  const enforcers: NativeTokenStreamEnforcers = {
     nativeTokenStreamingEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
     exactCalldataEnforcer: '0x5e12Ca712176E7557e4fAa1c8cc27382B60B5e39',
   };
@@ -191,7 +184,7 @@ describe('createNativeTokenStreamCaveats()', () => {
   it('creates nativeTokenStreaming and exactCalldata caveats', () => {
     const caveats = createNativeTokenStreamCaveats({
       permission,
-      contracts,
+      contracts: enforcers,
     });
 
     const initialAmountHex = initialAmount.slice(2).padStart(64, '0');
@@ -202,12 +195,12 @@ describe('createNativeTokenStreamCaveats()', () => {
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.nativeTokenStreamingEnforcer,
+        enforcer: enforcers.nativeTokenStreamingEnforcer,
         terms: nativeTokenStreamingExpectedTerms,
         args: '0x',
       },
       {
-        enforcer: contracts.exactCalldataEnforcer,
+        enforcer: enforcers.exactCalldataEnforcer,
         terms: '0x',
         args: '0x',
       },
@@ -226,7 +219,7 @@ describe('createNativeTokenStreamCaveats()', () => {
     expect(() =>
       createNativeTokenStreamCaveats({
         permission: invalidPermission,
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow();
   });
@@ -242,7 +235,7 @@ describe('createNativeTokenStreamCaveats()', () => {
             maxAmount: '0x64',
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-stream permission: maxAmount must be greater than initialAmount.',
@@ -259,7 +252,7 @@ describe('createNativeTokenStreamCaveats()', () => {
             amountPerSecond: '0x0',
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-stream permission: amountPerSecond must be a positive number.',
@@ -276,7 +269,7 @@ describe('createNativeTokenStreamCaveats()', () => {
             startTime: 0,
           },
         },
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid native-token-stream permission: startTime must be a positive number.',
@@ -298,10 +291,10 @@ describe('createNativeTokenStreamCaveats()', () => {
 
     const caveats = createNativeTokenStreamCaveats({
       permission: variedPermission,
-      contracts,
+      contracts: enforcers,
     });
 
-    expect(caveats[1]?.enforcer).toBe(contracts.exactCalldataEnforcer);
+    expect(caveats[1]?.enforcer).toBe(enforcers.exactCalldataEnforcer);
     expect(caveats[1]?.terms).toBe('0x');
   });
 });

--- a/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
+++ b/packages/7715-permission-types/test/permissions/caveats/tokenApprovalRevocation.test.ts
@@ -1,7 +1,3 @@
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
@@ -13,20 +9,18 @@ import {
 } from '../../../src/permissions/caveats/tokenApprovalRevocation';
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
-import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
+import { checksumEnforcerAddresses } from '../../../src/permissions/utils';
 import type {
   TokenApprovalRevocationPermission,
   Populated,
 } from '../../../src/types';
+import { contracts } from '../../test-utils';
 
 describe('token-approval-revocation decoder config', () => {
-  const chainId = CHAIN_ID.sepolia;
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][chainId];
+  const enforcers = checksumEnforcerAddresses(contracts);
   const { timestampEnforcer, approvalRevocationEnforcer, nonceEnforcer } =
-    getChecksumEnforcersByChainId(contracts);
-  const decoder = makeTokenApprovalRevocationDecoderConfig(
-    getChecksumEnforcersByChainId(contracts),
-  );
+    enforcers;
+  const decoder = makeTokenApprovalRevocationDecoderConfig(enforcers);
 
   const makeCaveats = (approvalRevocationTerms: Hex): ChecksumCaveat[] => [
     {
@@ -133,7 +127,7 @@ describe('token-approval-revocation decoder config', () => {
 });
 
 describe('createTokenApprovalRevocationCaveats()', () => {
-  const contracts: TokenApprovalRevocationEnforcers = {
+  const enforcers: TokenApprovalRevocationEnforcers = {
     approvalRevocationEnforcer: '0x7356Ed4321Ff9e7DAE246461829cDC170ff660Ab',
   };
 
@@ -154,12 +148,12 @@ describe('createTokenApprovalRevocationCaveats()', () => {
   it('creates approvalRevocation caveat', () => {
     const caveats = createTokenApprovalRevocationCaveats({
       permission,
-      contracts,
+      contracts: enforcers,
     });
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.approvalRevocationEnforcer,
+        enforcer: enforcers.approvalRevocationEnforcer,
         terms: '0x3f',
         args: '0x',
       },
@@ -182,12 +176,12 @@ describe('createTokenApprovalRevocationCaveats()', () => {
 
     const caveats = createTokenApprovalRevocationCaveats({
       permission: singleFlagPermission,
-      contracts,
+      contracts: enforcers,
     });
 
     expect(caveats).toStrictEqual([
       {
-        enforcer: contracts.approvalRevocationEnforcer,
+        enforcer: enforcers.approvalRevocationEnforcer,
         terms: '0x01',
         args: '0x',
       },
@@ -211,7 +205,7 @@ describe('createTokenApprovalRevocationCaveats()', () => {
     expect(() =>
       createTokenApprovalRevocationCaveats({
         permission: noFlagPermission,
-        contracts,
+        contracts: enforcers,
       }),
     ).toThrow(
       'Invalid ApprovalRevocation terms: at least one revocation primitive must be enabled',

--- a/packages/7715-permission-types/test/permissions/rules/erc20Payee.test.ts
+++ b/packages/7715-permission-types/test/permissions/rules/erc20Payee.test.ts
@@ -1,19 +1,15 @@
 import { createAllowedCalldataTerms } from '@metamask/delegation-core';
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import { getChecksumAddress } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { erc20PayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
-import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
+import { checksumEnforcerAddresses } from '../../../src/permissions/utils';
+import { contracts } from '../../test-utils';
 
 describe('erc20PayeeRuleDecoder', () => {
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][CHAIN_ID.sepolia];
-  const contractAddresses = getChecksumEnforcersByChainId(contracts);
+  const contractAddresses = checksumEnforcerAddresses(contracts);
   const { allowedCalldataEnforcer, nonceEnforcer } = contractAddresses;
   const requiredEnforcers = new Map<Hex, number>([[nonceEnforcer, 1]]);
 

--- a/packages/7715-permission-types/test/permissions/rules/expiry.test.ts
+++ b/packages/7715-permission-types/test/permissions/rules/expiry.test.ts
@@ -1,18 +1,14 @@
 import { createTimestampTerms } from '@metamask/delegation-core';
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { expiryRuleDecoder } from '../../../src/permissions/rules/expiry';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
-import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
+import { checksumEnforcerAddresses } from '../../../src/permissions/utils';
+import { contracts } from '../../test-utils';
 
 describe('expiryRule', () => {
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][CHAIN_ID.sepolia];
-  const contractAddresses = getChecksumEnforcersByChainId(contracts);
+  const contractAddresses = checksumEnforcerAddresses(contracts);
   const { timestampEnforcer, nonceEnforcer } = contractAddresses;
   const requiredEnforcers = new Map<Hex, number>([[nonceEnforcer, 1]]);
 

--- a/packages/7715-permission-types/test/permissions/rules/nativePayee.test.ts
+++ b/packages/7715-permission-types/test/permissions/rules/nativePayee.test.ts
@@ -1,19 +1,15 @@
 import { createAllowedTargetsTerms } from '@metamask/delegation-core';
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import { getChecksumAddress } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { nativePayeeRuleDecoder } from '../../../src/permissions/rules/payee';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
-import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
+import { checksumEnforcerAddresses } from '../../../src/permissions/utils';
+import { contracts } from '../../test-utils';
 
 describe('nativePayeeRuleDecoder', () => {
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][CHAIN_ID.sepolia];
-  const contractAddresses = getChecksumEnforcersByChainId(contracts);
+  const contractAddresses = checksumEnforcerAddresses(contracts);
   const { allowedTargetsEnforcer, nonceEnforcer } = contractAddresses;
   const requiredEnforcers = new Map<Hex, number>([[nonceEnforcer, 1]]);
 

--- a/packages/7715-permission-types/test/permissions/rules/redeemer.test.ts
+++ b/packages/7715-permission-types/test/permissions/rules/redeemer.test.ts
@@ -1,19 +1,15 @@
 import { createRedeemerTerms } from '@metamask/delegation-core';
-import {
-  CHAIN_ID,
-  DELEGATOR_CONTRACTS,
-} from '@metamask/delegation-deployments';
 import { getChecksumAddress } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { describe, it, expect } from 'vitest';
 
 import { redeemerRuleDecoder } from '../../../src/permissions/rules/redeemer';
 import type { ChecksumCaveat } from '../../../src/permissions/types';
-import { getChecksumEnforcersByChainId } from '../../../src/permissions/utils';
+import { checksumEnforcerAddresses } from '../../../src/permissions/utils';
+import { contracts } from '../../test-utils';
 
 describe('redeemerRuleDecoder', () => {
-  const contracts = DELEGATOR_CONTRACTS['1.3.0'][CHAIN_ID.sepolia];
-  const contractAddresses = getChecksumEnforcersByChainId(contracts);
+  const contractAddresses = checksumEnforcerAddresses(contracts);
   const { redeemerEnforcer, nonceEnforcer } = contractAddresses;
   const requiredEnforcers = new Map<Hex, number>([[nonceEnforcer, 1]]);
 

--- a/packages/7715-permission-types/test/test-utils.ts
+++ b/packages/7715-permission-types/test/test-utils.ts
@@ -1,2 +1,20 @@
+import type { EnforcerAddressesByName } from '../src/permissions/types';
+
 export const toWord = (value: bigint | number): string =>
   BigInt(value).toString(16).padStart(64, '0');
+
+export const contracts: EnforcerAddressesByName = {
+  erc20StreamingEnforcer: '0x1234567890abcdef1234567890abcdef12345678',
+  erc20PeriodTransferEnforcer: '0x234567890abcdef1234567890abcdef123456781',
+  nativeTokenStreamingEnforcer: '0x34567890abcdef1234567890abcdef1234567812',
+  nativeTokenPeriodTransferEnforcer:
+    '0x4567890abcdef1234567890abcdef12345678123',
+  approvalRevocationEnforcer: '0x567890abcdef1234567890abcdef123456781234',
+  exactCalldataEnforcer: '0x67890abcdef1234567890abcdef1234567812345',
+  valueLteEnforcer: '0x7890abcdef1234567890abcdef12345678123456',
+  timestampEnforcer: '0x890abcdef1234567890abcdef123456781234567',
+  nonceEnforcer: '0x90abcdef1234567890abcdef1234567812345678',
+  allowedCalldataEnforcer: '0x0abcdef1234567890abcdef12345678123456789',
+  allowedTargetsEnforcer: '0xabcdef1234567890abcdef123456781234567890',
+  redeemerEnforcer: '0xbcdef1234567890abcdef123456781234567890a',
+};


### PR DESCRIPTION
## 📝 Description

In @metamask/7715-permission-types, `DeployedContractsByName` is defined as `Record<string, Hex>`, which introduces risk of miskeyed contract accesses.

In @metamask/delegation-deployments the `DeployedContracts` is equally loosely typed, but the contract names are PascalCase.

This PR updates @metamask/7715-permission-types to expect `EnforcerAddressesByName` which is specifically keyed with enforcer contract names in camelCase - a consumer providing the addresses from @metamask/delegation-deployments would need to map the PascalCase names to camelCase.
 
## 🔄 What Changed?

List the specific changes made:
- 
- 
- 

## 🚀 Why?

Explain the motivation behind these changes:
- 
- 

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1.
 2.
 3.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change affects all integrators of `makePermissionDecoderConfigs`; wrong key mapping could mis-associate enforcer addresses at decode time, though runtime logic is largely unchanged.
> 
> **Overview**
> **Breaking change** to how enforcer contract addresses are passed into permission decoding in `@metamask/7715-permission-types`.
> 
> `makePermissionDecoderConfigs` and all permission decoder/rule APIs now take **`EnforcerAddressesByName`**: a map keyed by a fixed **`EnforcerContractName`** union (camelCase roles like `erc20PeriodTransferEnforcer`), not a loose `Record<string, Hex>` or the old checksummed struct type. **`DeployedContractsByName`** and **`ChecksumEnforcersByChainId`** are removed from the public surface.
> 
> Address normalization is **`checksumEnforcerAddresses`** (replacing **`getChecksumEnforcersByChainId`**), which checksums each field of an already-shaped `EnforcerAddressesByName` instead of resolving PascalCase deployment names from a chain contract bundle. Callers that source addresses from `@metamask/delegation-deployments` must map PascalCase keys to these camelCase keys themselves.
> 
> Tests drop direct `DELEGATOR_CONTRACTS` usage in favor of a typed **`contracts`** fixture in `test-utils`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122053944b7c1074e233166fcdbc3c130b4cc060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->