### PR TITLE
feat: add Arc Testnet support with RPC and native currency details

### DIFF
--- a/packages/delegation-deployments/CHANGELOG.md
+++ b/packages/delegation-deployments/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add chain deployment for Robinhood Chain mainnet and testnet ([#277](https://github.com/MetaMask/smart-accounts-kit/pull/277))
+- Add chain deployment for Arc Testnet ([#289](https://github.com/MetaMask/smart-accounts-kit/pull/289))
 
 ### Changed
 

--- a/packages/delegation-deployments/script/validate-contract-deployments.ts
+++ b/packages/delegation-deployments/script/validate-contract-deployments.ts
@@ -389,8 +389,25 @@ const celoSepoliaChain: Chain = {
   },
 };
 
+const arcTestnetChain: Chain = {
+  id: 5042002,
+  name: 'Arc Testnet',
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.testnet.arc.network'],
+    },
+  },
+  // Arc uses USDC as its native gas token instead of a volatile native currency.
+  nativeCurrency: {
+    name: 'USDC',
+    symbol: 'USDC',
+    decimals: 18,
+  },
+};
+
 export const chains = {
   ...allChains,
+  arcTestnet: arcTestnetChain,
   megaEthTestNet: megaEthTestNetChain,
   berachainMainnet: berachainMainnetChain,
   bepoliaTestnet: bepoliaTestnetChain,

--- a/packages/delegation-deployments/src/index.ts
+++ b/packages/delegation-deployments/src/index.ts
@@ -151,7 +151,6 @@ export const DELEGATOR_CONTRACTS: DeployedContracts = {
     [CHAIN_ID.katanaBokuto]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.intuitionTestnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.robinhoodTestnet]: DEPLOYMENTS_1_3_0,
-    // Deployment pending: not yet deployed on Arc as of writing.
     [CHAIN_ID.arcTestnet]: DEPLOYMENTS_1_3_0,
   },
 };

--- a/packages/delegation-deployments/src/index.ts
+++ b/packages/delegation-deployments/src/index.ts
@@ -57,6 +57,7 @@ export const CHAIN_ID = {
   katanaBokuto: 0xb405d,
   intuitionTestnet: 0x350b,
   robinhoodTestnet: 0xb626,
+  arcTestnet: 0x4cef52,
   // decommissioned
   lineaGoerli: 0xe704,
 };
@@ -150,5 +151,7 @@ export const DELEGATOR_CONTRACTS: DeployedContracts = {
     [CHAIN_ID.katanaBokuto]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.intuitionTestnet]: DEPLOYMENTS_1_3_0,
     [CHAIN_ID.robinhoodTestnet]: DEPLOYMENTS_1_3_0,
+    // Deployment pending: not yet deployed on Arc as of writing.
+    [CHAIN_ID.arcTestnet]: DEPLOYMENTS_1_3_0,
   },
 };


### PR DESCRIPTION
  ## 📝 Description

  Registers Arc Testnet in `@metamask/delegation-deployments` ahead of the delegation-framework contracts being deployed there, so the mapping and validation script are ready to go once deployment happens.

  ## 🔄 What Changed?

  - Added `CHAIN_ID.arcTestnet` (`0x4cef52` / `5042002`) in `src/index.ts`
  - Mapped `arcTestnet` to `DEPLOYMENTS_1_3_0` under the `1.3.0` testnets, with a comment noting deployment is still pending
  - Added a custom `arcTestnetChain` definition (RPC `https://rpc.testnet.arc.network`, USDC as native gas currency) to `script/validate-contract-deployments.ts`, since Arc isn't in `viem/chains`

  ## 🚀 Why?

  Circle's Arc network is currently testnet-only (chain ID `5042002`). Wiring up the chain config now means `validate-latest-contracts` can immediately confirm the deployment once the delegation-framework contracts land on Arc, without a follow-up config PR.

  ## 🧪 How to Test?

  - [ ] Manual testing steps:
   1. Once contracts are deployed to Arc Testnet, run:
      ~~~bash
      yarn validate-latest-contracts 5042002
      ~~~
   2. Confirm it reports `Arc Testnet succeeded`
  - [ ] Automated tests added/updated
  - [x] All existing tests pass

  ## ⚠️ Breaking Changes

  - [x] No breaking changes

  ## 📋 Checklist

  - [x] Code follows the project's coding standards
  - [x] Self-review completed
  - [ ] Documentation updated (if needed)
  - [ ] Tests added/updated
  - [ ] Changelog updated (if needed)
  - [ ] All CI checks pass

  ## 🔗 Related Issues

  Closes #
  Related to #

  ## 📚 Additional Notes

  The `1.3.0` addresses are not yet deployed on Arc Testnet (confirmed via `eth_getCode` against `DelegationManager`'s canonical address — currently empty). `validate-latest-contracts 5042002` will fail until deployment happens; that's expected for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry and validation script changes; no runtime logic or security-sensitive paths, though `validate-latest-contracts` for this chain will fail until contracts are deployed.
> 
> **Overview**
> Adds **Arc Testnet** (chain ID `5042002` / `0x4cef52`) to `@metamask/delegation-deployments` so the package knows about Circle’s Arc network before delegation contracts are live there.
> 
> `CHAIN_ID.arcTestnet` is exported and wired into `DELEGATOR_CONTRACTS` **1.3.0** testnets using the standard `DEPLOYMENTS_1_3_0` address set (same as other testnets). The validation script gets a custom `arcTestnet` chain entry—RPC `https://rpc.testnet.arc.network` and **USDC** as the native gas token—because Arc is not in `viem/chains`. The changelog notes the new deployment entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74503bf143184d912e767c5f3de33c6538aa9d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->