### PR TITLE
Peac337 patch 2

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,1 @@
+code review

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ jobs:
   check-workflows:
     name: Check workflows
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -11,17 +11,16 @@ on:
 
 jobs:
   run-security-scan:
-    name: Run security scan
+    name: Run Semgrep security scan
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
     steps:
-      - name: Analyse code
-        uses: MetaMask/action-security-code-scanner@v1
+      - name: Analyse code with Semgrep
+        uses: MetaMask/Semgrep-action@main
         with:
-          repo: ${{ github.repository }}
           paths_ignored: |
             '**/jest.config.js'
             '**/jest.environment.js'
@@ -29,6 +28,3 @@ jobs:
             '**/test/'
             'node_modules'
             'packages/delegator-e2e'
-          rules_excluded: example
-          project_metrics_token: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
-          slack_webhook: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,9 +7,9 @@ currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
+| 5.1.x   | :x: |
 | 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
+| 4.0.x   | :x: |
 | < 4.0   | :x:                |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
## 📝 Description

Provide a brief description of the changes in this PR

## 🔄 What Changed?

List the specific changes made:
- Workflow behavior change: replaced MetaMask/action-security-code-scanner@v1 with MetaMask/Semgrep-action@main in .github/workflows/security-code-scanner.yml.
- Input cleanup: removed inputs that were only relevant to the replaced scanner (repo, rules_excluded, metrics/slack passthroughs).
- Scope preserved: kept existing paths_ignored exclusions unchanged.

## 🚀 Why?

Explain the motivation behind these changes:
- GitHub rejects advanced/custom CodeQL SARIF uploads when default CodeQL setup is enabled, which hard-failed the job.
- Semgrep scanning remains in place, so we keep custom security signal without colliding with repository-level CodeQL configuration.

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1. Trigger the Main workflow on a branch/PR.
 2. Open the Code scanner job and verify Run Semgrep security scan executes.
 3. Confirm the job no longer fails with the SARIF/CodeQL default-setup error.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI security scanning behavior changes (different action, no metrics/Slack hooks on the scan step), though scan scope via paths_ignored is unchanged.
> 
> **Overview**
> Replaces **MetaMask/action-security-code-scanner@v1** with **MetaMask/Semgrep-action@main** in the reusable security workflow so CI keeps Semgrep coverage without uploading custom SARIF that clashes with the repo’s default CodeQL setup (which was failing the scanner job).
> 
> The Semgrep step keeps the same **`paths_ignored`** list but drops scanner-only inputs (`repo`, `rules_excluded`, metrics token, Slack webhook). Job/step labels are updated to reflect Semgrep.
> 
> Also adds **`contents: read`** on the **Check workflows** job in **Main**, a stub **`.github/skills/code-review/SKILL.md`**, and a new **`SECURITY.md`** vulnerability policy template (placeholder supported versions and reporting text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb30ecd4b172fdde82c71c9d6dedb88b3a02c696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->